### PR TITLE
Fix coordinator.data set to None after every update cycle

### DIFF
--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -678,7 +678,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             await asyncio.sleep(1)  # Small delay to avoid tight loops
 
                 
-    async def _async_update_data(self) -> None:
+    async def _async_update_data(self) -> Dict[str, Any]:
         """Trigger commands that will generate events on schedule.
         
         In the event-driven architecture, this method:
@@ -952,3 +952,5 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                     telemetry_task.set_name(f"client_telemetry_{client_name}")
                 else:
                     _LOGGER.warning(f"Could not find contact for client telemetry request: {pubkey_prefix}")
+
+        return result_data

--- a/custom_components/meshcore/device_tracker.py
+++ b/custom_components/meshcore/device_tracker.py
@@ -130,7 +130,7 @@ class DeviceTrackerManager:
             }
             
         # Default to unknown contact
-        contacts = self.coordinator.data.get("contacts", [])
+        contacts = (self.coordinator.data or {}).get("contacts", [])
         for contact in contacts:
             contact_pubkey = contact.get("public_key", {}).get("hex", "")
             if contact_pubkey.startswith(pubkey_prefix):

--- a/custom_components/meshcore/telemetry_sensor.py
+++ b/custom_components/meshcore/telemetry_sensor.py
@@ -274,7 +274,7 @@ class TelemetrySensorManager:
             }
 
         # Default to unknown contact
-        contacts = self.coordinator.data.get("contacts", [])
+        contacts = (self.coordinator.data or {}).get("contacts", [])
         for contact in contacts:
             contact_pubkey = contact.get("public_key", {}).get("hex", "")
             if contact_pubkey.startswith(pubkey_prefix):


### PR DESCRIPTION
## Summary

`_async_update_data` in `coordinator.py` builds a `result_data` dict and populates it with contacts, but never returns it. HA's `DataUpdateCoordinator` assigns the return value of `_async_update_data` to `self.data` (line 283 of `homeassistant/helpers/update_coordinator.py`), so `self.data` becomes `None` after every update cycle.

This creates a race condition where concurrent async tasks (repeater updates, telemetry updates) and entity property accessors can encounter `'NoneType' object has no attribute 'get'` when accessing `self.data` or `self.coordinator.data` during the window between `_async_update_data` returning and the next `async_set_updated_data` call.

## Changes

- **coordinator.py**: Add `return result_data` at the end of `_async_update_data` and fix the return type annotation from `-> None` to `-> Dict[str, Any]`
- **device_tracker.py**: Add defensive `None` guard on `self.coordinator.data.get()` call (`(self.coordinator.data or {}).get(...)`)
- **telemetry_sensor.py**: Same defensive `None` guard

## How it was found

The bug surfaced as an exception in a concurrent repeater update task that accessed `self.data.get("contacts", [])` while `self.data` was `None`:

```
Exception fetching neighbors for ca.cv.main-st: 'NoneType' object has no attribute 'get'
Source: custom_components/meshcore/coordinator.py:575
```

## Test plan

- [x] Verified `_async_update_data` has no return statement in current upstream code
- [x] Verified HA's `DataUpdateCoordinator._async_refresh` assigns `self.data = await self._async_update_data()` at line 283
- [x] Confirmed `device_tracker.py:133` and `telemetry_sensor.py:277` have unguarded `.data.get()` calls
- [x] Deploy and verify no more `'NoneType' object has no attribute 'get'` errors in HA logs
- [x] Verify repeater status updates, device tracker, and telemetry sensors function normally after fix