### PR TITLE
Add message delivery feedback with rolling updates

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -286,12 +286,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         sanitized_payload["decrypted"] = decrypted_data
 
                 # Store for correlation if decryption succeeded
-                if decrypted_data.get("decrypted") and decrypted_data.get("timestamp") and decrypted_data.get("text"):
+                if decrypted_data.get("decrypted") and decrypted_data.get("timestamp"):
                     channel_idx = decrypted_data["channel_idx"]
                     timestamp = decrypted_data["timestamp"]
-                    text = decrypted_data["text"]
+                    text = decrypted_data.get("text")
 
-                    hash_key = create_message_correlation_key(channel_idx, timestamp, text)
+                    hash_key = create_message_correlation_key(channel_idx, timestamp)
 
                     rx_log_entry = {
                         "channel_idx": channel_idx,

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -162,7 +162,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # Track correlation keys reserved for outgoing message delivery.
         # When we send a channel message, the outgoing handler registers its key here
         # so the incoming handler knows not to pop() it from _pending_rx_logs.
-        self._outgoing_correlation_keys: set[str] = set()
+        self._outgoing_correlation_keys: TTLCache = TTLCache(maxsize=64, ttl=60)
 
         if not hasattr(self, "last_update_success_time"):
             self.last_update_success_time = self._current_time()

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -159,6 +159,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             ttl=RX_LOG_CACHE_TTL_SECONDS
         )
 
+        # Track correlation keys reserved for outgoing message delivery.
+        # When we send a channel message, the outgoing handler registers its key here
+        # so the incoming handler knows not to pop() it from _pending_rx_logs.
+        self._outgoing_correlation_keys: set[str] = set()
+
         if not hasattr(self, "last_update_success_time"):
             self.last_update_success_time = self._current_time()
 

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -336,7 +336,7 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
                 # Reserve this key so the incoming handler doesn't pop() it.
                 # The incoming handler fires 500ms faster and would steal entries
                 # before our first collection pass at 1000ms.
-                coordinator._outgoing_correlation_keys.add(hash_key)
+                coordinator._outgoing_correlation_keys[hash_key] = True
 
                 all_rx_logs = []
 
@@ -367,7 +367,7 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
                 finally:
                     # Always release the reservation so the cache key can be
                     # reused by future messages on the same channel+timestamp.
-                    coordinator._outgoing_correlation_keys.discard(hash_key)
+                    coordinator._outgoing_correlation_keys.pop(hash_key, None)
 
                 if not all_rx_logs:
                     # Log diagnostic info to help debug correlation mismatches

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -22,6 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 
 # Single event type for all messages
 EVENT_MESHCORE_MESSAGE = "meshcore_message"
+# Lightweight event for progressive delivery sensor updates (not logged)
+EVENT_MESHCORE_DELIVERY_UPDATE = "meshcore_delivery_update"
 
 @callback
 def async_describe_events(
@@ -123,16 +125,22 @@ async def handle_channel_message(event, coordinator) -> None:
         # Correlate with RX_LOG data - delay 500ms to collect multiple receptions
         try:
             timestamp = payload.get("sender_timestamp")
-            original_text = payload.get("text", "")
 
-            if channel_idx is not None and timestamp and original_text:
+            if channel_idx is not None and timestamp:
                 await asyncio.sleep(0.5)
-                hash_key = create_message_correlation_key(channel_idx, timestamp, original_text)
-                rx_logs = coordinator._pending_rx_logs.pop(hash_key, None)
+                hash_key = create_message_correlation_key(channel_idx, timestamp)
 
-                if rx_logs:
-                    _LOGGER.debug(f"Correlated channel message with {len(rx_logs)} RX_LOG reception(s)")
-                    event_data["rx_log_data"] = rx_logs
+                # Skip pop if this key is reserved for outgoing delivery tracking.
+                # When we send a channel message, the outgoing handler registers its
+                # key so re-broadcasts of our own message are left for it to consume.
+                if hash_key in coordinator._outgoing_correlation_keys:
+                    _LOGGER.debug("Skipping RX_LOG pop for outgoing-reserved key %s", hash_key[:8])
+                else:
+                    rx_logs = coordinator._pending_rx_logs.pop(hash_key, None)
+
+                    if rx_logs:
+                        _LOGGER.debug(f"Correlated channel message with {len(rx_logs)} RX_LOG reception(s)")
+                        event_data["rx_log_data"] = rx_logs
         except Exception as ex:
             _LOGGER.debug(f"Error correlating channel message with RX_LOG: {ex}")
 
@@ -236,14 +244,17 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
         # Direct message to a contact
         pubkey_prefix = event_data.get("contact_public_key", "")[:12]
         receiver_name = event_data.get("receiver", "Unknown")
-        
+
         # Generate entity ID matching MeshCoreMessageEntity
         entity_id = get_contact_entity_id(
             ENTITY_DOMAIN_BINARY_SENSOR,
             device_key[:6],
             pubkey_prefix[:6]
         )
-        
+
+        # Include ACK delivery status from the send service
+        ack_received = event_data.get("ack_received")
+
         # Create event data for logbook
         logbook_event = {
             "message": message_text,
@@ -253,17 +264,24 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "entity_id": entity_id,
             "domain": DOMAIN,
             "timestamp": datetime.now().isoformat(),
-            "outgoing": True
+            "outgoing": True,
+            "message_type": "direct",
+            "send_id": event_data.get("send_id"),
         }
-        
+
+        # Add ACK status if available
+        if ack_received is not None:
+            logbook_event["ack_received"] = ack_received
+
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
-        
+
         _LOGGER.debug(
-            "Logged outgoing direct message to %s (%s): %s",
+            "Logged outgoing direct message to %s (%s): %s (ack: %s)",
             receiver_name,
             pubkey_prefix[:6] if pubkey_prefix else "",
-            message_text[:50] + ("..." if len(message_text) > 50 else "")
+            message_text[:50] + ("..." if len(message_text) > 50 else ""),
+            "yes" if ack_received else ("no" if ack_received is False else "n/a")
         )
         
     elif message_type == "channel":
@@ -272,14 +290,14 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
         # Get actual channel name from stored channel info
         channel_info = await coordinator.get_channel_info(channel_idx)
         channel_name = channel_info.get("channel_name", "public" if channel_idx == 0 else f"{channel_idx}")
-        
+
         # Generate entity ID matching MeshCoreMessageEntity
         entity_id = get_channel_entity_id(
             ENTITY_DOMAIN_BINARY_SENSOR,
             device_key[:6],
             channel_idx
         )
-        
+
         # Create event data for logbook
         logbook_event = {
             "message": message_text,
@@ -289,14 +307,95 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "entity_id": entity_id,
             "domain": DOMAIN,
             "timestamp": datetime.now().isoformat(),
-            "outgoing": True
+            "outgoing": True,
+            "message_type": "channel",
+            "send_id": event_data.get("send_id"),
         }
-        
-        # Fire event
-        hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
-        
+
+        # Correlate with RX_LOG data for outgoing channel messages.
+        # When we send a channel message, repeaters re-broadcast it and our
+        # radio picks up those re-broadcasts as RX_LOG events. This lets us
+        # count how many repeaters relayed our message.
+        #
+        # We use rolling 1-second collection passes, firing a progressive
+        # event after each pass so the sensor updates in near-real-time.
+        # Using pop() on a match forces late arrivals into a new cache entry
+        # under the same key, which subsequent passes pick up.
+        NUM_COLLECTION_PASSES = 4
+        PASS_INTERVAL_SECONDS = 1.0
+
+        try:
+            send_timestamp = event_data.get("send_timestamp")
+
+            if channel_idx is not None and send_timestamp:
+                # Single correlation key using channel + timestamp only.
+                # Text is excluded because the HA config name may differ from
+                # the on-device advertised name prepended to broadcasts.
+                hash_key = create_message_correlation_key(channel_idx, send_timestamp)
+
+                # Reserve this key so the incoming handler doesn't pop() it.
+                # The incoming handler fires 500ms faster and would steal entries
+                # before our first collection pass at 1000ms.
+                coordinator._outgoing_correlation_keys.add(hash_key)
+
+                all_rx_logs = []
+
+                try:
+                    for pass_num in range(NUM_COLLECTION_PASSES):
+                        await asyncio.sleep(PASS_INTERVAL_SECONDS)
+
+                        batch = coordinator._pending_rx_logs.pop(hash_key, None)
+                        if batch:
+                            all_rx_logs.extend(batch)
+                            _LOGGER.debug(
+                                "Pass %d: collected %d new RX_LOG(s), total %d",
+                                pass_num + 1, len(batch), len(all_rx_logs)
+                            )
+
+                        is_final = (pass_num == NUM_COLLECTION_PASSES - 1)
+                        update_event = dict(logbook_event)
+                        update_event["rx_log_data"] = list(all_rx_logs)
+                        update_event["repeater_count"] = len(all_rx_logs)
+                        update_event["progressive"] = not is_final
+
+                        if is_final:
+                            # Final pass: fire the real logbook event (single entry)
+                            hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, update_event)
+                        else:
+                            # Intermediate: lightweight event only the sensor listens to
+                            hass.bus.async_fire(EVENT_MESHCORE_DELIVERY_UPDATE, update_event)
+                finally:
+                    # Always release the reservation so the cache key can be
+                    # reused by future messages on the same channel+timestamp.
+                    coordinator._outgoing_correlation_keys.discard(hash_key)
+
+                if not all_rx_logs:
+                    # Log diagnostic info to help debug correlation mismatches
+                    cache_keys = list(coordinator._pending_rx_logs.keys())
+                    _LOGGER.debug(
+                        "No RX_LOG correlated with outgoing channel message. "
+                        "ch=%s, ts=%s, hash=%s, pending_cache_keys=%s",
+                        channel_idx, send_timestamp,
+                        hash_key[:8], cache_keys[:5]
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Correlated outgoing channel message with "
+                        "%d RX_LOG reception(s) total",
+                        len(all_rx_logs)
+                    )
+            else:
+                # No timestamp available for correlation, fire single event
+                logbook_event["repeater_count"] = 0
+                hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
+        except Exception as ex:
+            _LOGGER.debug(f"Error correlating outgoing channel message with RX_LOG: {ex}")
+            # Fire event even on error so logbook still gets the entry
+            hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
+
         _LOGGER.debug(
-            "Logged outgoing channel message to %s: %s",
+            "Logged outgoing channel message to %s: %s (repeaters: %s)",
             channel_name,
-            message_text[:50] + ("..." if len(message_text) > 50 else "")
+            message_text[:50] + ("..." if len(message_text) > 50 else ""),
+            logbook_event.get("repeater_count", "unknown")
         )

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
@@ -491,7 +491,45 @@ async def async_setup_entry(
                 except Exception as ex:
                     _LOGGER.error(f"Error creating reliability sensor {reliability_description.key} for client: {ex}")
     
+    # Add message delivery status sensor (tracks repeater count for channel msgs, ACK for direct msgs)
+    delivery_sensor = LastMessageDeliverySensor(coordinator)
+    entities.append(delivery_sensor)
+
     async_add_entities(entities)
+
+    # Set up listeners for outgoing message events to update the delivery sensor.
+    # - meshcore_message_sent: fires immediately when a message is sent (from services.py)
+    # - meshcore_delivery_update: fires on each intermediate collection pass (sensor only)
+    # - meshcore_message: fires once on the final pass (logbook + sensor)
+    from .logbook import EVENT_MESHCORE_MESSAGE, EVENT_MESHCORE_DELIVERY_UPDATE
+
+    @callback
+    def _handle_message_sent(event):
+        """Immediately set sensor to 'waiting' when a message is sent."""
+        data = event.data
+        if data.get("message_type"):
+            delivery_sensor.set_waiting(data)
+
+    @callback
+    def _handle_delivery_update(event):
+        """Update delivery sensor on each progressive collection pass."""
+        data = event.data
+        if data.get("outgoing") and data.get("message_type"):
+            delivery_sensor.update_from_event(data)
+
+    @callback
+    def _handle_message_event(event):
+        """Update delivery sensor on the final logbook event."""
+        data = event.data
+        if data.get("outgoing") and data.get("message_type"):
+            delivery_sensor.update_from_event(data)
+
+    unsub_sent = hass.bus.async_listen(f"{DOMAIN}_message_sent", _handle_message_sent)
+    unsub_delivery = hass.bus.async_listen(EVENT_MESHCORE_DELIVERY_UPDATE, _handle_delivery_update)
+    unsub_logbook = hass.bus.async_listen(EVENT_MESHCORE_MESSAGE, _handle_message_event)
+    entry.async_on_unload(unsub_sent)
+    entry.async_on_unload(unsub_delivery)
+    entry.async_on_unload(unsub_logbook)
 
 
 class RateLimiterSensor(CoordinatorEntity, SensorEntity):
@@ -554,9 +592,212 @@ class RateLimiterSensor(CoordinatorEntity, SensorEntity):
         self.async_write_ha_state()
 
 
+class LastMessageDeliverySensor(CoordinatorEntity, SensorEntity):
+    """Sensor showing delivery status of the last sent message.
+
+    For channel messages: shows how many repeaters relayed the message by
+    counting RX_LOG re-broadcasts (similar to MeshCore iOS app feedback).
+
+    For direct messages: shows whether the recipient acknowledged (ACK'd)
+    the message, confirming delivery.
+
+    The sensor state is a human-readable delivery summary. Detailed data
+    (per-repeater RSSI/SNR, ACK status, etc.) is available as attributes.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: MeshCoreDataUpdateCoordinator) -> None:
+        """Initialize the last message delivery sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+        raw_device_name = coordinator.name or "Unknown"
+        public_key_short = coordinator.pubkey[:6] if coordinator.pubkey else ""
+
+        self._attr_unique_id = "_".join([
+            coordinator.config_entry.entry_id,
+            "last_message_delivery",
+            public_key_short,
+            raw_device_name
+        ])
+
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR,
+            public_key_short,
+            "last_message_delivery",
+            sanitize_name(raw_device_name)
+        )
+
+        self._attr_icon = "mdi:radio-tower"
+        self._attr_name = "Last Message Delivery"
+
+        # Internal state – default to "Idle" so the entity is never "unavailable"
+        self._state: str = "Idle"
+        self._message_type: str | None = None
+        self._repeater_count: int | None = None
+        self._ack_received: bool | None = None
+        self._rx_log_data: list[dict] = []
+        self._last_message: str | None = None
+        self._current_send_id: str | None = None
+        self._last_send_time: str | None = None
+        self._receiver: str | None = None
+        self._channel: str | None = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return self.coordinator.device_info
+
+    @property
+    def translation_key(self) -> str:
+        """Return the translation key."""
+        return "last_message_delivery"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return a human-readable delivery status string."""
+        return self._state
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Return detailed delivery data as attributes."""
+        attrs: Dict[str, Any] = {}
+        if self._message_type is not None:
+            attrs["message_type"] = self._message_type
+        if self._last_message is not None:
+            attrs["last_message"] = self._last_message
+        if self._last_send_time is not None:
+            attrs["last_send_time"] = self._last_send_time
+
+        # Channel-specific attributes
+        if self._message_type == "channel":
+            attrs["repeater_count"] = self._repeater_count
+            if self._channel is not None:
+                attrs["channel"] = self._channel
+            if self._rx_log_data:
+                attrs["rx_log_data"] = self._rx_log_data
+                attrs["repeater_details"] = [
+                    {
+                        "snr": entry.get("snr"),
+                        "rssi": entry.get("rssi"),
+                        "path_len": entry.get("path_len"),
+                        "path": entry.get("path"),
+                    }
+                    for entry in self._rx_log_data
+                ]
+
+        # Direct message-specific attributes
+        if self._message_type == "direct":
+            if self._ack_received is not None:
+                attrs["ack_received"] = self._ack_received
+            if self._receiver is not None:
+                attrs["receiver"] = self._receiver
+
+        return attrs
+
+    def set_waiting(self, event_data: dict) -> None:
+        """Set sensor to 'waiting' state immediately when a message is sent."""
+        self._current_send_id = event_data.get("send_id")
+        self._message_type = event_data.get("message_type")
+        self._last_message = event_data.get("message")
+        self._last_send_time = event_data.get("timestamp")
+        self._channel = event_data.get("channel") or (
+            f"channel_{event_data.get('channel_idx', 0)}"
+            if self._message_type == "channel" else None
+        )
+        self._receiver = event_data.get("receiver")
+        self._repeater_count = None
+        self._rx_log_data = []
+        self._ack_received = None
+        self._state = "Waiting"
+        self.async_write_ha_state()
+
+    def update_from_event(self, event_data: dict) -> None:
+        """Update sensor state from a meshcore_message logbook event.
+
+        For channel messages with progressive=True, this merges new RX_LOG
+        entries with any already collected, giving rolling repeater counts.
+
+        Events from a previous send (stale send_id) are silently ignored
+        so that a rapid follow-up message isn't overwritten by late arrivals
+        from the earlier send's collection loop.
+        """
+        # Ignore updates from a previous (superseded) send
+        event_send_id = event_data.get("send_id")
+        if event_send_id and self._current_send_id and event_send_id != self._current_send_id:
+            return
+
+        self._message_type = event_data.get("message_type")
+        self._last_message = event_data.get("message")
+        self._last_send_time = event_data.get("timestamp")
+
+        if self._message_type == "channel":
+            new_rx_logs = event_data.get("rx_log_data", [])
+            is_progressive = event_data.get("progressive", False)
+
+            if is_progressive and self._rx_log_data:
+                # Merge: append only entries we haven't already seen.
+                # Each RX_LOG entry is identified by its LoRa reception
+                # characteristics — keys that actually exist in the entry schema.
+                existing_ids = set()
+                for entry in self._rx_log_data:
+                    eid = (
+                        entry.get("snr"),
+                        entry.get("rssi"),
+                        entry.get("path", ""),
+                        entry.get("channel_hash", ""),
+                        entry.get("timestamp"),
+                    )
+                    existing_ids.add(eid)
+                for entry in new_rx_logs:
+                    eid = (
+                        entry.get("snr"),
+                        entry.get("rssi"),
+                        entry.get("path", ""),
+                        entry.get("channel_hash", ""),
+                        entry.get("timestamp"),
+                    )
+                    if eid not in existing_ids:
+                        self._rx_log_data.append(entry)
+                        existing_ids.add(eid)
+            else:
+                self._rx_log_data = new_rx_logs
+
+            self._repeater_count = len(self._rx_log_data)
+            self._channel = event_data.get("channel")
+            self._ack_received = None
+            self._receiver = None
+            count = self._repeater_count or 0
+            if count == 0 and is_progressive:
+                self._state = "Waiting"
+            else:
+                self._state = f"{count} Repeater{'s' if count != 1 else ''}"
+
+        elif self._message_type == "direct":
+            self._ack_received = event_data.get("ack_received")
+            self._receiver = event_data.get("receiver_name")
+            self._repeater_count = None
+            self._rx_log_data = []
+            self._channel = None
+            if self._ack_received is True:
+                self._state = "Delivered"
+            elif self._ack_received is False:
+                self._state = "Unconfirmed"
+            else:
+                self._state = "Sent"
+
+        self.async_write_ha_state()
+
+
 class MeshCoreSensor(CoordinatorEntity, SensorEntity):
     """Representation of a MeshCore sensor."""
-    
+
     _attr_has_entity_name = True
 
     def __init__(

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -650,11 +650,6 @@ class LastMessageDeliverySensor(CoordinatorEntity, SensorEntity):
         return self.coordinator.device_info
 
     @property
-    def translation_key(self) -> str:
-        """Return the translation key."""
-        return "last_message_delivery"
-
-    @property
     def native_value(self) -> str | None:
         """Return a human-readable delivery status string."""
         return self._state

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -1,5 +1,6 @@
 """Services for the MeshCore integration."""
 import ast
+import asyncio
 import inspect
 import logging
 import re
@@ -197,45 +198,49 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         pubkey = contact.get("public_key", "Unknown")
                         _LOGGER.info("Successfully sent message to %s, pubkey: %s", display_name, pubkey)
 
-                        # Wait for ACK from the recipient to confirm delivery
-                        ack_received = False
-                        try:
-                            expected_ack = result.payload.get("expected_ack")
-                            suggested_timeout = result.payload.get("suggested_timeout", 10000)
-                            if expected_ack:
-                                ack_code = expected_ack.hex() if isinstance(expected_ack, bytes) else str(expected_ack)
-                                # Use suggested_timeout from device (ms → s) with 20% buffer
-                                ack_timeout = (suggested_timeout / 1000) * 1.2
-                                _LOGGER.debug(
-                                    "Waiting for ACK (code=%s, timeout=%.1fs) for message to %s",
-                                    ack_code[:8], ack_timeout, display_name
-                                )
-                                ack_event = await api.mesh_core.dispatcher.wait_for_event(
-                                    EventType.ACK,
-                                    attribute_filters={"code": ack_code},
-                                    timeout=ack_timeout
-                                )
-                                ack_received = ack_event is not None
-                                if ack_received:
-                                    _LOGGER.info("ACK received for message to %s", display_name)
-                                else:
-                                    _LOGGER.info("ACK timeout for message to %s", display_name)
-                        except Exception as ack_ex:
-                            _LOGGER.debug("Error waiting for ACK: %s", ack_ex)
+                        # Fire-and-forget: wait for ACK in background so the
+                        # service call returns immediately after sending.
+                        send_id = uuid.uuid4().hex[:8]
 
-                        # Create outgoing message event data
-                        outgoing_msg = {
-                            "message": message,
-                            "device": config_entry_id,
-                            "message_type": "direct",
-                            "receiver": contact.get("adv_name") or contact.get("name"),
-                            "timestamp": int(time.time()),
-                            "contact_public_key": pubkey,
-                            "ack_received": ack_received,
-                            "send_id": uuid.uuid4().hex[:8],
-                        }
-                        # Fire event for outgoing message to update message-related entities
-                        hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
+                        async def _wait_for_ack_and_notify():
+                            """Background: wait for ACK then fire delivery event."""
+                            ack_received = False
+                            try:
+                                expected_ack = result.payload.get("expected_ack")
+                                suggested_timeout = result.payload.get("suggested_timeout", 10000)
+                                if expected_ack:
+                                    ack_code = expected_ack.hex() if isinstance(expected_ack, bytes) else str(expected_ack)
+                                    ack_timeout = (suggested_timeout / 1000) * 1.2
+                                    _LOGGER.debug(
+                                        "Waiting for ACK (code=%s, timeout=%.1fs) for message to %s",
+                                        ack_code[:8], ack_timeout, display_name
+                                    )
+                                    ack_event = await api.mesh_core.dispatcher.wait_for_event(
+                                        EventType.ACK,
+                                        attribute_filters={"code": ack_code},
+                                        timeout=ack_timeout
+                                    )
+                                    ack_received = ack_event is not None
+                                    if ack_received:
+                                        _LOGGER.info("ACK received for message to %s", display_name)
+                                    else:
+                                        _LOGGER.info("ACK timeout for message to %s", display_name)
+                            except Exception as ack_ex:
+                                _LOGGER.debug("Error waiting for ACK: %s", ack_ex)
+
+                            outgoing_msg = {
+                                "message": message,
+                                "device": config_entry_id,
+                                "message_type": "direct",
+                                "receiver": contact.get("adv_name") or contact.get("name"),
+                                "timestamp": int(time.time()),
+                                "contact_public_key": pubkey,
+                                "ack_received": ack_received,
+                                "send_id": send_id,
+                            }
+                            hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
+
+                        asyncio.create_task(_wait_for_ack_and_notify())
                 except Exception as ex:
                     _LOGGER.error(
                         "Error sending message to %s: %s", target_identifier, ex

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -5,6 +5,7 @@ import logging
 import re
 import shlex
 import time
+import uuid
 import voluptuous as vol
 from typing import Any, Dict, Optional, cast
 
@@ -185,7 +186,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     
                     # Send the message using the new API
                     result = await api.mesh_core.commands.send_msg(contact, message)
-                    
+
                     if result.type == EventType.ERROR:
                         _LOGGER.warning(
                             "Failed to send message to %s: %s", target_identifier, result.payload
@@ -195,7 +196,33 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         display_name = contact_name if contact_name else target_identifier
                         pubkey = contact.get("public_key", "Unknown")
                         _LOGGER.info("Successfully sent message to %s, pubkey: %s", display_name, pubkey)
-                        
+
+                        # Wait for ACK from the recipient to confirm delivery
+                        ack_received = False
+                        try:
+                            expected_ack = result.payload.get("expected_ack")
+                            suggested_timeout = result.payload.get("suggested_timeout", 10000)
+                            if expected_ack:
+                                ack_code = expected_ack.hex() if isinstance(expected_ack, bytes) else str(expected_ack)
+                                # Use suggested_timeout from device (ms → s) with 20% buffer
+                                ack_timeout = (suggested_timeout / 1000) * 1.2
+                                _LOGGER.debug(
+                                    "Waiting for ACK (code=%s, timeout=%.1fs) for message to %s",
+                                    ack_code[:8], ack_timeout, display_name
+                                )
+                                ack_event = await api.mesh_core.dispatcher.wait_for_event(
+                                    EventType.ACK,
+                                    attribute_filters={"code": ack_code},
+                                    timeout=ack_timeout
+                                )
+                                ack_received = ack_event is not None
+                                if ack_received:
+                                    _LOGGER.info("ACK received for message to %s", display_name)
+                                else:
+                                    _LOGGER.info("ACK timeout for message to %s", display_name)
+                        except Exception as ack_ex:
+                            _LOGGER.debug("Error waiting for ACK: %s", ack_ex)
+
                         # Create outgoing message event data
                         outgoing_msg = {
                             "message": message,
@@ -203,7 +230,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                             "message_type": "direct",
                             "receiver": contact.get("adv_name") or contact.get("name"),
                             "timestamp": int(time.time()),
-                            "contact_public_key": pubkey
+                            "contact_public_key": pubkey,
+                            "ack_received": ack_received,
+                            "send_id": uuid.uuid4().hex[:8],
                         }
                         # Fire event for outgoing message to update message-related entities
                         hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
@@ -240,9 +269,13 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         "Sending message to channel %s: %s", channel_idx, message
                     )
                     
+                    # Capture a fallback timestamp before sending.
+                    # The actual device timestamp may differ from the HA server clock.
+                    fallback_timestamp = int(time.time())
+
                     # Send the channel message using the new API
-                    result = await api.mesh_core.commands.send_chan_msg(channel_idx, message)
-                    
+                    result = await api.mesh_core.commands.send_chan_msg(channel_idx, message, timestamp=fallback_timestamp)
+
                     if result.type == EventType.ERROR:
                         _LOGGER.warning(
                             "Failed to send message to channel %s: %s", channel_idx, result.payload
@@ -251,7 +284,21 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         _LOGGER.info(
                             "Successfully sent message to channel %s", channel_idx
                         )
-                        
+
+                        # Use the actual timestamp from the device response if available,
+                        # otherwise fall back to the server-side timestamp we passed in.
+                        # This avoids clock drift between HA and the device breaking correlation.
+                        send_timestamp = fallback_timestamp
+                        if hasattr(result, 'payload') and isinstance(result.payload, dict):
+                            device_ts = result.payload.get("timestamp")
+                            if device_ts and isinstance(device_ts, (int, float)):
+                                send_timestamp = int(device_ts)
+                                if send_timestamp != fallback_timestamp:
+                                    _LOGGER.debug(
+                                        "Using device timestamp %s instead of server timestamp %s",
+                                        send_timestamp, fallback_timestamp
+                                    )
+
                         # Create outgoing message event data
                         outgoing_msg = {
                             "message": message,
@@ -259,7 +306,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                             "message_type": "channel",
                             "receiver": f"channel_{channel_idx}",
                             "timestamp": int(time.time()),
-                            "channel_idx": channel_idx
+                            "channel_idx": channel_idx,
+                            "send_timestamp": send_timestamp,
+                            "send_id": uuid.uuid4().hex[:8],
                         }
                         # Fire event for outgoing message to update message-related entities
                         hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -353,18 +353,21 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
     return result
 
 
-def create_message_correlation_key(channel_idx: int, timestamp: int, text: str) -> str:
+def create_message_correlation_key(channel_idx: int, timestamp: int) -> str:
     """Create a correlation hash key for matching RX_LOG to channel messages.
+
+    Uses only channel index and timestamp for correlation. Text is excluded
+    because the HA config name may differ from the on-device advertised name,
+    making text-based matching unreliable.
 
     Args:
         channel_idx: Channel index
         timestamp: Sender's timestamp (unix time)
-        text: Message text content
 
     Returns:
         16-character hex string hash
     """
-    correlation_key = f"{channel_idx}:{timestamp}:{text}"
+    correlation_key = f"{channel_idx}:{timestamp}"
     hash_key = hashlib.sha256(correlation_key.encode()).hexdigest()[:16]
     return hash_key
 

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -360,6 +360,11 @@ def create_message_correlation_key(channel_idx: int, timestamp: int) -> str:
     because the HA config name may differ from the on-device advertised name,
     making text-based matching unreliable.
 
+    Note: Because the timestamp has 1-second granularity, two messages sent on
+    the same channel within the same second will produce the same correlation
+    key. In practice this is unlikely given mesh radio TX times, but it is a
+    known limitation.
+
     Args:
         channel_idx: Channel index
         timestamp: Sender's timestamp (unix time)


### PR DESCRIPTION
First let me apologize spaming the PR's with the previous four, got a little ahead of myself. They have been closed and can be deleted, if possible. I will be submitting two and will submit the remaining two after these have been discussed or approved. 

## Summary

Adds a `LastMessageDeliverySensor` that provides real-time delivery feedback for sent messages. For channel messages, it counts how many repeaters relayed the message by correlating RX_LOG re-broadcasts — similar to the feedback shown in the MeshCore iOS app. For direct messages, it waits for an ACK from the recipient to confirm delivery.

## Motivation

After sending a channel message, there's currently no way to know within Home Assistant whether the message was actually relayed across the mesh. The MeshCore companion app displays this feedback when sending a channel or direct message. This change mimics the App feedback. Also, letsmesh.net analyzer can show repeater counts, but that requires an external tool. This feature brings that feedback directly into HA as a sensor entity that updates progressively as repeater re-broadcasts arrive.

For direct messages, the existing integration fires-and-forgets with no delivery confirmation. This PR adds ACK waiting so the sensor can report whether the recipient actually received the message.

## How it works

### Channel message delivery tracking

1. **Timestamp-based correlation key** — When a channel message is sent, `services.py` captures the send timestamp and passes it to `send_chan_msg()`. A SHA256 correlation key is created from `channel_idx:timestamp` (text is intentionally excluded because the HA config name may differ from the on-device advertised name prepended to broadcasts).

2. **Outgoing key reservation** — The outgoing handler registers its correlation key in `coordinator._outgoing_correlation_keys` so the incoming channel message handler (which fires 500ms earlier) doesn't consume the RX_LOG entries first.

3. **4-pass rolling collection** — `handle_outgoing_message()` in `logbook.py` performs 4 collection passes at 1-second intervals, popping matched RX_LOG entries from the coordinator's pending cache on each pass. After each pass, a lightweight `meshcore_delivery_update` event is fired so the sensor updates progressively.

4. **Final logbook event** — On the last pass, the standard `meshcore_message` event fires (which creates the logbook entry), including the total repeater count and all collected RX_LOG data.

### Direct message ACK tracking

When sending a direct message, `services.py` now waits for an ACK event matching the `expected_ack` code from the send response, using the device's `suggested_timeout` with a 20% buffer. The ACK result is included in the outgoing message event data.

### Correlation key change (text removed)

The `create_message_correlation_key()` function in `utils.py` was simplified from `SHA256(channel_idx:timestamp:text)` to `SHA256(channel_idx:timestamp)`. This also required updating `__init__.py` where RX_LOG entries are stored — the text requirement was removed from the `if` guard and the function call.

## New entities

- `sensor.meshcore_<device>_last_message_delivery` — Human-readable delivery status with attributes:
  - `message_type` — "channel" or "direct"
  - `repeater_count` — Number of repeaters that relayed (channel only)
  - `repeater_details` — Per-repeater SNR/RSSI/path data (channel only)
  - `rx_log_data` — Raw RX_LOG entries (channel only)
  - `ack_received` — Boolean ACK status (direct only)
  - `receiver` — Recipient name (direct only)
  - `channel` — Channel name (channel only)
  - `last_message` — Message text preview
  - `last_send_time` — Timestamp of last send

### Sensor states

| Message type | Condition | State |
|---|---|---|
| Channel | Waiting for RX_LOGs | "Waiting" |
| Channel | N repeaters found | "N Repeater(s)" |
| Channel | No repeaters | "0 Repeaters" |
| Direct | ACK received | "Delivered" |
| Direct | ACK timeout | "Unconfirmed" |
| Direct | No ACK support | "Sent" |
| — | No message sent yet | "Idle" |

## New events

- `meshcore_delivery_update` — Lightweight event fired on each intermediate collection pass. Only the delivery sensor listens to this; it is not logged in the logbook.

## Test plan

- [x] Send a channel message and verify the delivery sensor updates progressively over ~4 seconds
- [x] Verify final repeater count matches RX_LOG events observed on the mesh
- [x] Send a direct message and verify ACK delivery feedback appears
- [x] Verify ACK timeout shows "Unconfirmed" when recipient is offline
- [x] Send a second message quickly and verify stale `send_id` events from the first send are ignored
- [x] Verify the incoming channel message handler skips RX_LOG pop for outgoing-reserved keys
- [x] Verify sensor resets to "Waiting" immediately on new send before any RX_LOGs arrive