### PR TITLE
Replace blocking RX_LOG correlation sleep with adaptive poll-wait

### DIFF
--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
     CONF_MAP_UPLOAD_ENABLED,
+    CONF_ADAPTIVE_POLL_WAIT,
     CONF_MQTT_IATA,
     CONF_MQTT_TOKEN_TTL_SECONDS,
     CONF_MQTT_BROKERS,
@@ -880,6 +881,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             new_data[CONF_SELF_TELEMETRY_ENABLED] = user_input[CONF_SELF_TELEMETRY_ENABLED]
             new_data[CONF_SELF_TELEMETRY_INTERVAL] = user_input[CONF_SELF_TELEMETRY_INTERVAL]
             new_data[CONF_MAP_UPLOAD_ENABLED] = user_input[CONF_MAP_UPLOAD_ENABLED]
+            new_data[CONF_ADAPTIVE_POLL_WAIT] = user_input[CONF_ADAPTIVE_POLL_WAIT]
             self.hass.config_entries.async_update_entry(self.config_entry, data=new_data) # type: ignore
 
             if new_data[CONF_LIMIT_DISCOVERED_CONTACTS]:
@@ -897,6 +899,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_telemetry_enabled = self.config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         current_telemetry_interval = self.config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
         current_map_upload_enabled = self.config_entry.data.get(CONF_MAP_UPLOAD_ENABLED, False)
+        current_adaptive_poll_wait = self.config_entry.data.get(CONF_ADAPTIVE_POLL_WAIT, False)
 
         return self.async_show_form(
             step_id="global_settings",
@@ -907,6 +910,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=current_telemetry_enabled): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=current_telemetry_interval): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_MAP_UPLOAD_ENABLED, default=current_map_upload_enabled): cv.boolean,
+                vol.Optional(CONF_ADAPTIVE_POLL_WAIT, default=current_adaptive_poll_wait): cv.boolean,
             }),
         )
 

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -135,6 +135,9 @@ RATE_LIMITER_REFILL_RATE_SECONDS: Final = 120
 RX_LOG_CACHE_MAX_SIZE: Final = 100
 RX_LOG_CACHE_TTL_SECONDS: Final = 5.0
 
+# Adaptive poll-wait for incoming channel message RX_LOG correlation
+CONF_ADAPTIVE_POLL_WAIT: Final = "adaptive_poll_wait"
+
 # Sensor availability timeout multiplier
 SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER: Final = 3
 

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -10,6 +10,7 @@ from .const import (
     DOMAIN,
     ENTITY_DOMAIN_BINARY_SENSOR,
     DEFAULT_DEVICE_NAME,
+    CONF_ADAPTIVE_POLL_WAIT,
 )
 from .utils import (
     create_message_correlation_key,
@@ -121,13 +122,21 @@ async def handle_channel_message(event, coordinator) -> None:
         if sender_pubkey:
             event_data["pubkey_prefix"] = sender_pubkey
 
-        # Fire-then-enhance: correlate with RX_LOG data without blocking the event.
-        # RX_LOG events arrive asynchronously as repeaters relay the message
-        # (~300-400ms per hop). Instead of sleeping to wait for them, we:
-        # 1. Immediately pop whatever is already in the cache (often the direct reception)
-        # 2. Fire the meshcore_message event right away
-        # 3. Start a background task to collect late-arriving repeater RX_LOGs
-        #    and fire progressive meshcore_delivery_update events
+        # RX_LOG correlation: match incoming channel messages with radio
+        # reception data (SNR, RSSI, hop count, path) from RX_LOG events.
+        #
+        # Two modes controlled by the adaptive_poll_wait config option:
+        #
+        # Default (disabled): Wait a fixed 500ms for RX_LOG data to
+        #   accumulate, then attach whatever arrived to the event and fire.
+        #   This is the original behavior and ensures maximum RX_LOG data
+        #   is present on the initial meshcore_message event.
+        #
+        # Adaptive (enabled): Poll every 50ms up to 500ms and fire as
+        #   soon as data arrives. A background task then collects
+        #   late-arriving repeater RX_LOGs and delivers them via
+        #   progressive meshcore_delivery_update events.
+        adaptive = coordinator.config_entry.data.get(CONF_ADAPTIVE_POLL_WAIT, False)
         hash_key = None
         try:
             timestamp = payload.get("sender_timestamp")
@@ -138,23 +147,39 @@ async def handle_channel_message(event, coordinator) -> None:
                 # Skip if this key is reserved for outgoing delivery tracking.
                 if hash_key in coordinator._outgoing_correlation_keys:
                     _LOGGER.debug("Skipping RX_LOG pop for outgoing-reserved key %s", hash_key[:8])
-                    hash_key = None  # Prevent background task from running
+                    hash_key = None
+                elif adaptive:
+                    # Adaptive poll-wait: check every 50ms, fire as soon as
+                    # data arrives, with a 500ms ceiling matching the old behavior.
+                    for _ in range(_INCOMING_MAX_POLLS):
+                        await asyncio.sleep(_INCOMING_POLL_INTERVAL)
+                        batch = coordinator._pending_rx_logs.pop(hash_key, None)
+                        if batch:
+                            event_data["rx_log_data"] = list(batch)
+                            _LOGGER.debug(
+                                "Adaptive RX_LOG correlation: %d entry(ies) after poll",
+                                len(batch),
+                            )
+                            break
                 else:
-                    # Immediate pop — gets direct reception if it arrived before us
-                    immediate_batch = coordinator._pending_rx_logs.pop(hash_key, None)
-                    if immediate_batch:
-                        event_data["rx_log_data"] = list(immediate_batch)
+                    # Fixed wait: sleep 500ms then pop whatever accumulated.
+                    await asyncio.sleep(_INCOMING_FIXED_WAIT)
+                    rx_logs = coordinator._pending_rx_logs.pop(hash_key, None)
+                    if rx_logs:
+                        event_data["rx_log_data"] = list(rx_logs)
                         _LOGGER.debug(
-                            "Immediate RX_LOG correlation: %d entry(ies)", len(immediate_batch)
+                            "Fixed-wait RX_LOG correlation: %d entry(ies)",
+                            len(rx_logs),
                         )
         except Exception as ex:
-            _LOGGER.debug(f"Error in immediate RX_LOG correlation: {ex}")
+            _LOGGER.debug("Error in RX_LOG correlation: %s", ex)
 
-        # Fire event IMMEDIATELY — no blocking
+        # Fire the meshcore_message event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)
 
-        # Start background collection for late-arriving repeater RX_LOGs
-        if hash_key is not None:
+        # In adaptive mode, start background collection for late-arriving
+        # repeater RX_LOGs (progressive delivery updates).
+        if adaptive and hash_key is not None:
             hass.async_create_task(
                 _collect_incoming_rx_logs(
                     hass, coordinator, hash_key, event_data
@@ -171,6 +196,13 @@ async def handle_channel_message(event, coordinator) -> None:
     except Exception as ex:
         _LOGGER.error("Error handling channel message: %s", ex, exc_info=True)
 
+
+# Fixed-wait duration (seconds) — original behavior.
+_INCOMING_FIXED_WAIT = 0.5
+
+# Adaptive poll-wait settings.
+_INCOMING_POLL_INTERVAL = 0.05   # 50ms per poll
+_INCOMING_MAX_POLLS = 10         # 10 polls × 50ms = 500ms ceiling
 
 # Background collection pass intervals (seconds to wait before each pop).
 # Repeater relays arrive ~300-400ms per hop; two passes catch 2-3 repeaters.

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -121,30 +121,45 @@ async def handle_channel_message(event, coordinator) -> None:
         if sender_pubkey:
             event_data["pubkey_prefix"] = sender_pubkey
 
-        # Correlate with RX_LOG data - delay 500ms to collect multiple receptions
+        # Fire-then-enhance: correlate with RX_LOG data without blocking the event.
+        # RX_LOG events arrive asynchronously as repeaters relay the message
+        # (~300-400ms per hop). Instead of sleeping to wait for them, we:
+        # 1. Immediately pop whatever is already in the cache (often the direct reception)
+        # 2. Fire the meshcore_message event right away
+        # 3. Start a background task to collect late-arriving repeater RX_LOGs
+        #    and fire progressive meshcore_delivery_update events
+        hash_key = None
         try:
             timestamp = payload.get("sender_timestamp")
 
             if channel_idx is not None and timestamp:
-                await asyncio.sleep(0.5)
                 hash_key = create_message_correlation_key(channel_idx, timestamp)
 
-                # Skip pop if this key is reserved for outgoing delivery tracking.
-                # When we send a channel message, the outgoing handler registers its
-                # key so re-broadcasts of our own message are left for it to consume.
+                # Skip if this key is reserved for outgoing delivery tracking.
                 if hash_key in coordinator._outgoing_correlation_keys:
                     _LOGGER.debug("Skipping RX_LOG pop for outgoing-reserved key %s", hash_key[:8])
+                    hash_key = None  # Prevent background task from running
                 else:
-                    rx_logs = coordinator._pending_rx_logs.pop(hash_key, None)
-
-                    if rx_logs:
-                        _LOGGER.debug(f"Correlated channel message with {len(rx_logs)} RX_LOG reception(s)")
-                        event_data["rx_log_data"] = rx_logs
+                    # Immediate pop — gets direct reception if it arrived before us
+                    immediate_batch = coordinator._pending_rx_logs.pop(hash_key, None)
+                    if immediate_batch:
+                        event_data["rx_log_data"] = list(immediate_batch)
+                        _LOGGER.debug(
+                            "Immediate RX_LOG correlation: %d entry(ies)", len(immediate_batch)
+                        )
         except Exception as ex:
-            _LOGGER.debug(f"Error correlating channel message with RX_LOG: {ex}")
+            _LOGGER.debug(f"Error in immediate RX_LOG correlation: {ex}")
 
-        # Fire event
+        # Fire event IMMEDIATELY — no blocking
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)
+
+        # Start background collection for late-arriving repeater RX_LOGs
+        if hash_key is not None:
+            hass.async_create_task(
+                _collect_incoming_rx_logs(
+                    hass, coordinator, hash_key, event_data
+                )
+            )
 
         _LOGGER.debug(
             "Logged channel message in %s from %s%s: %s",
@@ -155,6 +170,54 @@ async def handle_channel_message(event, coordinator) -> None:
         )
     except Exception as ex:
         _LOGGER.error("Error handling channel message: %s", ex, exc_info=True)
+
+
+# Background collection pass intervals (seconds to wait before each pop).
+# Repeater relays arrive ~300-400ms per hop; two passes catch 2-3 repeaters.
+_INCOMING_BG_PASS_INTERVALS = [0.5, 1.0]
+
+
+async def _collect_incoming_rx_logs(
+    hass, coordinator, hash_key: str, base_event_data: dict
+) -> None:
+    """Background task to collect late-arriving RX_LOG entries for incoming messages.
+
+    Fires meshcore_delivery_update events as new RX_LOG data arrives,
+    matching the progressive pattern used for outgoing channel messages.
+    """
+    try:
+        # Start with any RX_LOG data already attached to the initial event
+        all_rx_logs = list(base_event_data.get("rx_log_data", []))
+
+        for pass_idx, interval in enumerate(_INCOMING_BG_PASS_INTERVALS):
+            await asyncio.sleep(interval)
+
+            batch = coordinator._pending_rx_logs.pop(hash_key, None)
+            if not batch:
+                continue
+
+            all_rx_logs.extend(batch)
+            _LOGGER.debug(
+                "Background pass %d: collected %d new RX_LOG(s), total %d",
+                pass_idx + 1, len(batch), len(all_rx_logs)
+            )
+
+            # Fire progressive update event
+            update_data = {
+                "entity_id": base_event_data.get("entity_id"),
+                "domain": base_event_data.get("domain", DOMAIN),
+                "rx_log_data": list(all_rx_logs),
+                "repeater_count": len(all_rx_logs),
+                "progressive": True,
+                "message_type": "channel",
+                "sender_name": base_event_data.get("sender_name"),
+                "message": base_event_data.get("message"),
+                "timestamp": base_event_data.get("timestamp"),
+            }
+            hass.bus.async_fire(EVENT_MESHCORE_DELIVERY_UPDATE, update_data)
+
+    except Exception as ex:
+        _LOGGER.debug("Error in background RX_LOG collection: %s", ex)
 
 def handle_contact_message(event, coordinator) -> None:
     """Handle contact message event."""

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -133,10 +133,12 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
-          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)"
+          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
-          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed."
+          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
         "title": "Global Settings"
@@ -239,10 +241,12 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
-          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)"
+          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
-          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed."
+          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
         "title": "Global Settings"

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -101,6 +101,119 @@ action:
       message: "{{ trigger.event.data.message_type }}: {{ trigger.event.data.message }}"
 ```
 
+### meshcore_delivery_update
+
+Fired progressively as RX_LOG radio reception data arrives for a message. This event delivers repeater path information that was not yet available when the initial `meshcore_message` or `meshcore_message_sent` event fired.
+
+This event fires in two scenarios:
+
+1. **Outgoing channel messages** — After sending a channel message, the integration collects repeater reception data over 4 passes (1 second apart). A `meshcore_delivery_update` fires after each pass that finds new data.
+
+2. **Incoming channel messages (adaptive mode only)** — When [Adaptive Channel Message Delivery](./messaging#rx_log-correlation) is enabled, the initial `meshcore_message` event fires as soon as the first RX_LOG data arrives. Background collection passes then deliver late-arriving repeater data via this event.
+
+**Outgoing Message Fields:**
+- `message` - The message text that was sent
+- `sender_name` - Name of the sending node
+- `channel` - Channel name
+- `channel_idx` - Channel number
+- `entity_id` - Related entity
+- `domain` - `"meshcore"`
+- `timestamp` - ISO format timestamp
+- `outgoing` - `true`
+- `message_type` - `"channel"`
+- `send_id` - (Optional) Send identifier from the service call
+- `rx_log_data` - Cumulative array of all RX_LOG entries collected so far (same structure as `rx_log_data` on `meshcore_message`)
+- `repeater_count` - Number of repeaters that received the message
+- `progressive` - `true` for intermediate updates, `false` on the final collection pass
+
+**Incoming Message Fields (Adaptive Mode):**
+- `entity_id` - Source entity
+- `domain` - `"meshcore"`
+- `message_type` - `"channel"`
+- `sender_name` - Name of the message sender
+- `message` - The received message text
+- `timestamp` - ISO format timestamp
+- `rx_log_data` - Cumulative array of all RX_LOG entries collected so far
+- `repeater_count` - Number of repeater receptions collected
+- `progressive` - `true` (always, for incoming)
+
+**Example — Tracking Outgoing Delivery:**
+```yaml
+alias: Track Message Delivery
+trigger:
+  - platform: event
+    event_type: meshcore_delivery_update
+    event_data:
+      outgoing: true
+condition:
+  - condition: template
+    value_template: "{{ not trigger.event.data.progressive }}"
+action:
+  - service: notify.notify
+    data:
+      message: >
+        Message "{{ trigger.event.data.message }}" delivered via
+        {{ trigger.event.data.repeater_count }} repeater(s)
+```
+
+**Example — Monitoring Incoming Paths (Adaptive Mode):**
+```yaml
+alias: Log Additional Incoming Paths
+trigger:
+  - platform: event
+    event_type: meshcore_delivery_update
+    event_data:
+      message_type: "channel"
+condition:
+  - condition: template
+    value_template: "{{ trigger.event.data.outgoing is not defined }}"
+action:
+  - service: logbook.log
+    data:
+      name: "Mesh Path Update"
+      message: >
+        {{ trigger.event.data.sender_name }}'s message now seen via
+        {{ trigger.event.data.repeater_count }} path(s)
+```
+
+**Example Event Data — Outgoing (Final Pass):**
+```yaml
+event_type: meshcore_delivery_update
+data:
+  message: "Good morning mesh!"
+  sender_name: "PonyBot"
+  channel: "public"
+  channel_idx: 0
+  entity_id: binary_sensor.meshcore_a305ca_ch_0_messages
+  domain: "meshcore"
+  timestamp: "2025-09-11T18:08:47.722967"
+  outgoing: true
+  message_type: "channel"
+  rx_log_data:
+    - channel_idx: 0
+      channel_name: "public"
+      timestamp: 1762838456
+      text: "PonyBot: Good morning mesh!"
+      snr: 12.0
+      rssi: -70
+      path_len: 0
+      path: ""
+      channel_hash: "11"
+      decrypted: true
+    - channel_idx: 0
+      channel_name: "public"
+      timestamp: 1762838456
+      text: "PonyBot: Good morning mesh!"
+      snr: 5.5
+      rssi: -50
+      path_len: 1
+      path: "cf"
+      channel_hash: "11"
+      decrypted: true
+  repeater_count: 2
+  progressive: false
+```
+
 ## Raw SDK Events
 
 All events from the Meshcore SDK are exposed as `meshcore_raw_event`. These provide complete access to all device data and events.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -98,6 +98,7 @@ Configure integration-wide settings:
 - **Enable Self Telemetry**: Collect telemetry from this node
 - **Self Telemetry Interval** (60-3600 seconds): How often to collect self telemetry data
 - **Enable Map Upload (map.meshcore.dev)**: When enabled, adverts from repeaters and room servers you receive are uploaded to [map.meshcore.dev](https://map.meshcore.dev). Those nodes appear on the official MeshCore map for the community. See [Map Auto Uploader](./map-upload) for details.
+- **Adaptive Channel Message Delivery**: When enabled, incoming channel messages fire as soon as RX_LOG radio reception data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively via `meshcore_delivery_update` events. Disabled by default. See [Messaging — RX_LOG Correlation](./messaging#rx_log-correlation) for details.
 
 **Note:** Disabling contact discovery is recommended if you have 50+ contacts and only need to monitor specific tracked repeaters/clients.
 

--- a/docs/docs/messaging.md
+++ b/docs/docs/messaging.md
@@ -31,6 +31,65 @@ When messages are received:
 4. The message is logged to the Home Assistant logbook
 5. Binary sensor entities track message activity
 
+### RX_LOG Correlation
+
+When a channel message is received over the mesh network, it may arrive via multiple paths — directly from the sender and relayed through one or more repeaters. Each reception generates an RX_LOG entry containing radio metrics: signal-to-noise ratio (SNR), received signal strength (RSSI), hop count, and the routing path taken.
+
+The integration automatically correlates these RX_LOG entries with the corresponding `meshcore_message` event and attaches them as `rx_log_data`. This gives automations and bots visibility into how a message traveled through the mesh.
+
+#### Default Mode (Fixed Wait)
+
+By default, the integration waits a fixed 500ms after receiving a channel message before firing the `meshcore_message` event. During this window, RX_LOG entries from repeater relays accumulate. After 500ms, all collected entries are attached to the event as `rx_log_data`.
+
+This mode is simple and predictable. All available path data is present on the initial event, which is what most bots and automations expect.
+
+#### Adaptive Mode (Opt-In)
+
+When **Adaptive Channel Message Delivery** is enabled in Global Settings, the integration polls for RX_LOG data every 50ms instead of waiting the full 500ms. As soon as data arrives, the `meshcore_message` event fires immediately.
+
+After the initial event, a background task makes two additional collection passes (at 0.5s and 1.0s) to pick up late-arriving repeater RX_LOGs. These are delivered via `meshcore_delivery_update` events — the same progressive pattern used for outgoing message delivery tracking.
+
+In testing, RX_LOG data consistently arrived within the first 50ms poll, even for messages routed through 5 repeaters. This reduces typical message delivery latency from 500ms to ~50ms.
+
+#### Tradeoffs
+
+| | Default (Fixed Wait) | Adaptive |
+|---|---|---|
+| Latency | Always 500ms | ~50ms typical, 500ms ceiling |
+| `rx_log_data` on initial event | All available paths | First path(s) only |
+| Late-arriving repeater data | Missed if >500ms | Delivered via `meshcore_delivery_update` |
+| Automation complexity | Listen to one event | May need to handle progressive updates |
+
+#### When to Enable Adaptive Mode
+
+Enable adaptive mode if:
+
+- You want lower-latency message delivery for dashboards or notifications
+- Your automations don't depend on having all paths present on the initial event
+- You're willing to listen for `meshcore_delivery_update` events to get complete path data
+
+Keep the default if:
+
+- Your bots or automations report total path counts from the initial event
+- You want the simplest integration with no progressive events to handle
+- The 500ms delay is acceptable for your use case
+
+#### Enabling Adaptive Mode
+
+1. Go to **Settings** → **Devices & Services** → **Meshcore**
+2. Click **Configure** → **Global Settings**
+3. Enable **Adaptive Channel Message Delivery**
+
+No restart required. The change takes effect on the next received channel message.
+
+#### Outgoing Message Delivery Tracking
+
+Outgoing channel messages also use progressive RX_LOG collection, regardless of the adaptive mode setting. When you send a channel message, the integration makes 4 collection passes over 4 seconds, firing `meshcore_delivery_update` events as repeater reception data arrives. The final pass includes `"progressive": false` to signal that collection is complete.
+
+This allows dashboards and bots to show delivery status updates in real time — for example, displaying how many repeaters relayed your message and which paths it took.
+
+See [Events — meshcore_delivery_update](./events#meshcore_delivery_update) for the full event field reference.
+
 ## Logbook Integration
 
 All messages automatically appear in the Home Assistant logbook with appropriate formatting and icons.


### PR DESCRIPTION
### Summary

Incoming channel messages currently block for a fixed 500ms (`asyncio.sleep(0.5)`) while waiting for RX_LOG correlation data before firing the `meshcore_message` event. This delays every channel message by half a second regardless of whether RX_LOG data arrives sooner.

This PR adds an **opt-in** adaptive poll-wait mode, controlled by a new config toggle in Global Settings. **The default behavior is unchanged** — the fixed 500ms sleep is preserved out of the box.

### Config Option

**Global Settings → Adaptive Channel Message Delivery** (disabled by default)

- **Disabled (default):** Fixed 500ms sleep, then attach whatever RX_LOG data accumulated. Identical to current `main` behavior. No changes needed for existing consumers.
- **Enabled:** Poll `_pending_rx_logs` every 50ms and fire as soon as data arrives (500ms ceiling). A background task collects late-arriving repeater RX_LOGs and delivers them via `meshcore_delivery_update` events.

### Changes

- `const.py` — New `CONF_ADAPTIVE_POLL_WAIT` constant
- `config_flow.py` — Added toggle to `async_step_global_settings()` (save, read, form schema)
- `logbook.py` — `handle_channel_message()`: config-driven branch between fixed-wait (default) and adaptive poll-wait. New constants: `_INCOMING_FIXED_WAIT` (0.5s), `_INCOMING_POLL_INTERVAL` (0.05s), `_INCOMING_MAX_POLLS` (10)
- `translations/en.json` — Label and description for the new option

### Behavior

- **Default (adaptive disabled):** Identical to current `main`. Every incoming channel message waits 500ms. `rx_log_data` attached to initial event.
- **Adaptive enabled:** `meshcore_message` fires as soon as RX_LOG data arrives (typically ~50ms), with a 500ms ceiling. Late-arriving repeater data delivered progressively via `meshcore_delivery_update` events.

**No breaking changes.** Default behavior is unchanged. The adaptive mode is strictly opt-in.

### Testing

Tested on a live HA host with a MeshCore network. Results across 3 channel messages routed through multiple repeaters (adaptive mode enabled):

| Data Arrived | Route | Latency Reduction |
|-------------|-------|-------------------|
| 50ms (poll 1/10) | 5 repeaters | 500ms → 50ms |
| 50ms (poll 1/10) | 4 repeaters | 500ms → 50ms |
| 50ms (poll 1/10) | 3 repeaters | 500ms → 50ms |

RX_LOG data arrived on the first poll in all cases, even for messages routed through up to 5 repeaters. Background collection passes found no additional late-arriving data. No errors in HA logs.