### PR TITLE
Update installation.md

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -51,6 +51,7 @@ This guide will help you install and configure the Meshcore integration for Home
 #### USB Connection
 - Enter the USB port path (e.g., `/dev/ttyUSB0` or `/dev/ttyACM0`)
 - Set the baud rate (default: 115200)
+- **Note**: If you flashed the 'Companion Bluetooth' firmware, this will fail to connect. Flash 'Companion USB' instead.
 
 #### BLE Connection
 - Select your Meshcore device from discovered devices
@@ -116,6 +117,7 @@ Once configured, you should see:
 - Verify the device is properly connected and the correct port is selected
 - Try a different baud rate if the default doesn't work
 - Check permissions for USB device access
+- Make sure you flashed the 'Companion USB' firmware, instead of the 'Companion Bluetooth' firmware.
 - Common port paths:
   - Linux: `/dev/ttyUSB0`, `/dev/ttyACM0`
   - macOS: `/dev/tty.usbserial-*`


### PR DESCRIPTION
Add note about using the correct companion firmware when using the USB connection. When using the Companion Bluetooth firmware, this it will fail to connect. Tested with Meshcore firmware 1.12.0 on Heltec v3; And `meshcore-ha` 2.2.5

I would very much recommend adding the note to the docs;   
as this may save other people a lot of time on trouble shooting.