### PR TITLE
Bump meshcore requirement to >=2.2.24

### DIFF
--- a/custom_components/meshcore/manifest.json
+++ b/custom_components/meshcore/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["logbook"],
   "codeowners": ["@awolden"],
   "loggers": ["custom_components.meshcore"],
-  "requirements": ["meshcore>=2.2.15", "meshcore-cli>=0.0.0", "pycryptodome>=3.20.0", "cachetools>=5.3.0", "paho-mqtt>=1.6.0", "pynacl>=1.5.0"],
+  "requirements": ["meshcore>=2.2.24", "meshcore-cli>=0.0.0", "pycryptodome>=3.20.0", "cachetools>=5.3.0", "paho-mqtt>=1.6.0", "pynacl>=1.5.0"],
   "iot_class": "local_polling",
   "version": "2.4.0",
   "config_flow": true


### PR DESCRIPTION
## Summary

Bump the MeshCore Python dependency floor to a version that includes the channel list corruption fix from `meshcore_py` issue #154 

## Change

* `custom_components/meshcore/manifest.json`

  * `meshcore>=2.2.15` → `meshcore>=2.2.24`

## Why

Users can hit runtime crashes in `meshcore/reader.py` on older `2.2.x` builds, especially the `self.channels` corruption path that leads to errors like:

```text
TypeError: object of type 'NoneType' has no len()
```

in channel handling.

`meshcore 2.2.24` includes the newer reader fixes and avoids that broken path.

## Impact

* No feature behavior changes in `meshcore-ha` itself
* Ensures Home Assistant installs a fixed `meshcore` version during dependency resolution
* Improves channel message stability for affected users

## Validation

* Reproduced the crash on the older dependency path
* Verified that updating the requirement and reloading the integration resolves the crash in local Home Assistant testing
