### PR TITLE
Add public key change detection, entity migration, and companion prefix sensor

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -18,6 +18,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.components.http import StaticPathConfig
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import issue_registry as ir
 
 
 from .const import (
@@ -28,6 +30,7 @@ from .const import (
     CONF_TCP_HOST,
     CONF_TCP_PORT,
     CONF_BAUDRATE,
+    CONF_PUBKEY,
     CONF_REPEATER_SUBSCRIPTIONS,
     CONF_LIMIT_DISCOVERED_CONTACTS,
     CONF_MAX_DISCOVERED_CONTACTS,
@@ -100,6 +103,62 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     _LOGGER.debug("Migration to configuration version %s successful", config_entry.version)
     return True
 
+def _migrate_entity_ids(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    old_prefix: str,
+    new_prefix: str,
+) -> None:
+    """Rename entity IDs and unique_ids that contain the old pubkey prefix.
+
+    Called when the device's public key changes (e.g. after private key import).
+    Updates both entity_id and unique_id in the entity registry so that
+    entities created with the new prefix match existing registry entries,
+    preventing orphaned duplicates.
+    """
+    entity_registry = er.async_get(hass)
+    migrated = 0
+    old_pattern = f"_{old_prefix}_"
+    new_pattern = f"_{new_prefix}_"
+
+    for entity in list(entity_registry.entities.values()):
+        # Only migrate entities belonging to this config entry
+        if entity.config_entry_id != entry.entry_id:
+            continue
+
+        needs_update = False
+        new_entity_id = entity.entity_id
+        new_unique_id = entity.unique_id
+
+        # Migrate entity_id if it contains the old pubkey prefix
+        if old_pattern in entity.entity_id:
+            new_entity_id = entity.entity_id.replace(old_pattern, new_pattern, 1)
+            needs_update = True
+
+        # Migrate unique_id if it contains the old pubkey prefix
+        if old_prefix in entity.unique_id:
+            new_unique_id = entity.unique_id.replace(old_prefix, new_prefix)
+            needs_update = True
+
+        if not needs_update:
+            continue
+
+        try:
+            entity_registry.async_update_entity(
+                entity.entity_id,
+                new_entity_id=new_entity_id,
+                new_unique_id=new_unique_id,
+            )
+            _LOGGER.info("Migrated entity: %s -> %s", entity.entity_id, new_entity_id)
+            migrated += 1
+        except Exception as ex:
+            _LOGGER.error("Failed to migrate entity %s: %s", entity.entity_id, ex)
+
+    _LOGGER.info(
+        "Migrated %d entities from prefix %s to %s", migrated, old_prefix, new_prefix
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeshCore from a config entry."""
     # Home Assistant can trigger a duplicate setup during rapid reload/update cycles.
@@ -159,6 +218,49 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Continue setup even if connection failed - coordinator will retry
     if not connected:
         _LOGGER.warning("Starting integration with no initial connection - coordinator will retry")
+
+    # --- Public key change detection and entity migration ---
+    # After connecting, the API caches SELF_INFO (including public_key) via send_appstart().
+    # Compare the live key to what's stored in config_entry to detect key changes.
+    live_pubkey = api._last_self_info.get("public_key", "") if connected else ""
+    stored_pubkey = entry.data.get(CONF_PUBKEY, "")
+
+    if live_pubkey and stored_pubkey and live_pubkey != stored_pubkey:
+        _LOGGER.warning(
+            "Public key changed! Old: %s... New: %s... Migrating entities.",
+            stored_pubkey[:12], live_pubkey[:12],
+        )
+
+        # Migrate entity IDs and unique_ids before platforms are set up
+        old_prefix = stored_pubkey[:6]
+        new_prefix = live_pubkey[:6]
+        _migrate_entity_ids(hass, entry, old_prefix, new_prefix)
+
+        # Update config entry with new pubkey so coordinator picks it up
+        new_data = dict(entry.data)
+        new_data[CONF_PUBKEY] = live_pubkey
+        hass.config_entries.async_update_entry(entry, data=new_data)
+
+        # Create persistent repair issue to warn about automation/dashboard references
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"pubkey_changed_{entry.entry_id}",
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="pubkey_changed",
+            translation_placeholders={
+                "old_key": stored_pubkey[:12],
+                "new_key": live_pubkey[:12],
+            },
+        )
+    elif live_pubkey and not stored_pubkey:
+        # First time getting pubkey (shouldn't normally happen, but handle gracefully)
+        new_data = dict(entry.data)
+        new_data[CONF_PUBKEY] = live_pubkey
+        hass.config_entries.async_update_entry(entry, data=new_data)
+        _LOGGER.info("Stored initial public key: %s...", live_pubkey[:12])
 
     # TODO: remove this with contact refresh interval migration?
     # Get the messages interval for base update frequency

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -118,6 +118,9 @@ CONF_MESSAGES_INTERVAL: Final = "messages_interval"
 
 DEFAULT_UPDATE_TICK: Final = 5  # base polling interval
 
+# Repair issue IDs
+REPAIR_PUBKEY_CHANGED: Final = "pubkey_changed"
+
 # Other constants
 CONNECTION_TIMEOUT: Final = 10  # seconds
 

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -379,7 +379,10 @@ async def async_setup_entry(
 
     # Add rate limiter monitoring sensor
     entities.append(RateLimiterSensor(coordinator))
-    
+
+    # Add companion prefix sensor (first byte of public key, used in routing paths)
+    entities.append(MeshCoreCompanionPrefixSensor(coordinator))
+
     # Store the async_add_entities function for later use
     coordinator.sensor_add_entities = async_add_entities
     
@@ -703,6 +706,98 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         return self._native_value
+
+class MeshCoreCompanionPrefixSensor(CoordinatorEntity, SensorEntity):
+    """Sensor displaying the device's companion prefix from its public key.
+
+    In MeshCore, the first N bytes of a node's public key are used as its
+    routing prefix — the short identifier shown in message paths to indicate
+    which repeaters a packet traversed.
+
+    The prefix length is determined by the device's path_hash_mode setting
+    (available in firmware v1.14.0+ / protocol v10+):
+      - mode 0: 1 byte  (2 hex chars)  — default
+      - mode 1: 2 bytes (4 hex chars)
+      - mode 2: 3 bytes (6 hex chars)
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: MeshCoreDataUpdateCoordinator) -> None:
+        """Initialize the companion prefix sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        public_key_short = coordinator.pubkey[:6] if coordinator.pubkey else ""
+
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_companion_prefix_{public_key_short}"
+        )
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR, public_key_short, "companion_prefix"
+        )
+        self._attr_name = "Companion Prefix"
+        self._attr_icon = "mdi:routes"
+        self._full_key = coordinator.pubkey or ""
+        # path_hash_mode: 0 = 1 byte, 1 = 2 bytes, 2 = 3 bytes
+        # Default to 0 (1 byte) for firmware versions that don't report it
+        self._path_hash_mode = 0
+
+        # Try to read initial path_hash_mode from cached SELF_INFO
+        if coordinator.api._last_self_info:
+            self._path_hash_mode = coordinator.api._last_self_info.get(
+                "path_hash_mode", 0
+            )
+
+        # Subscribe to SELF_INFO for live updates
+        if coordinator.api.mesh_core:
+            meshcore = coordinator.api.mesh_core
+
+            def update_from_self_info(event: Event):
+                changed = False
+                new_key = event.payload.get("public_key")
+                if new_key and new_key != self._full_key:
+                    self._full_key = new_key
+                    changed = True
+                new_mode = event.payload.get("path_hash_mode")
+                if new_mode is not None and new_mode != self._path_hash_mode:
+                    self._path_hash_mode = new_mode
+                    changed = True
+                if changed:
+                    self.async_write_ha_state()
+
+            meshcore.dispatcher.subscribe(
+                EventType.SELF_INFO, update_from_self_info
+            )
+
+    @property
+    def _prefix_byte_len(self) -> int:
+        """Return the prefix length in bytes based on path_hash_mode."""
+        return self._path_hash_mode + 1
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return DeviceInfo(**self.coordinator.device_info)
+
+    @property
+    def native_value(self) -> str:
+        """Return the companion prefix (N bytes of public key as hex chars)."""
+        hex_chars = self._prefix_byte_len * 2
+        if self._full_key and len(self._full_key) >= hex_chars:
+            return self._full_key[:hex_chars].upper()
+        return "Unknown"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the full public key and path hash mode as attributes."""
+        mode_labels = {0: "1 byte", 1: "2 bytes", 2: "3 bytes"}
+        return {
+            "public_key": self._full_key,
+            "path_hash_mode": self._path_hash_mode,
+            "prefix_length": mode_labels.get(self._path_hash_mode, "unknown"),
+        }
+
 
 class MeshCoreReliabilitySensor(CoordinatorEntity, SensorEntity):
     """Sensor for tracking request successes/failures for nodes."""

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -8,7 +8,7 @@ import time
 import voluptuous as vol
 from typing import Any, Dict, Optional, cast
 
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.const import MAJOR_VERSION
@@ -639,21 +639,25 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                                 coordinator.async_set_updated_data(updated_data)
 
                     # Convert any binary data to hex strings for logging and events
+                    json_safe_payload = {}
                     if hasattr(result, 'payload') and isinstance(result.payload, dict):
                         # Create a JSON-serializable version of the payload
-                        json_safe_payload = {}
                         for key, value in result.payload.items():
                             if isinstance(value, bytes):
                                 json_safe_payload[key] = value.hex()
                             else:
                                 json_safe_payload[key] = value
-                        
+
                         # Log only the JSON-safe version
-                        _LOGGER.info("Command result: %s with payload: %s", 
+                        _LOGGER.info("Command result: %s with payload: %s",
                                     result.type, json_safe_payload)
                     else:
                         _LOGGER.info("Command result: %s", result)
-                    
+
+                    # Return response data for commands that support it
+                    # (e.g., export_private_key when called with return_response=True)
+                    if json_safe_payload:
+                        return json_safe_payload
                     return
                     
                 except Exception as ex:
@@ -723,6 +727,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_EXECUTE_COMMAND,
         async_execute_command_service,
         schema=EXECUTE_COMMAND_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
     )
     
     hass.services.async_register(

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -82,6 +82,7 @@ execute_command:
     Execute a command provided by the MeshCore Python library. This is an advanced feature
     that provides direct access to the underlying commands interface.
     CAUTION: Some commands will make PERMANENT CHANGES to your node's configuration. Use with care.
+  response: optional
   fields:
     command:
       name: Command

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -369,6 +369,12 @@
       }
     }
   },
+  "issues": {
+    "pubkey_changed": {
+      "title": "MeshCore public key changed",
+      "description": "The MeshCore device's public key has changed from `{old_key}...` to `{new_key}...`. All entity IDs have been automatically migrated to use the new key prefix.\n\nIf you have automations, scripts, or dashboards referencing the old entity IDs (containing `{old_key}`), you will need to update them manually to use the new prefix (`{new_key}`).\n\nThis issue can be dismissed once you have verified your configuration."
+    }
+  },
   "entity": {
     "sensor": {
       "node_status": {


### PR DESCRIPTION
## Summary

Detects when the companion device's public key changes (e.g., after firmware reflash or private key import) and automatically migrates all entity IDs and unique IDs to the new key prefix, preventing orphaned entities. Also adds a companion prefix sensor that displays the device's routing prefix, and enables `return_response` on the `execute_command` service.

## Motivation

MeshCore entity IDs include the first 6 characters of the device's public key (e.g., `sensor.meshcore_1ed4c1_battery`). When a companion device is defaulted or its private key is imported/exported, the public key changes, causing all existing entities to become orphaned while duplicate entities are created with the new prefix. This requires manual cleanup in the entity registry and breaks any automations or dashboards referencing the old entity IDs.

This PR detects the key change on startup and migrates entities automatically, then creates a persistent HA repair issue alerting the user to update any manual references.

## How it works

### Public key change detection (`__init__.py`)

During `async_setup_entry()`, after the API connects and caches `SELF_INFO`:

1. The live public key from `api._last_self_info["public_key"]` is compared against the stored `CONF_PUBKEY` in config entry data
2. If they differ, `_migrate_entity_ids()` is called before platforms are set up
3. The config entry is updated with the new public key
4. A persistent repair issue is created via `issue_registry`

### Entity migration (`_migrate_entity_ids()`)

Iterates all entity registry entries for the config entry and for each entity:
- If `entity_id` contains the old prefix pattern (`_OLDPK_`), it's renamed to use the new prefix
- If `unique_id` contains the old prefix string, it's updated similarly
- Uses `entity_registry.async_update_entity()` for atomic updates
- Logs each migration and a final count

### Companion prefix sensor (`sensor.py`)

`MeshCoreCompanionPrefixSensor` displays the device's routing prefix — the short identifier that appears in message hop paths to identify which node relayed a packet.

The prefix length is determined by the device's `path_hash_mode` setting (firmware v1.14.0+ / protocol v10+):
- Mode 0: 1 byte (2 hex chars) — default
- Mode 1: 2 bytes (4 hex chars)
- Mode 2: 3 bytes (6 hex chars)

The sensor subscribes to `SELF_INFO` events for live updates if the key or mode changes at runtime.

**Attributes:**
- `public_key` — Full public key hex string
- `path_hash_mode` — Current mode (0, 1, or 2)
- `prefix_length` — Human-readable ("1 byte", "2 bytes", "3 bytes")

### `execute_command` return response (`services.py`, `services.yaml`)

The `execute_command` service now supports `return_response: true`, allowing automations and scripts to capture the JSON payload from commands like `export_private_key`. Previously the response was logged but not accessible to the caller. The `services.yaml` declaration adds `response: optional` to enable this.

## New entities

- `sensor.meshcore_<device>_companion_prefix` — Displays routing prefix (e.g., "1E" for mode 0, "1ED4" for mode 1)

## New repair issues

- `pubkey_changed` — Persistent warning created when a key change is detected, listing the old and new prefixes and advising the user to update manual references. Dismissible once verified.

## Test plan

- [x] Simulate a pubkey change by modifying the stored `CONF_PUBKEY` in config entry data and restarting — verify entities migrate and repair issue is created
- [x] Verify companion prefix sensor shows correct value for the current `path_hash_mode`
- [x] Verify prefix sensor updates live when `SELF_INFO` reports a new mode
- [x] Test `execute_command` with `return_response: true` — verify the JSON payload is returned
- [x] Verify normal startup path (no key change) has no impact on existing entities
- [x] Verify first-time setup (no stored pubkey) stores the key without creating a repair issue