### PR TITLE
Only cleanup monitored repeaters associated with the current integration

### DIFF
--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -406,6 +406,10 @@ async def async_setup_entry(
         for identifier in device.identifiers:
             if identifier[0] == DOMAIN:
                 device_id = identifier[1]
+
+                # Only consider devices belonging to this config entry
+                if not device_id.startswith(entry.entry_id):
+                    continue
                 
                 # If this device is a repeater but not in our active list, remove it
                 if "_repeater_" in device_id and device_id not in active_repeater_device_ids:


### PR DESCRIPTION
Only cleanup the monitored repeaters that belong to the current integration.

I _think_ this should fix https://github.com/meshcore-dev/meshcore-ha/issues/75; it fixed what I was experiencing anyway.

Before the fix:
https://github.com/user-attachments/assets/f70c35d7-f337-4ab2-bfea-9288c07b84ba

After the fix:
https://github.com/user-attachments/assets/70756867-2245-407f-8e72-8117f2df55c0

