### PR TITLE
Change airtime and rx_airtime to total increasing

### DIFF
--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -206,7 +206,7 @@ REPEATER_SENSORS = [
         key="airtime",
         native_unit_of_measurement="min",
         suggested_display_precision="1",
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:radio",
     ),
     SensorEntityDescription(
@@ -292,7 +292,7 @@ REPEATER_SENSORS = [
         key="rx_airtime",
         native_unit_of_measurement="min",
         suggested_display_precision="1",
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:radio",
     ),
     SensorEntityDescription(


### PR DESCRIPTION
These sensors measure the airtime and rx airtime in minutes. They should be total increasing because there is no way for them to lower except for node reboots.

Unfortunately this change makes the sensor lose its current statistics history. I don't know if there is a way to prevent this.