### PR TITLE
Subscribe to MESSAGES_WAITING for instant message delivery

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -492,6 +492,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             handle_new_contact
         )
 
+        # Subscribe to MESSAGES_WAITING for instant message delivery.
+        # The companion firmware sends this push notification when messages
+        # are queued on the device.  Without this, messages sit in the device
+        # queue until the coordinator's periodic poll calls get_msg().
+        async def handle_messages_waiting(event):
+            """Immediately fetch messages when device signals they are available."""
+            _LOGGER.debug("MESSAGES_WAITING received, triggering immediate message fetch")
+            asyncio.create_task(coordinator.async_flush_messages())
+
+        coordinator.api.mesh_core.subscribe(
+            EventType.MESSAGES_WAITING,
+            handle_messages_waiting
+        )
+        _LOGGER.info("MESSAGES_WAITING auto-fetch subscriber registered")
+
     # Fetch initial data immediately
     # await coordinator._async_update_data()
     

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -152,6 +152,10 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # Track coordinator start time for auto-disable logic
         self._coordinator_start_time = time.time()
 
+        # Lock to serialize get_msg() calls between MESSAGES_WAITING
+        # auto-fetch and the coordinator's periodic poll
+        self._message_lock = asyncio.Lock()
+
         # RX_LOG correlation cache: auto-evicts after TTL expires
         # Key: correlation hash, Value: list of RX_LOG data (multiple receptions possible)
         self._pending_rx_logs = TTLCache(
@@ -677,7 +681,31 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 self._active_telemetry_tasks.pop(pubkey_prefix)
             await asyncio.sleep(1)  # Small delay to avoid tight loops
 
-                
+    async def async_flush_messages(self) -> Dict[str, Any]:
+        """Immediately flush pending messages from the device queue.
+
+        Called by the MESSAGES_WAITING event handler for instant message
+        delivery.  Uses _message_lock to prevent overlap with the
+        coordinator poll's own get_msg() loop.
+        """
+        async with self._message_lock:
+            try:
+                while True:
+                    result = await self.api.mesh_core.commands.get_msg()
+                    if result.type == EventType.NO_MORE_MSGS:
+                        break
+                    elif result.type == EventType.ERROR:
+                        _LOGGER.error(
+                            "Error flushing messages: %s", result.payload
+                        )
+                        break
+                    else:
+                        _LOGGER.debug(
+                            "Auto-fetched message: %s", result.type
+                        )
+            except Exception as ex:
+                _LOGGER.error("Error in async_flush_messages: %s", ex)
+
     async def _async_update_data(self) -> Dict[str, Any]:
         """Trigger commands that will generate events on schedule.
         
@@ -797,22 +825,23 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 self.logger.debug(f"Skipping self telemetry (next in {self._self_telemetry_interval - (current_time - self._last_self_telemetry_update):.1f}s)")
             
-        # Check for messages
-        _LOGGER.info("Clearing message queue...")
-        try:
-            res = True
-            while res:
-                result = await self.api.mesh_core.commands.get_msg()
-                if result.type == EventType.NO_MORE_MSGS:
-                    res = False
-                    _LOGGER.debug("No more messages in queue")
-                elif result.type == EventType.ERROR:
-                    res = False
-                    _LOGGER.error(f"Error retrieving messages: {result.payload}")
-                else:
-                    _LOGGER.debug(f"Cleared message: {result}")
-        except Exception as ex:
-            _LOGGER.error(f"Error clearing message queue: {ex}")
+        # Check for messages (lock prevents overlap with MESSAGES_WAITING auto-fetch)
+        async with self._message_lock:
+            _LOGGER.info("Clearing message queue...")
+            try:
+                res = True
+                while res:
+                    result = await self.api.mesh_core.commands.get_msg()
+                    if result.type == EventType.NO_MORE_MSGS:
+                        res = False
+                        _LOGGER.debug("No more messages in queue")
+                    elif result.type == EventType.ERROR:
+                        res = False
+                        _LOGGER.error(f"Error retrieving messages: {result.payload}")
+                    else:
+                        _LOGGER.debug(f"Cleared message: {result}")
+            except Exception as ex:
+                _LOGGER.error(f"Error clearing message queue: {ex}")
         
         for repeater_config in self._tracked_repeaters:
             if not repeater_config.get('name') or not repeater_config.get('pubkey_prefix'):


### PR DESCRIPTION
## Summary

- Subscribes to the firmware's `MESSAGES_WAITING` push notification (`0x83`) so incoming messages are fetched immediately instead of waiting for the coordinator's periodic poll
- Adds `async_flush_messages()` to the coordinator with an `asyncio.Lock` to prevent overlap between auto-fetch and the periodic poll's own `get_msg()` loop
- Wraps the existing periodic `get_msg()` block in the same lock for safe serialization

## Problem

When the companion firmware queues incoming messages, it sends a `MESSAGES_WAITING` push notification. The integration never subscribed to this event, so messages sat in the device queue until the coordinator's periodic poll called `get_msg()` — introducing a delay of up to the full poll interval (~3 seconds).

## Changes

| File | Change |
|------|--------|
| `__init__.py` | Register `MESSAGES_WAITING` event subscriber in `async_setup_entry` that calls `coordinator.async_flush_messages()` |
| `coordinator.py` | Add `_message_lock` (asyncio.Lock), new `async_flush_messages()` method, wrap existing periodic message poll in same lock |

## Test plan

- Verified message delivery latency drops from ~3s to near-instant on a live HA host with MeshCore companion device
- Confirmed periodic poll still works correctly alongside auto-fetch
- No regressions in existing message handling