### PR TITLE
add a pubkey_prefix with only 2 chars for display

### DIFF
--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -548,6 +548,8 @@ class MeshCoreContactDiagnosticBinarySensor(CoordinatorEntity, BinarySensorEntit
         # Add all contact properties as attributes
         for key, value in self._contact_data.items():
             attributes[key] = value
+            
+        attributes["pubkey_short"] = self.public_key[:2] if self.public_key else ""
         
         # Get node type string
         node_type = self._contact_data.get("type")


### PR DESCRIPTION
This PR introduces a short 2-char prefix of the public_key to display it on a map for example.

```
type: custom:auto-entities
filter:
  include:
    - integration: meshcore
      entity_id: binary_sensor.meshcore_*_contact
      attributes:
        node_type_str: Repeater
      options:
        label_mode: attribute
        attribute: pubkey_short
card:
  type: map
  default_zoom: 15
  cluster: false
grid_options:
  columns: 48
  rows: auto
```

<img width="903" height="734" alt="Screenshot 2026-02-25 at 21 12 00" src="https://github.com/user-attachments/assets/af7bb482-17e8-440d-ad03-2de71b86c928" />
