### PR TITLE
Fix repeater/telemetry status timeout and login response check

### DIFF
--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.helpers.storage import Store
 
 from meshcore.events import Event, EventType
-from meshcore.packets import BinaryReqType
 
 from .rate_limiter import TokenBucket
 from .const import (
@@ -477,18 +476,27 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                         contact,
                         repeater_config.get(CONF_REPEATER_PASSWORD, "")
                     )
-                    
-                    if login_result and login_result.type == EventType.LOGIN_SUCCESS:
-                        self.logger.info(f"Successfully logged in to repeater {repeater_name}")
-                        self._increment_success(pubkey_prefix)
-                        # Track login time and reset failure count on success
-                        self._repeater_login_times[pubkey_prefix] = self._current_time()
-                        self._repeater_consecutive_failures[pubkey_prefix] = 0
+
+                    # send_login returns MSG_SENT (login packet queued) or ERROR.
+                    # Wait for the actual LOGIN_SUCCESS event from the repeater.
+                    if login_result and login_result.type == EventType.MSG_SENT:
+                        login_event = await self.api.mesh_core.wait_for_event(
+                            EventType.LOGIN_SUCCESS,
+                            timeout=10.0,
+                        )
+                        if login_event:
+                            self.logger.info(f"Successfully logged in to repeater {repeater_name}")
+                            self._increment_success(pubkey_prefix)
+                            self._repeater_login_times[pubkey_prefix] = self._current_time()
+                            self._repeater_consecutive_failures[pubkey_prefix] = 0
+                        else:
+                            self.logger.error(f"Login to repeater {repeater_name} timed out waiting for LOGIN_SUCCESS")
+                            self._increment_failure(pubkey_prefix)
+                            self._repeater_login_times[pubkey_prefix] = self._current_time()
                     else:
-                        error_msg = login_result.payload if login_result and login_result.type == EventType.ERROR else "timeout or no response"
+                        error_msg = login_result.payload if login_result and login_result.type == EventType.ERROR else "send failed"
                         self.logger.error(f"Login to repeater {repeater_name} failed: {error_msg}")
                         self._increment_failure(pubkey_prefix)
-                        # Update login time to enforce cooldown even on failure
                         self._repeater_login_times[pubkey_prefix] = self._current_time()
 
                 except Exception as ex:
@@ -511,16 +519,13 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 self._apply_repeater_backoff(pubkey_prefix, new_failure_count, update_interval)
                 return
 
-            await self.api.mesh_core.commands.send_binary_req(contact, BinaryReqType.STATUS)
-            result = await self.api.mesh_core.wait_for_event(
-                EventType.STATUS_RESPONSE,
-                attribute_filters={"pubkey_prefix": pubkey_prefix},
-            )
+            result = await self.api.mesh_core.commands.req_status_sync(contact)
             _LOGGER.debug(f"Status response received: {result}")
-                
-            # Handle response
-            if not result or result.type == EventType.ERROR:
-                self.logger.warn(f"Error requesting status from repeater {repeater_name}: {result}")
+
+
+            # Handle response -- req_status_sync returns a payload dict or None
+            if not result:
+                self.logger.warning(f"Error requesting status from repeater {repeater_name}: no response (timeout or send failure)")
                 # Increment failure count and apply backoff
                 new_failure_count = failure_count + 1
                 self._repeater_consecutive_failures[pubkey_prefix] = new_failure_count
@@ -532,8 +537,8 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
                 update_interval = repeater_config.get(CONF_REPEATER_UPDATE_INTERVAL, DEFAULT_REPEATER_UPDATE_INTERVAL)
                 self._apply_repeater_backoff(pubkey_prefix, new_failure_count, update_interval)
-            elif result.payload.get('uptime', 0) == 0:
-                self.logger.warn(f"Malformed status response from repeater {repeater_name}: {result.payload}")
+            elif result.get('uptime', 0) == 0:
+                self.logger.warning(f"Malformed status response from repeater {repeater_name}: {result}")
                 new_failure_count = failure_count + 1
                 self._repeater_consecutive_failures[pubkey_prefix] = new_failure_count
                 self._increment_failure(pubkey_prefix)
@@ -554,7 +559,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 self._next_repeater_update_times[pubkey_prefix] = next_update_time
             
         except Exception as ex:
-            self.logger.warn(f"Exception updating repeater {repeater_name}: {ex}")
+            self.logger.warning(f"Exception updating repeater {repeater_name}: {ex}")
             # Increment failure count and apply backoff
             new_failure_count = self._repeater_consecutive_failures.get(pubkey_prefix, 0) + 1
             self._repeater_consecutive_failures[pubkey_prefix] = new_failure_count
@@ -641,13 +646,9 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 self._apply_backoff(pubkey_prefix, new_failure_count, update_interval, "telemetry")
                 return
 
-            await self.api.mesh_core.commands.send_binary_req(contact, BinaryReqType.TELEMETRY)
-            telemetry_result = await self.api.mesh_core.wait_for_event(
-                EventType.TELEMETRY_RESPONSE,
-                attribute_filters={"pubkey_prefix": pubkey_prefix},
-            )
+            telemetry_result = await self.api.mesh_core.commands.req_telemetry_sync(contact)
             
-            if telemetry_result and telemetry_result.type != EventType.ERROR:
+            if telemetry_result:
                 self.logger.debug(f"Telemetry response received from {node_name}: {telemetry_result}")
                 # Reset failure count on success
                 self._telemetry_consecutive_failures[pubkey_prefix] = 0
@@ -669,7 +670,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 self._apply_backoff(pubkey_prefix, new_failure_count, update_interval, "telemetry")
                 
         except Exception as ex:
-            self.logger.warn(f"Exception requesting telemetry from node {node_name}: {ex}")
+            self.logger.warning(f"Exception requesting telemetry from node {node_name}: {ex}")
             # Increment failure count and apply backoff
             new_failure_count = failure_count + 1
             self._telemetry_consecutive_failures[pubkey_prefix] = new_failure_count
@@ -832,7 +833,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             
         # Check for messages (lock prevents overlap with MESSAGES_WAITING auto-fetch)
         async with self._message_lock:
-            _LOGGER.info("Clearing message queue...")
+            _LOGGER.debug("Clearing message queue...")
             try:
                 res = True
                 while res:
@@ -842,7 +843,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                         _LOGGER.debug("No more messages in queue")
                     elif result.type == EventType.ERROR:
                         res = False
-                        _LOGGER.error(f"Error retrieving messages: {result.payload}")
+                        _LOGGER.error(f"Error retrieving messages: {result}")
                     else:
                         _LOGGER.debug(f"Cleared message: {result}")
             except Exception as ex:


### PR DESCRIPTION
### Summary

Fixes managed repeater status and telemetry requests that intermittently time out — most commonly after an HA restart, where the repeater appears non-functional until a second restart "warms up" mesh routes.

Three root causes addressed:

1. **Missing error check on `send_binary_req`.** The return value was discarded — if the send failed (no path, write error), the coordinator waited the full timeout for a response that would never arrive.
2. **Fixed 5-second timeout.** The SDK calculates `suggested_timeout` based on path length to the destination. Multi-hop repeaters need longer. The coordinator was using the SDK's default 5s regardless.
3. **Wrong `send_login` response check.** `send_login` returns `MSG_SENT` (packet queued), not `LOGIN_SUCCESS` — the actual login result arrives asynchronously. The coordinator checked for `LOGIN_SUCCESS` on the return value, which never matched, so login always appeared to fail.

### Changes

- Replace manual `send_binary_req` + `wait_for_event` with SDK's `req_status_sync()` and `req_telemetry_sync()` — these handle error checking, firmware-calculated timeout, and precise tag-based response matching internally.
- Fix `send_login` to check for `MSG_SENT`, then `wait_for_event(LOGIN_SUCCESS, timeout=10.0)` for the actual repeater response.
- Lower "Clearing message queue..." from `_LOGGER.info` to `_LOGGER.debug` (logged every update cycle with no actionable content).
- Replace deprecated `logger.warn()` with `logger.warning()` (4 occurrences).
- Remove unused `BinaryReqType` import.

### Context

This is part 1 of 3 coordinated PRs improving companion device communication reliability. The companion firmware can only track one outstanding mesh request at a time (`clearPendingReqs()` wipes all five pending flags before every outbound request). These three PRs address different layers of that constraint:

| PR | What It Fixes |
|----|---------------|
| **This PR** | Incorrect timeout handling and missing error checks |
| PR 2 (separate, no dependency) | Unnecessary `get_msg()` polling every 5s (~17,280 commands/day) |
| PR 3 (future, depends on 1+2) | Command serialization — mutual exclusion on the shared connection |

Full analysis: [Forensics — Companion Device Communication Reliability](https://gist.github.com/mwolter805/78718a9a7a975b8320d31180712eed74)

### Testing

Tested on live HA host with one managed multi-hop repeater. Status and telemetry responses now return consistently after HA restart without requiring a second restart. Login flow works correctly — LOGIN_SUCCESS event is captured from the repeater. No regressions in message handling or contact sync.