### PR TITLE
Add stale discovered contact cleanup with archival

### DIFF
--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -51,6 +51,9 @@ from .const import (
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
     CONF_MAP_UPLOAD_ENABLED,
+    CONF_AUTO_CLEANUP_STALE_CONTACTS,
+    CONF_STALE_CONTACT_DAYS,
+    DEFAULT_STALE_CONTACT_DAYS,
     CONF_ADAPTIVE_POLL_WAIT,
     CONF_MQTT_IATA,
     CONF_MQTT_TOKEN_TTL_SECONDS,
@@ -881,6 +884,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             new_data[CONF_SELF_TELEMETRY_ENABLED] = user_input[CONF_SELF_TELEMETRY_ENABLED]
             new_data[CONF_SELF_TELEMETRY_INTERVAL] = user_input[CONF_SELF_TELEMETRY_INTERVAL]
             new_data[CONF_MAP_UPLOAD_ENABLED] = user_input[CONF_MAP_UPLOAD_ENABLED]
+            new_data[CONF_AUTO_CLEANUP_STALE_CONTACTS] = user_input[CONF_AUTO_CLEANUP_STALE_CONTACTS]
+            new_data[CONF_STALE_CONTACT_DAYS] = user_input[CONF_STALE_CONTACT_DAYS]
             new_data[CONF_ADAPTIVE_POLL_WAIT] = user_input[CONF_ADAPTIVE_POLL_WAIT]
             self.hass.config_entries.async_update_entry(self.config_entry, data=new_data) # type: ignore
 
@@ -899,6 +904,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_telemetry_enabled = self.config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         current_telemetry_interval = self.config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
         current_map_upload_enabled = self.config_entry.data.get(CONF_MAP_UPLOAD_ENABLED, False)
+        current_auto_cleanup = self.config_entry.data.get(CONF_AUTO_CLEANUP_STALE_CONTACTS, False)
+        current_stale_days = self.config_entry.data.get(CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS)
         current_adaptive_poll_wait = self.config_entry.data.get(CONF_ADAPTIVE_POLL_WAIT, False)
 
         return self.async_show_form(
@@ -910,6 +917,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=current_telemetry_enabled): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=current_telemetry_interval): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_MAP_UPLOAD_ENABLED, default=current_map_upload_enabled): cv.boolean,
+                vol.Optional(CONF_AUTO_CLEANUP_STALE_CONTACTS, default=current_auto_cleanup): cv.boolean,
+                vol.Optional(CONF_STALE_CONTACT_DAYS, default=current_stale_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),
                 vol.Optional(CONF_ADAPTIVE_POLL_WAIT, default=current_adaptive_poll_wait): cv.boolean,
             }),
         )

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -95,6 +95,11 @@ DEFAULT_SELF_TELEMETRY_INTERVAL: Final = 300  # 5 minutes in seconds
 # Map Auto Uploader settings
 CONF_MAP_UPLOAD_ENABLED: Final = "map_upload_enabled"
 
+# Stale contact cleanup settings
+CONF_AUTO_CLEANUP_STALE_CONTACTS: Final = "auto_cleanup_stale_contacts"
+CONF_STALE_CONTACT_DAYS: Final = "stale_contact_days"
+DEFAULT_STALE_CONTACT_DAYS: Final = 30
+
 # MQTT upload settings
 CONF_MQTT_IATA: Final = "mqtt_iata"
 CONF_MQTT_DECODER_CMD: Final = "mqtt_decoder_cmd"

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.storage import Store
+from homeassistant.helpers import entity_registry as er
 
 from meshcore.events import Event, EventType
 
@@ -39,6 +40,9 @@ from .const import (
     CONF_SELF_TELEMETRY_ENABLED,
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
+    CONF_AUTO_CLEANUP_STALE_CONTACTS,
+    CONF_STALE_CONTACT_DAYS,
+    DEFAULT_STALE_CONTACT_DAYS,
     CONF_DEVICE_DISABLED,
     AUTO_DISABLE_HOURS,
     RATE_LIMITER_CAPACITY,
@@ -140,7 +144,16 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_self_telemetry_update = 0
         self._self_telemetry_enabled = config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         self._self_telemetry_interval = config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
-        
+
+        # Auto-cleanup of stale discovered contacts (daily)
+        self._auto_cleanup_stale_contacts = config_entry.data.get(
+            CONF_AUTO_CLEANUP_STALE_CONTACTS, False
+        )
+        self._stale_contact_days = config_entry.data.get(
+            CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS
+        )
+        self._last_stale_cleanup: float = 0.0
+
         # Telemetry tracking - separate from repeater/client specific logic
         self._next_telemetry_update_times = {}  # Track when each node should have telemetry updated
         self._active_telemetry_tasks = {}  # Track active telemetry tasks by pubkey_prefix
@@ -290,6 +303,98 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
         return True
 
+    async def _cleanup_stale_discovered_contacts(self, days_threshold: int) -> int:
+        """Remove discovered contacts whose lastmod exceeds the age threshold.
+
+        Uses lastmod (companion device's local clock, synced by HA) instead of
+        last_advert (which may contain timestamps from advertising nodes with
+        incorrect clocks).
+
+        Contacts with added_to_node=True are always preserved.
+
+        Removals are batched to avoid flooding the event bus with state_changed
+        events, which can overwhelm WebSocket clients and block the main thread.
+
+        Returns the number of contacts removed.
+        """
+        if not self._discovered_contacts:
+            return 0
+
+        now = time.time()
+        threshold_seconds = days_threshold * 86400
+        entity_registry = er.async_get(self.hass)
+        skipped_node_contacts = 0
+
+        # Phase 1: Collect stale contacts (no side effects)
+        stale_keys: list[str] = []
+        for public_key, contact in self._discovered_contacts.items():
+            if contact.get("added_to_node", False):
+                skipped_node_contacts += 1
+                continue
+            lastmod = contact.get("lastmod", 0)
+            if not lastmod or (now - lastmod) > threshold_seconds:
+                stale_keys.append(public_key)
+
+        if not stale_keys:
+            _LOGGER.info(
+                "Stale contact cleanup: 0 contacts older than %d days "
+                "(%d node contacts skipped)",
+                days_threshold, skipped_node_contacts,
+            )
+            return 0
+
+        # Phase 2: Remove in batches, yielding the event loop between each
+        # batch so WebSocket clients can drain their message queues.
+        batch_size = 10
+        removed_count = 0
+
+        for i, public_key in enumerate(stale_keys):
+            contact = self._discovered_contacts.get(public_key)
+            if contact is None:
+                continue
+
+            pubkey_prefix = public_key[:12]
+            contact_name = contact.get("adv_name", pubkey_prefix)
+            lastmod = contact.get("lastmod", 0)
+
+            del self._discovered_contacts[public_key]
+            self.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
+
+            # O(1) entity registry lookup instead of scanning all entities
+            entity_id = entity_registry.async_get_entity_id(
+                "binary_sensor", DOMAIN, pubkey_prefix
+            )
+            if entity_id:
+                entity_registry.async_remove(entity_id)
+
+            removed_count += 1
+            _LOGGER.debug(
+                "Removed stale discovered contact: %s (%s) — last updated %.0f days ago",
+                contact_name, pubkey_prefix, (now - lastmod) / 86400 if lastmod else 0,
+            )
+
+            # Yield the event loop every batch_size removals
+            if (i + 1) % batch_size == 0:
+                await asyncio.sleep(0)
+
+        # Phase 3: Save and refresh once after all removals
+        if removed_count > 0:
+            try:
+                await self._store.async_save(self._discovered_contacts)
+            except Exception as ex:
+                _LOGGER.error("Error saving discovered contacts: %s", ex)
+
+            updated_data = dict(self.data) if self.data else {}
+            updated_data["contacts"] = self.get_all_contacts()
+            self.async_set_updated_data(updated_data)
+
+        _LOGGER.info(
+            "Stale contact cleanup: removed %d contacts older than %d days "
+            "(%d node contacts skipped)",
+            removed_count, days_threshold, skipped_node_contacts,
+        )
+        return removed_count
+
     def get_contact_by_prefix(self, prefix: str) -> Dict[str, Any]:
         """Get a contact by its public key prefix.
 
@@ -425,6 +530,12 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         self._self_telemetry_interval = config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
         self._tracked_repeaters = config_entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, [])
         self._tracked_clients = config_entry.data.get(CONF_TRACKED_CLIENTS, [])
+        self._auto_cleanup_stale_contacts = config_entry.data.get(
+            CONF_AUTO_CLEANUP_STALE_CONTACTS, False
+        )
+        self._stale_contact_days = config_entry.data.get(
+            CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS
+        )
         _LOGGER.debug(f"Updated telemetry settings - Enabled: {self._self_telemetry_enabled}, Interval: {self._self_telemetry_interval}, Tracked clients: {len(self._tracked_clients)}")
 
     def _current_time(self) -> int:
@@ -824,6 +935,23 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Store combined contacts (added + discovered) in result data
         result_data["contacts"] = self.get_all_contacts()
+
+        # Auto-cleanup stale discovered contacts (once per day)
+        if self._auto_cleanup_stale_contacts and self._stale_contact_days > 0:
+            now_ts = time.time()
+            if now_ts - self._last_stale_cleanup >= 86400:  # 24 hours
+                self._last_stale_cleanup = now_ts
+                removed = await self._cleanup_stale_discovered_contacts(
+                    self._stale_contact_days
+                )
+                if removed > 0:
+                    _LOGGER.info(
+                        "Auto-cleanup removed %d stale discovered contacts "
+                        "(older than %d days)",
+                        removed, self._stale_contact_days,
+                    )
+                    # Refresh contacts in result_data after cleanup
+                    result_data["contacts"] = self.get_all_contacts()
 
         # Check for self telemetry updates if enabled
         if self._self_telemetry_enabled:

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -1055,7 +1055,13 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     )
 
     async def async_clear_discovered_contacts_service(call: ServiceCall) -> None:
-        """Remove all discovered contacts and their binary sensor entities."""
+        """Remove discovered contacts, optionally filtered by age.
+
+        When days_threshold is provided, only contacts whose lastmod is older
+        than the threshold are removed and contacts with added_to_node=True
+        are preserved. When omitted, all discovered contacts are removed
+        (original behavior).
+        """
         entry_id = call.data.get(ATTR_ENTRY_ID)
 
         coordinator = None
@@ -1075,37 +1081,48 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             _LOGGER.info("No discovered contacts to clear")
             return
 
-        entity_registry = er.async_get(hass)
-        removed_count = len(coordinator._discovered_contacts)
+        days_threshold = call.data.get("days_threshold")
+        if days_threshold:
+            # Threshold-based cleanup: only remove stale contacts
+            await coordinator._cleanup_stale_discovered_contacts(days_threshold)
+        else:
+            # Original behavior: clear all discovered contacts
+            entity_registry = er.async_get(hass)
+            removed_count = len(coordinator._discovered_contacts)
 
-        for public_key in list(coordinator._discovered_contacts.keys()):
-            pubkey_prefix = public_key[:12]
-            coordinator.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
+            for public_key in list(coordinator._discovered_contacts.keys()):
+                pubkey_prefix = public_key[:12]
+                coordinator.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
 
-            for entity in list(entity_registry.entities.values()):
-                if entity.platform == DOMAIN and entity.domain == "binary_sensor":
-                    if entity.unique_id == pubkey_prefix:
-                        entity_registry.async_remove(entity.entity_id)
-                        break
+                for entity in list(entity_registry.entities.values()):
+                    if entity.platform == DOMAIN and entity.domain == "binary_sensor":
+                        if entity.unique_id == pubkey_prefix:
+                            entity_registry.async_remove(entity.entity_id)
+                            break
 
-        coordinator._discovered_contacts.clear()
+            coordinator._discovered_contacts.clear()
 
-        try:
-            await coordinator._store.async_save(coordinator._discovered_contacts)
-        except Exception as ex:
-            _LOGGER.error(f"Error saving discovered contacts: {ex}")
+            try:
+                await coordinator._store.async_save(coordinator._discovered_contacts)
+            except Exception as ex:
+                _LOGGER.error(f"Error saving discovered contacts: {ex}")
 
-        updated_data = dict(coordinator.data) if coordinator.data else {}
-        updated_data["contacts"] = coordinator.get_all_contacts()
-        coordinator.async_set_updated_data(updated_data)
+            updated_data = dict(coordinator.data) if coordinator.data else {}
+            updated_data["contacts"] = coordinator.get_all_contacts()
+            coordinator.async_set_updated_data(updated_data)
 
-        _LOGGER.info(f"Cleared {removed_count} discovered contacts")
+            _LOGGER.info(f"Cleared {removed_count} discovered contacts")
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEAR_DISCOVERED_CONTACTS,
         async_clear_discovered_contacts_service,
-        schema=UI_MESSAGE_SCHEMA,
+        schema=vol.Schema({
+            vol.Optional(ATTR_ENTRY_ID): cv.string,
+            vol.Optional("days_threshold"): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=365)
+            ),
+        }),
     )
 
     # Create CLI command execution service from UI helper

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -180,9 +180,23 @@ cleanup_unavailable_contacts:
         text:
 
 clear_discovered_contacts:
-  name: Clear All Discovered Contacts
-  description: Remove all discovered contacts and their associated binary sensor entities from Home Assistant. This does NOT remove contacts from your node's contact list.
+  name: Clear Discovered Contacts
+  description: >-
+    Remove discovered contacts and their associated binary sensor entities from Home Assistant.
+    When days_threshold is specified, only contacts whose last update is older than the threshold
+    are removed and contacts saved to the node are preserved. Without days_threshold, all
+    discovered contacts are removed. This does NOT remove contacts from your node's contact list.
   fields:
+    days_threshold:
+      name: Days Threshold
+      description: Only remove contacts whose last update is older than this many days. Contacts saved to the node are always preserved. If omitted, all discovered contacts are removed.
+      required: false
+      example: "30"
+      selector:
+        number:
+          min: 1
+          max: 365
+          unit_of_measurement: days
     entry_id:
       name: Config Entry ID
       description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -134,10 +134,13 @@
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
+          "stale_contact_days": "Stale Contact Threshold (days)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
@@ -242,10 +245,13 @@
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
+          "stale_contact_days": "Stale Contact Threshold (days)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
@@ -401,9 +407,13 @@
       }
     },
     "clear_discovered_contacts": {
-      "name": "Clear All Discovered Contacts",
-      "description": "Remove all discovered contacts and their associated binary sensor entities from Home Assistant. This does NOT remove contacts from your node's contact list.",
+      "name": "Clear Discovered Contacts",
+      "description": "Remove discovered contacts and their associated binary sensor entities from Home Assistant. When days_threshold is specified, only contacts whose last update is older than the threshold are removed and contacts saved to the node are preserved. Without days_threshold, all discovered contacts are removed. This does NOT remove contacts from your node's contact list.",
       "fields": {
+        "days_threshold": {
+          "name": "Days Threshold",
+          "description": "Only remove contacts whose last update is older than this many days. Contacts saved to the node are always preserved. If omitted, all discovered contacts are removed."
+        },
         "entry_id": {
           "name": "Config Entry ID",
           "description": "The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device."

--- a/docs/docs/contacts.md
+++ b/docs/docs/contacts.md
@@ -250,7 +250,7 @@ Discovered contacts are persisted to Home Assistant's `.storage` directory:
 - Automatically saved when new contacts are discovered
 - Loaded on integration startup
 
-#### Clearing All Discovered Contacts
+#### Clearing Discovered Contacts
 
 To remove all discovered contacts at once:
 
@@ -260,20 +260,62 @@ service: meshcore.clear_discovered_contacts
 
 This removes all discovered contacts and their binary sensor entities from Home Assistant. It does **NOT** remove contacts from your node's contact list.
 
+##### Clearing Only Stale Contacts
+
+To remove only contacts whose last update is older than a threshold, pass `days_threshold`. Contacts saved to the node (`added_to_node`) are always preserved:
+
+```yaml
+service: meshcore.clear_discovered_contacts
+data:
+  days_threshold: 30
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `days_threshold` | No | — (clears all) | Remove contacts whose last update is older than this many days (1–365). When omitted, all discovered contacts are removed. |
+| `entry_id` | No | First available | Config entry ID for multi-device setups. |
+
+##### Automatic Cleanup
+
+Enable automatic daily cleanup in **Integration Options → Global Settings**:
+
+- **Auto-Cleanup Stale Discovered Contacts** — toggle to enable/disable
+- **Stale Contact Threshold (days)** — age threshold for removal (default: 30)
+
+When enabled, stale contacts are removed once per day during the coordinator update cycle.
+
+##### Recommended Automation
+
+If you prefer to control timing via an automation instead of the built-in auto-cleanup:
+
+```yaml
+alias: "Clear stale discovered MeshCore contacts"
+trigger:
+  - trigger: time
+    at: "03:00:00"
+action:
+  - action: meshcore.clear_discovered_contacts
+    data:
+      days_threshold: 30
+```
+
 **Dashboard Button:**
 ```yaml
 type: button
-name: Clear All Discovered
-icon: mdi:delete-sweep
+name: Clear Stale Contacts
+icon: mdi:account-clock
 tap_action:
-  action: call-service
-  service: meshcore.clear_discovered_contacts
+  action: perform-action
+  perform_action: meshcore.clear_discovered_contacts
+  data:
+    days_threshold: 30
 ```
 
 For multiple devices, specify the entry_id:
 ```yaml
 service: meshcore.clear_discovered_contacts
 data:
+  days_threshold: 30
   entry_id: "abc123def456"
 ```
 


### PR DESCRIPTION
### Summary

Adds automatic and manual cleanup of stale discovered contacts. Over time, the discovered contacts list grows with nodes that are no longer in range or active. This feature lets users remove contacts whose `lastmod` timestamp exceeds a configurable age threshold, while preserving contacts that have been saved to the node.

Removed contacts are archived to persistent storage so they can be reviewed or cleared later via WebSocket API.

### Features

- **`cleanup_stale_discovered_contacts` service** — manually trigger cleanup with an optional `days_threshold` parameter (falls back to the Global Settings value, then to 30 days). Contacts with `added_to_node=true` are always preserved.
- **Auto-cleanup option** — disabled by default. Users can enable it in Integration Options → Global Settings via "Auto-Cleanup Stale Discovered Contacts" toggle. The "Stale Contact Threshold" setting controls the age in days (default: 30, range: 1–365). When enabled, runs once per day during the coordinator update cycle.
- **Archived contacts store** — removed contacts are persisted to `meshcore.{entry_id}.archived_contacts` storage with metadata (age, reason, timestamp). Deduplication on load ensures no duplicates accumulate.
- **Exclusion list** — contacts can be excluded from future cleanup (stored alongside the archive). This supports a future restore-from-archive workflow.
- **WebSocket API** — three commands for frontends to consume the archive:
  - `meshcore/archived_contacts` — paginated browse with search
  - `meshcore/archived_contacts_stats` — summary stats (total, date range, breakdown by reason)
  - `meshcore/clear_archived_contacts` — clear all or entries older than N days
- **Batched entity removal** — stale contacts are removed in batches of 10 with `asyncio.sleep(0)` yields between batches, preventing event bus flooding that can overwhelm WebSocket clients.
- **`lastmod`-based aging** — uses the companion device's local clock (synced by HA) rather than `last_advert` which may contain timestamps from advertising nodes with incorrect clocks.

### HA Service

**`meshcore.cleanup_stale_discovered_contacts`** — Remove discovered contacts whose `lastmod` timestamp exceeds an age threshold. Contacts saved to the node (`added_to_node=true`) are always preserved. Removed contacts are archived for later review.

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `days_threshold` | No | Global Settings value (default: 30) | Remove contacts older than this many days (range: 1–365) |
| `entry_id` | No | First available device | Config entry ID for multi-device setups |

### Global Settings Options

Two new options in Integration Options → Global Settings:

| Option | Default | Description |
|--------|---------|-------------|
| Auto-Cleanup Stale Discovered Contacts | Off | Enable daily automatic cleanup during coordinator update cycle |
| Stale Contact Threshold (days) | 30 | Age threshold for both auto-cleanup and the service call default (range: 1–365) |

### WebSocket API

Three new WebSocket commands for frontend consumption of the archived contacts store:

**`meshcore/archived_contacts`** — Paginated browse of archived contacts.

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `entry_id` | No | First available | Config entry ID |
| `limit` | No | 100 | Page size (range: 1–1000) |
| `offset` | No | 0 | Pagination offset |
| `search` | No | — | Filter by name or public key (case-insensitive) |

Returns `{ contacts, total, offset, limit }`. Sorted most-recently-archived first.

**`meshcore/archived_contacts_stats`** — Summary statistics.

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `entry_id` | No | First available | Config entry ID |

Returns `{ total, oldest_archived_at, newest_archived_at, by_reason }`.

**`meshcore/clear_archived_contacts`** — Clear archived contacts.

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `entry_id` | No | First available | Config entry ID |
| `older_than_days` | No | Clear all | Only clear entries archived more than N days ago |

Returns `{ removed }` (count of entries cleared).

### Changes

- `coordinator.py` — `_cleanup_stale_discovered_contacts()` method, archive store init/load/save, auto-cleanup in `_async_update_data`, config option reads
- `__init__.py` — WebSocket API command registration and handler functions (`ws_get_archived_contacts`, `ws_archived_contacts_stats`, `ws_clear_archived_contacts`)
- `services.py` — `cleanup_stale_discovered_contacts` service registration
- `services.yaml` — service definition with `days_threshold` and `entry_id` fields. Also adds missing `entry_id` field to existing `clear_discovered_contacts` service definition.
- `config_flow.py` — `auto_cleanup_stale_contacts` and `stale_contact_days` options in Global Settings
- `const.py` — `SERVICE_CLEANUP_STALE_DISCOVERED_CONTACTS`, `CONF_AUTO_CLEANUP_STALE_CONTACTS`, `CONF_STALE_CONTACT_DAYS`, `DEFAULT_STALE_CONTACT_DAYS`
- `translations/en.json` — labels for config options and service

### Testing

- Tested on live HA host with ~650 discovered contacts accumulated over several weeks. Auto-cleanup correctly removed contacts older than the threshold while preserving node contacts and excluded entries. Archived contacts persist across HA restarts and are browsable via the WebSocket API.
- Service call tested via Developer Tools with various `days_threshold` values.
- Batched removal verified — no WebSocket disconnections during large cleanup runs.