### PR TITLE
Fix set_flood_scope parameter type from int to str

### DIFF
--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -510,7 +510,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         "send_binary_req": ["contact", "int"],  # contact, BinaryReqType (int enum)
                         "send_path_discovery": ["contact"],
                         "send_trace": ["int", "int", "int", "bytes"],  # auth_code, tag, flags, path
-                        "set_flood_scope": ["int"],
+                        "set_flood_scope": ["str"],
 
                         # Binary commands
                         "req_telemetry": ["contact", "int"],  # contact, timeout


### PR DESCRIPTION
## Summary

One-line fix: changes `set_flood_scope` parameter type from `["int"]` to `["str"]` in the execute_command mapping.

## Problem

`set_flood_scope` takes a string scope name (e.g., `"FOO"`), but the command mapping declared it as `int`, causing "could not convert to integer" errors. This was a regression introduced in 4ecdc49.

Fixes #180, also addresses the `set_flood_scope` portion of #175.