### PR TITLE
Add RX Message Log: toggle switch + logbook

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -6,7 +6,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from datetime import timedelta
+from datetime import datetime, timedelta
 from meshcore.events import EventType
 
 from .const import (
@@ -34,6 +34,7 @@ from .const import (
     DEFAULT_MAX_DISCOVERED_CONTACTS,
     CONF_MESSAGES_INTERVAL,
     DEFAULT_UPDATE_TICK,
+    ENTITY_DOMAIN_BINARY_SENSOR,
 )
 from .coordinator import MeshCoreDataUpdateCoordinator
 from .meshcore_api import MeshCoreAPI
@@ -41,15 +42,18 @@ from .mqtt_uploader import MeshCoreMqttUploader
 from .services import async_setup_services, async_unload_services
 from .utils import (
     create_message_correlation_key,
+    format_entity_id,
     parse_and_decrypt_rx_log,
     parse_rx_log_data,
+    parse_rx_log_full,
     sanitize_event_data,
 )
+from .logbook import EVENT_MESHCORE_RX_LOG
 
 _LOGGER = logging.getLogger(__name__)
 
 # List of platforms to set up
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.TEXT, Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.TEXT, Platform.DEVICE_TRACKER, Platform.SWITCH]
 STATIC_PATH_REGISTERED_KEY = f"{DOMAIN}_static_path_registered"
 
 
@@ -300,7 +304,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         "text": text,
                         "snr": event.payload.get("snr"),
                         "rssi": event.payload.get("rssi"),
-                        "path_len": decrypted_data.get("path_len"),
+                        "hop_count": decrypted_data.get("hop_count", decrypted_data.get("path_len", 0)),
                         "path": decrypted_data.get("path"),
                         "channel_hash": decrypted_data.get("channel_hash"),
                     }
@@ -311,6 +315,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         coordinator._pending_rx_logs[hash_key] = [rx_log_entry]
 
                     _LOGGER.debug(f"Stored RX_LOG for correlation: ch={channel_idx}, hash={hash_key[:8]}")
+
+                # Fire RX_LOG event to logbook if enabled
+                if getattr(coordinator, "rx_log_enabled", False):
+                    parsed_full = parse_rx_log_full(event.payload, decrypted_data)
+                    if parsed_full:
+                        device_key = coordinator.pubkey or "unknown"
+                        rx_entity_id = format_entity_id(
+                            ENTITY_DOMAIN_BINARY_SENSOR,
+                            device_key[:6],
+                            "rx",
+                            "messages"
+                        )
+                        rx_event_data = {
+                            "entity_id": rx_entity_id,
+                            "domain": DOMAIN,
+                            **parsed_full,
+                            "timestamp": datetime.now().isoformat(),
+                        }
+                        hass.bus.async_fire(EVENT_MESHCORE_RX_LOG, rx_event_data)
 
             # Fire event to HA event bus with sanitized payload
             _LOGGER.debug(f"Firing event to HA event bus: {event}")

--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -251,6 +251,10 @@ async def async_setup_entry(
         if contact_entities:
             async_add_entities(contact_entities)
 
+    # Create the RX Messages entity unconditionally (the switch controls whether events fire)
+    rx_log_entity = MeshCoreRxLogEntity(coordinator)
+    async_add_entities([rx_log_entity])
+
     mqtt_uploader = getattr(coordinator, "mqtt_uploader", None)
     if mqtt_uploader:
         mqtt_entities = [
@@ -669,5 +673,60 @@ class MeshCoreContactDiagnosticBinarySensor(CoordinatorEntity, BinarySensorEntit
         if last_advert > 0:
             last_advert_time = datetime.fromtimestamp(last_advert)
             attributes["last_advert_formatted"] = last_advert_time.isoformat()
-            
+
         return attributes
+
+
+class MeshCoreRxLogEntity(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor entity for RX Message Log entries.
+
+    This entity serves as the logbook target for RX_LOG events.
+    The entity always exists; the companion switch controls whether events fire.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the RX Messages entity."""
+        super().__init__(coordinator)
+
+        device_key = coordinator.pubkey or ""
+        pubkey6 = device_key[:6]
+
+        # Unique ID
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_rx_messages_{pubkey6}"
+        )
+
+        # Entity ID: binary_sensor.meshcore_{pubkey6}_rx_messages
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_BINARY_SENSOR,
+            pubkey6,
+            "rx",
+            "messages"
+        )
+
+        self._attr_name = "RX Messages"
+        self._attr_icon = "mdi:access-point"
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return DeviceInfo(**self.coordinator.device_info)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true — entity is always active."""
+        return True
+
+    @property
+    def state(self) -> str:
+        """Return the state of the entity."""
+        return "Active" if self.is_on else "Inactive"
+
+    @property
+    def available(self) -> bool:
+        """Always available."""
+        return True

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -138,3 +138,46 @@ class NodeType(IntEnum):
     REPEATER = 2
     ROOM_SERVER = 3
     SENSOR = 4
+
+
+# LoRa frame payload types (header bits 2-5, from firmware Packet.h)
+RX_PAYLOAD_TYPE_NAMES: Final = {
+    0x00: "REQUEST",
+    0x01: "RESPONSE",
+    0x02: "DIRECT TEXT",
+    0x03: "ACK",
+    0x04: "ADVERT",
+    0x05: "GROUP TEXT",
+    0x06: "GROUP DATA",
+    0x07: "ANON REQUEST",
+    0x08: "PATH",
+    0x09: "TRACE",
+    0x0A: "MULTIPART",
+    0x0B: "CONTROL",
+    0x0F: "RAW CUSTOM",
+}
+
+# LoRa frame route types (header bits 0-1, from firmware Packet.h)
+RX_ROUTE_TYPE_NAMES: Final = {
+    0x00: "TRANSPORT FLOOD",
+    0x01: "FLOOD",
+    0x02: "DIRECT",
+    0x03: "TRANSPORT DIRECT",
+}
+
+# Advert node types (from firmware AdvertDataHelpers.h)
+ADV_NODE_TYPE_NAMES: Final = {
+    0: "UNKNOWN",
+    1: "CLIENT",
+    2: "REPEATER",
+    3: "ROOM SERVER",
+    4: "SENSOR",
+}
+
+# Advert payload structure constants (from firmware AdvertDataHelpers.h, MeshCore.h)
+ADV_PUB_KEY_SIZE: Final = 32
+ADV_SIGNATURE_SIZE: Final = 64
+ADV_LATLON_MASK: Final = 0x10
+ADV_FEAT1_MASK: Final = 0x20
+ADV_FEAT2_MASK: Final = 0x40
+ADV_NAME_MASK: Final = 0x80

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -22,6 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 
 # Single event type for all messages
 EVENT_MESHCORE_MESSAGE = "meshcore_message"
+# RX Message Log event — all received RF packets when the switch is enabled
+EVENT_MESHCORE_RX_LOG = "meshcore_rx_log"
 
 @callback
 def async_describe_events(
@@ -56,6 +58,76 @@ def async_describe_events(
         }
     
     async_describe_event(DOMAIN, EVENT_MESHCORE_MESSAGE, process_message_event)
+
+    @callback
+    def process_rx_log_event(event: Event) -> dict[str, str]:
+        """Process MeshCore RX_LOG events for logbook."""
+        data = event.data
+        route_type = data.get("route_type", "UNKNOWN")
+        payload_type = data.get("payload_type", "UNKNOWN")
+        snr = data.get("snr")
+        rssi = data.get("rssi")
+        size_bytes = data.get("size_bytes", 0)
+        # hop_count is the actual number of relay hops (from unpacked path_len byte)
+        # Fall back to path_len for backward compatibility with older event data
+        hop_count = data.get("hop_count", data.get("path_len", 0))
+        path_nodes = data.get("path_nodes", [])
+
+        # Build path display
+        if path_nodes:
+            path_str = f" [{','.join(path_nodes)}]"
+        else:
+            path_str = ""
+
+        # Build description based on payload type
+        parts = [f"{route_type} {payload_type}"]
+
+        # Advert-specific details
+        if payload_type == "ADVERT":
+            node_name = data.get("node_name", "")
+            node_type = data.get("node_type", "")
+            if node_name:
+                parts[0] += f' from "{node_name}"'
+                if node_type:
+                    parts[0] += f" ({node_type})"
+
+        # GroupText-specific details
+        elif payload_type == "GROUP TEXT":
+            decrypted = data.get("decrypted", False)
+            if decrypted:
+                channel_name = data.get("channel_name", "")
+                message_text = data.get("message_text", "")
+                if channel_name:
+                    parts[0] += f" on #{channel_name}"
+                if message_text:
+                    # Truncate long messages
+                    display_text = message_text[:60] + ("..." if len(message_text) > 60 else "")
+                    parts[0] += f': "{display_text}"'
+            else:
+                parts[0] += " (encrypted)"
+
+        # Path info
+        hop_label = "hop" if hop_count == 1 else "hops"
+        parts.append(f"{hop_count} {hop_label}{path_str}")
+
+        # Signal quality
+        if snr is not None:
+            parts.append(f"SNR: {snr:.2f} dB")
+        if rssi is not None:
+            parts.append(f"RSSI: {rssi} dBm")
+
+        # Size
+        parts.append(f"{size_bytes} bytes")
+
+        description = " \u00b7 ".join(parts)
+
+        return {
+            "message": description,
+            "domain": DOMAIN,
+            "icon": "mdi:access-point",
+        }
+
+    async_describe_event(DOMAIN, EVENT_MESHCORE_RX_LOG, process_rx_log_event)
 
 async def handle_channel_message(event, coordinator) -> None:
     """Handle channel message event."""

--- a/custom_components/meshcore/switch.py
+++ b/custom_components/meshcore/switch.py
@@ -1,0 +1,83 @@
+"""Switch platform for MeshCore integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .utils import format_entity_id, sanitize_name
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up MeshCore switch entities from config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Initialize rx_log_enabled on the coordinator (defaults to OFF)
+    coordinator.rx_log_enabled = False
+
+    async_add_entities([RxMessageLogSwitch(coordinator)])
+
+
+class RxMessageLogSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to enable/disable RX Message Log."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the RX Message Log switch."""
+        super().__init__(coordinator)
+
+        device_key = coordinator.pubkey or ""
+        pubkey6 = device_key[:6]
+
+        # Unique ID
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_rx_message_log_{pubkey6}"
+        )
+
+        # Entity ID: switch.meshcore_{pubkey6}_rx_message_log
+        self.entity_id = format_entity_id(
+            "switch", pubkey6, "rx_message_log"
+        )
+
+        self._attr_name = "RX Message Log"
+        self._attr_icon = "mdi:radio-tower"
+
+    @property
+    def device_info(self):
+        """Return device info to link this entity to the MeshCore device."""
+        return DeviceInfo(**self.coordinator.device_info)
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the RX message log is enabled."""
+        return getattr(self.coordinator, "rx_log_enabled", False)
+
+    @property
+    def icon(self) -> str:
+        """Return icon based on state."""
+        return "mdi:radio-tower" if self.is_on else "mdi:radio-tower-off"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the RX message log."""
+        self.coordinator.rx_log_enabled = True
+        _LOGGER.info("RX Message Log enabled")
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the RX message log."""
+        self.coordinator.rx_log_enabled = False
+        _LOGGER.info("RX Message Log disabled")
+        self.async_write_ha_state()

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -11,7 +11,14 @@ from typing import Any
 from Crypto.Cipher import AES
 from homeassistant.util import slugify
 
-from .const import BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType
+import struct
+
+from .const import (
+    BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType,
+    RX_PAYLOAD_TYPE_NAMES, RX_ROUTE_TYPE_NAMES, ADV_NODE_TYPE_NAMES,
+    ADV_PUB_KEY_SIZE, ADV_SIGNATURE_SIZE,
+    ADV_LATLON_MASK, ADV_FEAT1_MASK, ADV_FEAT2_MASK, ADV_NAME_MASK,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -279,15 +286,21 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         if len(packet_bytes) < 2:
             return result
 
-        # Parse header and path
+        # Parse header and packed path_len byte
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
         header = packet_bytes[0]
-        path_len = packet_bytes[1]
+        path_len_raw = packet_bytes[1]
+        hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+        hop_count = path_len_raw & 63          # number of relay hops
+        path_byte_len = hop_count * hash_size
 
         # Extract payload type from header (bits 2-5)
         payload_type = (header >> 2) & 0x0F
 
         result["header"] = f"{header:02x}"
-        result["path_len"] = path_len
+        result["path_len"] = path_len_raw
+        result["hop_count"] = hop_count
+        result["hash_size"] = hash_size
         result["payload_type"] = payload_type
 
         # Check if this is GroupText (0x05)
@@ -296,7 +309,7 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
             return result
 
         # Validate packet length
-        path_end = 2 + path_len
+        path_end = 2 + path_byte_len
         if len(packet_bytes) < path_end + 3:  # Need at least channel_hash + 2-byte MAC
             return result
 
@@ -339,7 +352,9 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
                         "timestamp": timestamp,
                         "text": message_text,
                         "decrypted": True,
-                        "path_len": path_len,
+                        "path_len": path_len_raw,
+                        "hop_count": hop_count,
+                        "hash_size": hash_size,
                         "path": path_data.hex(),
                         "channel_hash": f"{channel_hash_byte:02x}"
                     }
@@ -374,16 +389,20 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
 
     RX_LOG_DATA events contain raw LoRa payload with header, path, and channel hash.
     Format:
-    - Bytes 0-1: Header/identifier
-    - Bytes 2-3: Hop count (path_len)
-    - Bytes 4+: Path data (2 hex chars per node)
+    - Byte 0: Header (route type in bits 0-1, payload type in bits 2-5)
+    - Byte 1: Packed path_len byte:
+        - Bits 6-7: path hash size encoding ((value >> 6) + 1 = bytes per hop: 1, 2, or 3)
+        - Bits 0-5: hop count (number of relay nodes in path)
+        - Actual path byte length = hop_count * hash_size
+    - Bytes 2+: Path data (hash_size bytes per hop)
     - After path: Channel hash
 
     Args:
         payload: Raw event payload (dict with 'payload' or 'raw_hex', or direct hex string)
 
     Returns:
-        Dict with parsed fields: header, path_len, path, channel_hash
+        Dict with parsed fields: header, path_len (raw byte), hop_count, hash_size,
+        path, path_nodes, channel_hash.
         Returns empty dict on parsing errors (fault tolerant)
     """
     result = {}
@@ -415,20 +434,26 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
             _LOGGER.debug(f"RX_LOG hex too short: {len(hex_str)} chars")
             return result
 
-        # Parse header (bytes 0-1)
+        # Parse header (byte 0)
         result["header"] = hex_str[0:2]
 
-        # Parse path_len (bytes 2-3)
+        # Parse packed path_len byte (byte 1)
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
         try:
-            path_len = int(hex_str[2:4], 16)
-            result["path_len"] = path_len
+            path_len_raw = int(hex_str[2:4], 16)
+            hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+            hop_count = path_len_raw & 63          # number of relay hops
+            result["path_len"] = path_len_raw
+            result["hash_size"] = hash_size
+            result["hop_count"] = hop_count
         except ValueError:
             _LOGGER.debug(f"Could not parse path_len from: {hex_str[2:4]}")
             return result
 
         # Calculate expected positions
         path_start = 4
-        path_end = path_start + (path_len * 2)  # Each node is 2 hex chars
+        path_byte_len = hop_count * hash_size
+        path_end = path_start + (path_byte_len * 2)  # 2 hex chars per byte
 
         # Validate length for path data
         if len(hex_str) < path_end:
@@ -439,10 +464,11 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         path_hex = hex_str[path_start:path_end]
         result["path"] = path_hex
 
-        # Parse individual nodes in path (2 chars each)
+        # Parse individual nodes in path (hash_size bytes = hash_size*2 hex chars each)
         path_nodes = []
-        for i in range(0, len(path_hex), 2):
-            node_hex = path_hex[i:i+2]
+        node_hex_len = hash_size * 2
+        for i in range(0, len(path_hex), node_hex_len):
+            node_hex = path_hex[i:i + node_hex_len]
             path_nodes.append(node_hex)
         result["path_nodes"] = path_nodes
 
@@ -452,11 +478,211 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
             if len(hex_str) >= path_end + 2:
                 result["channel_hash"] = hex_str[path_end:path_end+2]
 
-        _LOGGER.debug(f"Parsed RX_LOG: header={result.get('header')}, path_len={result.get('path_len')}, "
-                     f"path={result.get('path')}, channel_hash={result.get('channel_hash')}")
+        _LOGGER.debug(f"Parsed RX_LOG: header={result.get('header')}, hop_count={hop_count}, "
+                     f"hash_size={hash_size}, path={result.get('path')}, "
+                     f"channel_hash={result.get('channel_hash')}")
 
     except Exception as ex:
         _LOGGER.debug(f"Error parsing RX_LOG data: {ex}")
 
     return result
+
+
+def parse_rx_log_full(event_payload: dict, decrypted_data: dict | None = None) -> dict | None:
+    """Parse an RX_LOG event payload into display-ready fields.
+
+    Combines SNR/RSSI from the event with full LoRa frame parsing including
+    advert payload details (node name, type, location) and GroupText decryption.
+
+    Args:
+        event_payload: Raw RX_LOG event payload dict with snr, rssi, payload fields
+        decrypted_data: Optional pre-computed decrypted GroupText data from
+                        parse_and_decrypt_rx_log()
+
+    Returns:
+        Dict with all display-ready fields, or None if payload cannot be parsed.
+    """
+    try:
+        # Extract signal quality from event payload
+        snr = event_payload.get("snr")
+        rssi = event_payload.get("rssi")
+
+        # Get the raw LoRa frame hex
+        hex_str = None
+        if isinstance(event_payload, dict):
+            hex_str = event_payload.get("payload") or event_payload.get("raw_hex")
+        elif isinstance(event_payload, (str, bytes)):
+            hex_str = event_payload
+
+        if not hex_str:
+            return None
+
+        # Convert to bytes
+        if isinstance(hex_str, str):
+            packet_bytes = bytes.fromhex(hex_str.replace(" ", "").replace("\n", ""))
+        elif isinstance(hex_str, bytes):
+            packet_bytes = hex_str
+        else:
+            return None
+
+        if len(packet_bytes) < 2:
+            return None
+
+        # Parse header byte
+        header = packet_bytes[0]
+        route_type_raw = header & 0x03
+        payload_type_raw = (header >> 2) & 0x0F
+
+        # Parse packed path_len byte
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
+        path_len_raw = packet_bytes[1]
+        hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+        hop_count = path_len_raw & 63          # number of relay hops
+        path_byte_len = hop_count * hash_size
+        path_end = 2 + path_byte_len
+
+        if len(packet_bytes) < path_end:
+            return None
+
+        path_data = packet_bytes[2:path_end]
+        # Parse individual nodes (hash_size bytes each)
+        path_nodes = []
+        for i in range(0, len(path_data), hash_size):
+            path_nodes.append(path_data[i:i + hash_size].hex())
+
+        # Build result
+        result = {
+            "snr": snr,
+            "rssi": rssi,
+            "size_bytes": len(packet_bytes),
+            "route_type": RX_ROUTE_TYPE_NAMES.get(route_type_raw, f"UNKNOWN({route_type_raw})"),
+            "payload_type": RX_PAYLOAD_TYPE_NAMES.get(payload_type_raw, f"UNKNOWN({payload_type_raw})"),
+            "payload_type_raw": payload_type_raw,
+            "path_len": path_len_raw,
+            "hop_count": hop_count,
+            "hash_size": hash_size,
+            "path": path_data.hex(),
+            "path_nodes": path_nodes,
+        }
+
+        # Parse advert-specific fields
+        if payload_type_raw == 0x04:
+            _parse_advert_payload(packet_bytes[path_end:], result)
+
+        # Include GroupText decryption data if available
+        if payload_type_raw == 0x05 and decrypted_data:
+            if decrypted_data.get("decrypted"):
+                result["channel_name"] = decrypted_data.get("channel_name", "")
+                result["channel_idx"] = decrypted_data.get("channel_idx")
+                result["message_text"] = decrypted_data.get("text", "")
+                result["decrypted"] = True
+            else:
+                result["decrypted"] = False
+
+        return result
+
+    except Exception as ex:
+        _LOGGER.debug(f"Error in parse_rx_log_full: {ex}")
+        return None
+
+
+def _parse_advert_payload(payload_after_path: bytes, result: dict) -> None:
+    """Parse advert-specific fields from the payload after the LoRa header + path.
+
+    Advert structure (from firmware Mesh.cpp, AdvertDataHelpers.cpp):
+    1. Public key — 32 bytes (ADV_PUB_KEY_SIZE)
+    2. Timestamp — 4 bytes, uint32_t little-endian
+    3. Signature — 64 bytes (ADV_SIGNATURE_SIZE)
+    4. App data — variable length, parsed by AdvertDataParser
+
+    App data flags byte (byte 0):
+    - Bits 0-3: Node type (0=unknown, 1=client, 2=repeater, 3=room, 4=sensor)
+    - Bit 4 (0x10): Latitude/longitude present (8 bytes total)
+    - Bit 5 (0x20): Extra1 present (2 bytes)
+    - Bit 6 (0x40): Extra2 present (2 bytes)
+    - Bit 7 (0x80): Name present (remaining bytes)
+
+    Args:
+        payload_after_path: Raw bytes starting after the LoRa header + path
+        result: Dict to update with advert-specific fields
+    """
+    try:
+        offset = 0
+
+        # Public key (32 bytes)
+        if len(payload_after_path) < offset + ADV_PUB_KEY_SIZE:
+            return
+        pubkey = payload_after_path[offset:offset + ADV_PUB_KEY_SIZE]
+        result["node_pubkey"] = pubkey.hex()
+        offset += ADV_PUB_KEY_SIZE
+
+        # Timestamp (4 bytes, little-endian)
+        if len(payload_after_path) < offset + 4:
+            return
+        advert_timestamp = struct.unpack_from("<I", payload_after_path, offset)[0]
+        result["advert_timestamp"] = advert_timestamp
+        offset += 4
+
+        # Signature (64 bytes)
+        if len(payload_after_path) < offset + ADV_SIGNATURE_SIZE:
+            return
+        offset += ADV_SIGNATURE_SIZE
+
+        # App data (variable length)
+        app_data = payload_after_path[offset:]
+        if len(app_data) < 1:
+            # No app data, use pubkey prefix as name
+            result["node_name"] = result["node_pubkey"][:12]
+            result["node_type"] = "UNKNOWN"
+            result["has_location"] = False
+            return
+
+        # Parse flags byte
+        flags = app_data[0]
+        node_type_raw = flags & 0x0F
+        result["node_type"] = ADV_NODE_TYPE_NAMES.get(node_type_raw, f"UNKNOWN({node_type_raw})")
+
+        app_offset = 1
+
+        # Latitude/longitude (if bit 4 set)
+        if flags & ADV_LATLON_MASK:
+            if len(app_data) >= app_offset + 8:
+                lat_raw = struct.unpack_from("<i", app_data, app_offset)[0]
+                app_offset += 4
+                lon_raw = struct.unpack_from("<i", app_data, app_offset)[0]
+                app_offset += 4
+                result["has_location"] = True
+                result["latitude"] = lat_raw / 1e6
+                result["longitude"] = lon_raw / 1e6
+            else:
+                result["has_location"] = False
+        else:
+            result["has_location"] = False
+
+        # Extra1 (if bit 5 set)
+        if flags & ADV_FEAT1_MASK:
+            if len(app_data) >= app_offset + 2:
+                app_offset += 2
+
+        # Extra2 (if bit 6 set)
+        if flags & ADV_FEAT2_MASK:
+            if len(app_data) >= app_offset + 2:
+                app_offset += 2
+
+        # Name (if bit 7 set, remaining bytes)
+        if flags & ADV_NAME_MASK:
+            name_bytes = app_data[app_offset:]
+            if name_bytes:
+                result["node_name"] = name_bytes.decode("utf-8", errors="ignore").strip("\x00")
+            else:
+                result["node_name"] = result.get("node_pubkey", "")[:12]
+        else:
+            result["node_name"] = result.get("node_pubkey", "")[:12]
+
+    except Exception as ex:
+        _LOGGER.debug(f"Error parsing advert payload: {ex}")
+        # Best-effort: set defaults for any missing fields
+        result.setdefault("node_name", result.get("node_pubkey", "")[:12])
+        result.setdefault("node_type", "UNKNOWN")
+        result.setdefault("has_location", False)
 


### PR DESCRIPTION
## Summary

- Adds an RX Message Log switch entity that enables logging every received LoRa packet to HA logbook via a new RX Messages binary sensor
- Includes full packet parsing with `parse_rx_log_full()` — extracts route type, payload type, SNR, RSSI, hop path, packet size, and type-specific details (advert fields, GroupText decryption)
- Switch is off by default to avoid logbook noise; when enabled, fires `meshcore_rx_log` events for each received RF packet

## Details

**Files changed:** `__init__.py`, `binary_sensor.py`, `const.py`, `logbook.py`, `switch.py` (new), `utils.py`

### New entities

- `switch.meshcore_<device>_rx_message_log` — toggle to enable/disable RX packet logging
- `binary_sensor.meshcore_<device>_rx_messages` — RX log event target for logbook entries

### Packet parsing (`parse_rx_log_full`)

Parses the full LoRa frame structure including:
- Header byte → route type (flood/direct/routed) and payload type
- Variable-length hop path with configurable hash size (modes 0/1/2)
- Payload-specific parsing: advert fields (node type, GPS, battery, features, name), GroupText decryption
- Protocol constants for all known payload types, route types, and advert node types

### Logbook integration

- `EVENT_MESHCORE_RX_LOG` events are described in logbook with human-readable format showing route type, payload type, SNR, RSSI, hops, and path
- Logbook entries appear on the RX Messages binary sensor entity

## Test plan

- [ ] Toggle RX Message Log switch on and verify RX_LOG events appear in HA logbook
- [ ] Verify packet details are correctly parsed (route type, payload type, SNR, RSSI, hop count)
- [ ] Toggle switch off and confirm logging stops
- [ ] Verify no performance impact with switch disabled (default state)
- [ ] Test with various packet types: adverts, GroupText, direct messages