### PR TITLE
Fix message entity created with 'None Messages' name

### DIFF
--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -268,7 +268,7 @@ async def async_setup_entry(
                 # Create message entity if needed
                 pubkey_prefix = event.data["contact_public_key"][:12]
                 if pubkey_prefix not in coordinator.tracked_contacts:
-                    contact_name = event.data.get("receiver", "Unknown")
+                    contact_name = event.data.get("receiver") or "Unknown"
                     message_entity = MeshCoreMessageEntity(
                         coordinator, pubkey_prefix, f"{contact_name} Messages", 
                         public_key=pubkey_prefix

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -183,7 +183,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                             "message": message,
                             "device": config_entry_id,
                             "message_type": "direct",
-                            "receiver": contact.get("name"),
+                            "receiver": contact.get("adv_name") or contact.get("name"),
                             "timestamp": int(time.time()),
                             "contact_public_key": pubkey
                         }


### PR DESCRIPTION
## Summary
Fixes a bug where MeshCoreMessageEntity was created with the name 'None Messages' on the first outgoing direct message to a contact.

## Root Cause
Two issues in the outgoing message event chain:

1. **services.py**: contact.get('name') used the wrong dict key. The meshcore SDK contact dict uses 'adv_name' for the advertised name. The key 'name' does not exist, so it always returned None.

2. **binary_sensor.py**: event.data.get('receiver', 'Unknown') does not fall back to 'Unknown' when the key exists but has a None value.

## Changes
- services.py: Use contact.get('adv_name') or contact.get('name') for the receiver field
- binary_sensor.py: Use event.data.get('receiver') or 'Unknown' to guard against explicit None values

## Test plan
- [x] Send a direct message to a saved contact with no prior message history
- [x] Verify the created MeshCoreMessageEntity has the correct name
- [x] Verify existing contacts with message history are unaffected