### PR TITLE
Raise ConfigEntryNotReady when device connection fails

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -17,6 +17,7 @@ from .const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components.http import StaticPathConfig
 
 
@@ -156,9 +157,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         else:
             _LOGGER.error(f"Failed to connect after {max_retries} attempts")
 
-    # Continue setup even if connection failed - coordinator will retry
     if not connected:
-        _LOGGER.warning("Starting integration with no initial connection - coordinator will retry")
+        raise ConfigEntryNotReady(
+            f"Failed to connect to MeshCore device at "
+            f"{entry.data.get(CONF_TCP_HOST, 'unknown')}:{entry.data.get(CONF_TCP_PORT, 5000)} "
+            f"after {max_retries} attempts"
+        )
 
     # TODO: remove this with contact refresh interval migration?
     # Get the messages interval for base update frequency


### PR DESCRIPTION
### Summary

When the MeshCore device is temporarily unreachable during HA restart or integration reload, `async_setup_entry()` fails all 3 connection attempts but then continues setup anyway. Because `MeshCoreAPI._mesh_core` is never initialized without a successful connection, every platform that touches `mesh_core` immediately crashes:

```
ERROR [custom_components.meshcore] Failed to connect after 3 attempts
ERROR [custom_components.meshcore.meshcore_api] MeshCore instance is not initialized
ERROR [homeassistant.components.sensor] Error while setting up meshcore platform for sensor: MeshCore instance is not initialized
ERROR [homeassistant.components.binary_sensor] Error while setting up meshcore platform for binary_sensor: MeshCore instance is not initialized
ERROR [homeassistant.components.device_tracker] Error while setting up meshcore platform for device_tracker: MeshCore instance is not initialized
```

The integration then enters a 5-second retry loop that runs indefinitely, flooding the log (HA warns "logging too frequently: 200 messages"). The integration card shows no clear error — entities just sit in "unavailable" with no indication that setup is being retried.

Fix: raise `ConfigEntryNotReady` when all connection attempts fail. This is the standard HA pattern for integrations that depend on a network device.

### Before

- Integration continues setup with no connection → all platforms crash with `MeshCore instance is not initialized`
- All entities created in unavailable state, no user-visible error on integration card
- Aggressive 5-second retry loop floods the log indefinitely

### After

- Integration card shows "Retrying setup" with HA's built-in exponential backoff (30s → 5min)
- No entities or platforms created until device is reachable
- Once device comes online, HA automatically completes setup on next retry — all entities come up cleanly

### Changes

- `__init__.py`:
  - Added `from homeassistant.exceptions import ConfigEntryNotReady`
  - Replaced "Continue setup even if connection failed" warning block with `raise ConfigEntryNotReady(...)`