### PR TITLE
Display configured transmit power, not maximum

### DIFF
--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -648,7 +648,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
             
         elif key == "tx_power":
             def update_tx(event: Event):
-                self._native_value = event.payload.get("max_tx_power")
+                self._native_value = event.payload.get("tx_power")
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_tx,


### PR DESCRIPTION
The UI was always displaying the maximum transmit power, typically 22 dBm, regardless of the configured transmit power. Display the configured transmit power instead.

With the change I see the configured 15dBm
<img width="170" height="79" alt="image" src="https://github.com/user-attachments/assets/7e1486d3-8a37-4874-be61-84aef7744898" />

Fixes #146 

