### PR TITLE
Add contact signal data enrichment and message route tracking

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -43,6 +43,7 @@ from .utils import (
     create_message_correlation_key,
     parse_and_decrypt_rx_log,
     parse_rx_log_data,
+    parse_rx_log_full,
     sanitize_event_data,
 )
 
@@ -99,6 +100,64 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     
     _LOGGER.debug("Migration to configuration version %s successful", config_entry.version)
     return True
+
+def _attribute_rx_to_contact(
+    coordinator: MeshCoreDataUpdateCoordinator,
+    event_payload: dict,
+    parsed_full: dict,
+) -> None:
+    """Store signal data on contacts from RX_LOG packets with exact identification.
+
+    Only stores data when the contact can be identified unambiguously:
+
+    - Adverts (payload_type 0x04): The sender's full 32-byte public key is
+      embedded in the packet, allowing exact matching regardless of hop count.
+      SNR/RSSI is only stored for direct adverts (hop_count == 0) since that
+      measures the actual RF link to the sender.
+
+    Route-based matching (using short path-node hashes) is intentionally not
+    used because mode-0 hashing (1-byte prefixes) is too ambiguous with large
+    contact lists.
+
+    Message-based attribution (channel and direct messages) is handled
+    separately in logbook.py where the sender is already identified.
+    """
+    payload_type_raw = parsed_full.get("payload_type_raw")
+    hop_count = parsed_full.get("hop_count", 0)
+    path_nodes = parsed_full.get("path_nodes", [])
+
+    # Only adverts contain the sender's full public key
+    if payload_type_raw != 0x04:
+        return
+
+    node_pubkey = parsed_full.get("node_pubkey", "")
+    if not node_pubkey or len(node_pubkey) < 12:
+        return
+
+    candidate = node_pubkey[:12]
+
+    # Verify we know this contact (saved or discovered)
+    if not (candidate in coordinator._contacts
+            or any(pk.startswith(candidate) for pk in coordinator._discovered_contacts)):
+        return
+
+    rx_data = {
+        "last_snr": event_payload.get("snr") if hop_count == 0 else None,
+        "last_rssi": event_payload.get("rssi") if hop_count == 0 else None,
+        "last_rx_hops": hop_count,
+        "last_rx_path": parsed_full.get("path", ""),
+        "last_rx_path_nodes": path_nodes,
+        "last_rx_route_type": parsed_full.get("route_type", ""),
+        "last_rx_payload_type": parsed_full.get("payload_type", ""),
+        "last_rx_timestamp": time.time(),
+    }
+    stored = coordinator.update_contact_rx_data(candidate, rx_data)
+    if stored:
+        _LOGGER.debug(
+            "Stored RX data for advert sender %s: SNR=%s RSSI=%s hops=%s",
+            candidate, rx_data["last_snr"], rx_data["last_rssi"], hop_count,
+        )
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeshCore from a config entry."""
@@ -312,6 +371,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     _LOGGER.debug(f"Stored RX_LOG for correlation: ch={channel_idx}, hash={hash_key[:8]}")
 
+                # Parse full packet structure (needed for contact attribution)
+                parsed_full = parse_rx_log_full(event.payload, decrypted_data)
+
+                # --- Contact RX data attribution ---
+                # Identify which contact this packet came from and store signal data
+                if parsed_full:
+                    _attribute_rx_to_contact(coordinator, event.payload, parsed_full)
+                    # Notify entities so contact binary sensors refresh with new RX attributes.
+                    # The 10-second rate limit inside update_contact_rx_data throttles frequency.
+                    if coordinator._dirty_contacts:
+                        coordinator.async_set_updated_data(coordinator.data or {})
             # Fire event to HA event bus with sanitized payload
             _LOGGER.debug(f"Firing event to HA event bus: {event}")
             hass.bus.async_fire(f"{DOMAIN}_raw_event", {

--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -669,5 +669,18 @@ class MeshCoreContactDiagnosticBinarySensor(CoordinatorEntity, BinarySensorEntit
         if last_advert > 0:
             last_advert_time = datetime.fromtimestamp(last_advert)
             attributes["last_advert_formatted"] = last_advert_time.isoformat()
-            
+
+        # RX signal data (SNR, RSSI, path) from last received packet
+        rx_data = self.coordinator.get_contact_rx_data(self.pubkey_prefix)
+        if rx_data:
+            attributes["last_snr"] = rx_data.get("last_snr")
+            attributes["last_rssi"] = rx_data.get("last_rssi")
+            attributes["last_rx_hops"] = rx_data.get("last_rx_hops")
+            attributes["last_rx_path"] = rx_data.get("last_rx_path")
+            attributes["last_rx_path_nodes"] = rx_data.get("last_rx_path_nodes", [])
+            attributes["last_rx_route_type"] = rx_data.get("last_rx_route_type")
+            attributes["last_rx_payload_type"] = rx_data.get("last_rx_payload_type")
+            rx_ts = rx_data.get("last_rx_timestamp")
+            if rx_ts:
+                attributes["last_rx_time"] = datetime.fromtimestamp(rx_ts).isoformat()
         return attributes

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -138,3 +138,46 @@ class NodeType(IntEnum):
     REPEATER = 2
     ROOM_SERVER = 3
     SENSOR = 4
+
+
+# LoRa frame payload types (header bits 2-5, from firmware Packet.h)
+RX_PAYLOAD_TYPE_NAMES: Final = {
+    0x00: "REQUEST",
+    0x01: "RESPONSE",
+    0x02: "DIRECT TEXT",
+    0x03: "ACK",
+    0x04: "ADVERT",
+    0x05: "GROUP TEXT",
+    0x06: "GROUP DATA",
+    0x07: "ANON REQUEST",
+    0x08: "PATH",
+    0x09: "TRACE",
+    0x0A: "MULTIPART",
+    0x0B: "CONTROL",
+    0x0F: "RAW CUSTOM",
+}
+
+# LoRa frame route types (header bits 0-1, from firmware Packet.h)
+RX_ROUTE_TYPE_NAMES: Final = {
+    0x00: "TRANSPORT FLOOD",
+    0x01: "FLOOD",
+    0x02: "DIRECT",
+    0x03: "TRANSPORT DIRECT",
+}
+
+# Advert node types (from firmware AdvertDataHelpers.h)
+ADV_NODE_TYPE_NAMES: Final = {
+    0: "UNKNOWN",
+    1: "CLIENT",
+    2: "REPEATER",
+    3: "ROOM SERVER",
+    4: "SENSOR",
+}
+
+# Advert payload structure constants (from firmware AdvertDataHelpers.h, MeshCore.h)
+ADV_PUB_KEY_SIZE: Final = 32
+ADV_SIGNATURE_SIZE: Final = 64
+ADV_LATLON_MASK: Final = 0x10
+ADV_FEAT1_MASK: Final = 0x20
+ADV_FEAT2_MASK: Final = 0x40
+ADV_NAME_MASK: Final = 0x80

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -169,6 +169,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # Set of pubkey prefixes that have been updated and need sensor refresh
         self._dirty_contacts = set()
 
+        # RX signal data per contact — keyed by 12-char pubkey prefix
+        # Stores last received SNR, RSSI, path, hops, etc.
+        self._contact_rx_data: dict[str, dict[str, Any]] = {}
+        self._contact_rx_rate_limit: dict[str, float] = {}  # last update time per prefix
+
     def mark_contact_dirty(self, pubkey_prefix: str):
         """Mark a contact as needing update (for performance optimization).
 
@@ -196,6 +201,42 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         if pubkey_prefix:
             normalized = pubkey_prefix[:12]
             self._dirty_contacts.discard(normalized)
+
+    def update_contact_rx_data(self, pubkey_prefix: str, rx_data: dict[str, Any]) -> bool:
+        """Store latest RX signal data for a contact with 10-second rate limit.
+
+        Returns True if the data was stored, False if rate-limited.
+        """
+        if not pubkey_prefix:
+            return False
+        normalized = pubkey_prefix[:12]
+        now = time.time()
+        last_update = self._contact_rx_rate_limit.get(normalized, 0)
+        if now - last_update < 10:
+            return False
+        self._contact_rx_data[normalized] = rx_data
+        self._contact_rx_rate_limit[normalized] = now
+        self.mark_contact_dirty(normalized)
+        return True
+
+    def get_contact_rx_data(self, pubkey_prefix: str) -> dict[str, Any]:
+        """Return stored RX signal data for a contact, or empty dict."""
+        if not pubkey_prefix:
+            return {}
+        return self._contact_rx_data.get(pubkey_prefix[:12], {})
+
+    def clear_all_contact_rx_data(self) -> int:
+        """Clear all stored RX signal data and rate limits.
+
+        Returns the number of contacts whose data was cleared.
+        Marks each affected contact as dirty so sensors refresh.
+        """
+        count = len(self._contact_rx_data)
+        for prefix in list(self._contact_rx_data.keys()):
+            self.mark_contact_dirty(prefix)
+        self._contact_rx_data.clear()
+        self._contact_rx_rate_limit.clear()
+        return count
 
     def get_all_contacts(self) -> list:
         """Get deduplicated list of all contacts (added + discovered).

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -2,6 +2,7 @@
 import asyncio
 from calendar import c
 import logging
+import time
 from typing import  Callable
 from datetime import datetime
 
@@ -37,7 +38,7 @@ def async_describe_events(
         message = data.get("message", "")
         channel = data.get("channel", "")
         sender = data.get("sender_name", "Unknown")
-        
+
         # Format description based on message type and direction
         if channel:
             # Channel message
@@ -47,7 +48,21 @@ def async_describe_events(
             # Direct message
             description = f"{sender}: {message}"
             icon = "mdi:message-text"
-        
+
+        # Append route if RX_LOG data is available (incoming messages only).
+        # Format: [route:xx,yy,zz] — easily stripped by UI cards.
+        rx_logs = data.get("rx_log_data", [])
+        if rx_logs and not data.get("outgoing"):
+            first_rx = rx_logs[0]
+            path_nodes = first_rx.get("path_nodes", [])
+            if not path_nodes:
+                # Fall back to raw path hex, split into 2-char pairs
+                raw_path = first_rx.get("path", "")
+                if raw_path:
+                    path_nodes = [raw_path[i:i+2] for i in range(0, len(raw_path), 2)]
+            if path_nodes:
+                description += f" [route:{','.join(path_nodes)}]"
+
         return {
             # "name": sender,
             "message": description,
@@ -84,10 +99,16 @@ async def handle_channel_message(event, coordinator) -> None:
 
                 # Use the provided coordinator for contact lookup
                 if coordinator and hasattr(coordinator, "api") and coordinator.api.mesh_core:
-                    # Try to find contact by name to get public key
+                    # Try saved contacts first (SDK), then discovered contacts
                     contact = coordinator.api.mesh_core.get_contact_by_name(sender_name)
                     if contact and isinstance(contact, dict):
                         sender_pubkey = contact.get("public_key", "")[:12]
+                    elif hasattr(coordinator, "_discovered_contacts"):
+                        # Search discovered contacts by advertised name
+                        for full_pk, disc in coordinator._discovered_contacts.items():
+                            if disc.get("adv_name") == sender_name:
+                                sender_pubkey = full_pk[:12]
+                                break
 
         # Check for Home Assistant instance
         if not hasattr(coordinator, "hass"):
@@ -120,7 +141,13 @@ async def handle_channel_message(event, coordinator) -> None:
         if sender_pubkey:
             event_data["pubkey_prefix"] = sender_pubkey
 
-        # Correlate with RX_LOG data - delay 500ms to collect multiple receptions
+        # Correlate with RX_LOG data using multiple collection passes.
+        # RX_LOG events may arrive after the channel message event, especially
+        # on multi-hop paths. Two passes (500ms + 1000ms) catch late arrivals
+        # without delaying the logbook entry excessively.
+        INCOMING_COLLECTION_PASSES = 2
+        INCOMING_PASS_INTERVALS = [0.5, 1.0]  # seconds to wait before each pass
+
         try:
             timestamp = payload.get("sender_timestamp")
             original_text = payload.get("text", "")
@@ -133,6 +160,29 @@ async def handle_channel_message(event, coordinator) -> None:
                 if rx_logs:
                     _LOGGER.debug(f"Correlated channel message with {len(rx_logs)} RX_LOG reception(s)")
                     event_data["rx_log_data"] = rx_logs
+
+                    # Store route data on the sender's contact entity.
+                    # Use the first RX_LOG entry (typically the most direct path).
+                    if sender_pubkey:
+                        first_rx = rx_logs[0]
+                        rx_data = {
+                            "last_snr": first_rx.get("snr"),
+                            "last_rssi": first_rx.get("rssi"),
+                            "last_rx_hops": first_rx.get("hop_count", 0),
+                            "last_rx_path": first_rx.get("path", ""),
+                            "last_rx_path_nodes": [],  # Not parsed in RX_LOG entries
+                            "last_rx_route_type": "channel_msg",
+                            "last_rx_payload_type": "GroupText",
+                            "last_rx_timestamp": time.time(),
+                        }
+                        stored = coordinator.update_contact_rx_data(sender_pubkey, rx_data)
+                        if stored:
+                            _LOGGER.debug(
+                                "Stored route data on sender %s from channel message: SNR=%s RSSI=%s hops=%s",
+                                sender_pubkey[:6], rx_data["last_snr"],
+                                rx_data["last_rssi"], rx_data["last_rx_hops"],
+                            )
+                            coordinator.async_set_updated_data(coordinator.data or {})
         except Exception as ex:
             _LOGGER.debug(f"Error correlating channel message with RX_LOG: {ex}")
 
@@ -202,6 +252,30 @@ def handle_contact_message(event, coordinator) -> None:
             "timestamp": datetime.now().isoformat(),
             "message_type": "direct"  # Explicit message type for filtering
         }
+
+        # Store route data on the sender's contact entity.
+        # Direct messages come straight from the sender's radio; store any
+        # signal data the SDK provides and record that a message was received.
+        try:
+            rx_data = {
+                "last_snr": payload.get("snr"),
+                "last_rssi": payload.get("rssi"),
+                "last_rx_hops": payload.get("hop_count"),
+                "last_rx_path": payload.get("path", ""),
+                "last_rx_path_nodes": [],
+                "last_rx_route_type": "direct_msg",
+                "last_rx_payload_type": "ContactMsg",
+                "last_rx_timestamp": time.time(),
+            }
+            stored = coordinator.update_contact_rx_data(pubkey_prefix, rx_data)
+            if stored:
+                _LOGGER.debug(
+                    "Stored route data on sender %s from direct message: SNR=%s RSSI=%s",
+                    pubkey_prefix[:6], rx_data["last_snr"], rx_data["last_rssi"],
+                )
+                coordinator.async_set_updated_data(coordinator.data or {})
+        except Exception as ex:
+            _LOGGER.debug(f"Error storing direct message route data: {ex}")
 
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -6,12 +6,18 @@ import hashlib
 import hmac
 import logging
 import re
+import struct
 from typing import Any
 
 from Crypto.Cipher import AES
 from homeassistant.util import slugify
 
-from .const import BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType
+from .const import (
+    BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType,
+    RX_PAYLOAD_TYPE_NAMES, RX_ROUTE_TYPE_NAMES, ADV_NODE_TYPE_NAMES,
+    ADV_PUB_KEY_SIZE, ADV_SIGNATURE_SIZE,
+    ADV_LATLON_MASK, ADV_FEAT1_MASK, ADV_FEAT2_MASK, ADV_NAME_MASK,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -459,4 +465,203 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         _LOGGER.debug(f"Error parsing RX_LOG data: {ex}")
 
     return result
+
+
+def parse_rx_log_full(event_payload: dict, decrypted_data: dict | None = None) -> dict | None:
+    """Parse an RX_LOG event payload into display-ready fields.
+
+    Combines SNR/RSSI from the event with full LoRa frame parsing including
+    advert payload details (node name, type, location) and GroupText decryption.
+
+    Args:
+        event_payload: Raw RX_LOG event payload dict with snr, rssi, payload fields
+        decrypted_data: Optional pre-computed decrypted GroupText data from
+                        parse_and_decrypt_rx_log()
+
+    Returns:
+        Dict with all display-ready fields, or None if payload cannot be parsed.
+    """
+    try:
+        # Extract signal quality from event payload
+        snr = event_payload.get("snr")
+        rssi = event_payload.get("rssi")
+
+        # Get the raw LoRa frame hex
+        hex_str = None
+        if isinstance(event_payload, dict):
+            hex_str = event_payload.get("payload") or event_payload.get("raw_hex")
+        elif isinstance(event_payload, (str, bytes)):
+            hex_str = event_payload
+
+        if not hex_str:
+            return None
+
+        # Convert to bytes
+        if isinstance(hex_str, str):
+            packet_bytes = bytes.fromhex(hex_str.replace(" ", "").replace("\n", ""))
+        elif isinstance(hex_str, bytes):
+            packet_bytes = hex_str
+        else:
+            return None
+
+        if len(packet_bytes) < 2:
+            return None
+
+        # Parse header byte
+        header = packet_bytes[0]
+        route_type_raw = header & 0x03
+        payload_type_raw = (header >> 2) & 0x0F
+
+        # Parse packed path_len byte
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
+        path_len_raw = packet_bytes[1]
+        hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+        hop_count = path_len_raw & 63          # number of relay hops
+        path_byte_len = hop_count * hash_size
+        path_end = 2 + path_byte_len
+
+        if len(packet_bytes) < path_end:
+            return None
+
+        path_data = packet_bytes[2:path_end]
+        # Parse individual nodes (hash_size bytes each)
+        path_nodes = []
+        for i in range(0, len(path_data), hash_size):
+            path_nodes.append(path_data[i:i + hash_size].hex())
+
+        # Build result
+        result = {
+            "snr": snr,
+            "rssi": rssi,
+            "size_bytes": len(packet_bytes),
+            "route_type": RX_ROUTE_TYPE_NAMES.get(route_type_raw, f"UNKNOWN({route_type_raw})"),
+            "payload_type": RX_PAYLOAD_TYPE_NAMES.get(payload_type_raw, f"UNKNOWN({payload_type_raw})"),
+            "payload_type_raw": payload_type_raw,
+            "path_len": path_len_raw,
+            "hop_count": hop_count,
+            "hash_size": hash_size,
+            "path": path_data.hex(),
+            "path_nodes": path_nodes,
+        }
+
+        # Parse advert-specific fields
+        if payload_type_raw == 0x04:
+            _parse_advert_payload(packet_bytes[path_end:], result)
+
+        # Include GroupText decryption data if available
+        if payload_type_raw == 0x05 and decrypted_data:
+            if decrypted_data.get("decrypted"):
+                result["channel_name"] = decrypted_data.get("channel_name", "")
+                result["channel_idx"] = decrypted_data.get("channel_idx")
+                result["message_text"] = decrypted_data.get("text", "")
+                result["decrypted"] = True
+            else:
+                result["decrypted"] = False
+
+        return result
+
+    except Exception as ex:
+        _LOGGER.debug(f"Error in parse_rx_log_full: {ex}")
+        return None
+
+
+def _parse_advert_payload(payload_after_path: bytes, result: dict) -> None:
+    """Parse advert-specific fields from the payload after the LoRa header + path.
+
+    Advert structure (from firmware Mesh.cpp, AdvertDataHelpers.cpp):
+    1. Public key — 32 bytes (ADV_PUB_KEY_SIZE)
+    2. Timestamp — 4 bytes, uint32_t little-endian
+    3. Signature — 64 bytes (ADV_SIGNATURE_SIZE)
+    4. App data — variable length, parsed by AdvertDataParser
+
+    App data flags byte (byte 0):
+    - Bits 0-3: Node type (0=unknown, 1=client, 2=repeater, 3=room, 4=sensor)
+    - Bit 4 (0x10): Latitude/longitude present (8 bytes total)
+    - Bit 5 (0x20): Extra1 present (2 bytes)
+    - Bit 6 (0x40): Extra2 present (2 bytes)
+    - Bit 7 (0x80): Name present (remaining bytes)
+
+    Args:
+        payload_after_path: Raw bytes starting after the LoRa header + path
+        result: Dict to update with advert-specific fields
+    """
+    try:
+        offset = 0
+
+        # Public key (32 bytes)
+        if len(payload_after_path) < offset + ADV_PUB_KEY_SIZE:
+            return
+        pubkey = payload_after_path[offset:offset + ADV_PUB_KEY_SIZE]
+        result["node_pubkey"] = pubkey.hex()
+        offset += ADV_PUB_KEY_SIZE
+
+        # Timestamp (4 bytes, little-endian)
+        if len(payload_after_path) < offset + 4:
+            return
+        advert_timestamp = struct.unpack_from("<I", payload_after_path, offset)[0]
+        result["advert_timestamp"] = advert_timestamp
+        offset += 4
+
+        # Signature (64 bytes)
+        if len(payload_after_path) < offset + ADV_SIGNATURE_SIZE:
+            return
+        offset += ADV_SIGNATURE_SIZE
+
+        # App data (variable length)
+        app_data = payload_after_path[offset:]
+        if len(app_data) < 1:
+            # No app data, use pubkey prefix as name
+            result["node_name"] = result["node_pubkey"][:12]
+            result["node_type"] = "UNKNOWN"
+            result["has_location"] = False
+            return
+
+        # Parse flags byte
+        flags = app_data[0]
+        node_type_raw = flags & 0x0F
+        result["node_type"] = ADV_NODE_TYPE_NAMES.get(node_type_raw, f"UNKNOWN({node_type_raw})")
+
+        app_offset = 1
+
+        # Latitude/longitude (if bit 4 set)
+        if flags & ADV_LATLON_MASK:
+            if len(app_data) >= app_offset + 8:
+                lat_raw = struct.unpack_from("<i", app_data, app_offset)[0]
+                app_offset += 4
+                lon_raw = struct.unpack_from("<i", app_data, app_offset)[0]
+                app_offset += 4
+                result["has_location"] = True
+                result["latitude"] = lat_raw / 1e6
+                result["longitude"] = lon_raw / 1e6
+            else:
+                result["has_location"] = False
+        else:
+            result["has_location"] = False
+
+        # Extra1 (if bit 5 set)
+        if flags & ADV_FEAT1_MASK:
+            if len(app_data) >= app_offset + 2:
+                app_offset += 2
+
+        # Extra2 (if bit 6 set)
+        if flags & ADV_FEAT2_MASK:
+            if len(app_data) >= app_offset + 2:
+                app_offset += 2
+
+        # Name (if bit 7 set, remaining bytes)
+        if flags & ADV_NAME_MASK:
+            name_bytes = app_data[app_offset:]
+            if name_bytes:
+                result["node_name"] = name_bytes.decode("utf-8", errors="ignore").strip("\x00")
+            else:
+                result["node_name"] = result.get("node_pubkey", "")[:12]
+        else:
+            result["node_name"] = result.get("node_pubkey", "")[:12]
+
+    except Exception as ex:
+        _LOGGER.debug(f"Error parsing advert payload: {ex}")
+        # Best-effort: set defaults for any missing fields
+        result.setdefault("node_name", result.get("node_pubkey", "")[:12])
+        result.setdefault("node_type", "UNKNOWN")
+        result.setdefault("has_location", False)
 


### PR DESCRIPTION
## Summary

- Enriches contact diagnostic sensors with RF signal data (SNR, RSSI, hop path, route type) by attributing RX_LOG packets to their source contacts
- Adds `[route:xx,yy,zz]` hop path annotations to logbook message descriptions so users can see the relay path for each message
- Implements 3-tier contact attribution: advert packets (direct pubkey match), channel messages (sender name lookup), and direct messages (pubkey prefix match), with 10-second per-contact rate limiting

## Details

**Files changed:** `__init__.py`, `binary_sensor.py`, `const.py`, `coordinator.py`, `logbook.py`, `utils.py`

### Contact signal data attribution

In `forward_all_events()` (`__init__.py`), RX_LOG events are parsed and attributed to contacts:
1. **Advert packets** — `parse_rx_log_full()` extracts the advertiser's public key; matched directly against known contacts
2. **Channel messages** — after decryption, the sender name is resolved to a contact
3. **Direct messages** — pubkey prefix from the packet is matched to contacts

Attributed data is stored via `coordinator.update_contact_rx_data()` with a 10-second per-contact rate limit to prevent excessive state writes on busy meshes.

### New sensor attributes

Contact diagnostic binary sensors (`binary_sensor.py`) gain these attributes when RX data is available:
- `last_snr`, `last_rssi` — signal quality from most recent packet
- `last_rx_hops` — hop count
- `last_rx_path`, `last_rx_path_nodes` — relay path as hex string and node list
- `last_rx_route_type`, `last_rx_payload_type` — packet metadata
- `last_rx_time` — timestamp of last attributed packet

### Logbook route annotations

`logbook.py` appends `[route:xx,yy,zz]` to message descriptions when RX_LOG correlation provides path data, showing the relay nodes that carried each message.

### Note on `parse_rx_log_full` infrastructure

This branch includes `parse_rx_log_full()` and associated protocol constants (`const.py`, `utils.py`) needed for advert parsing and contact attribution. These are also present in the `feature/rx-message-log` branch. When that branch merges first, these additions will be redundant but not conflicting.

## Test plan

- [ ] Verify contact sensor gains SNR/RSSI/path attributes after receiving an advert from that contact
- [ ] Send a channel message and verify route annotation appears in logbook
- [ ] Verify 10-second rate limiting prevents excessive state updates
- [ ] Confirm contacts without RX_LOG data don't show null signal attributes
- [ ] Test with multi-hop paths to verify path_nodes array is correct