### PR TITLE
Fix AttributeError in execute_command service (stale set_command_result call)

### DIFF
--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -712,7 +712,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     else:
                         _LOGGER.info("Command result: %s", result)
 
-                    coordinator.set_command_result(command_str, result)
                     # Return response data for commands that support it
                     # (e.g., export_private_key when called with return_response=True)
                     if json_safe_payload:


### PR DESCRIPTION
## Summary

Every `execute_command` service call raises an `AttributeError` because an orphaned call to `coordinator.set_command_result()` was left in `services.py` after the last-command sensor feature was scoped out.

The underlying command executes successfully, but the unhandled exception causes the service call to be reported as failed to the caller.

## Background

- `26cde40` (2026-03-24) introduced the last-command sensor feature, adding `set_command_result()` / `set_command_error()` methods to the coordinator and call sites in `services.py`.
- `fc3bb80` (2026-03-29) scoped that feature out — removing the coordinator methods, the `_coordinator_for_cli_feedback()` helper, and most call sites in `services.py`. However, one `coordinator.set_command_result(command_str, result)` call was missed in the success path of `execute_command`.

## Error

```
ERROR (MainThread) [custom_components.meshcore.services] Error executing command send_appstart:
    'MeshCoreDataUpdateCoordinator' object has no attribute 'set_command_result'
```

This occurs on every `execute_command` invocation regardless of which command is run.

## Changes

- Remove the orphaned `coordinator.set_command_result(command_str, result)` call from the `execute_command` success path in `services.py`

No other files affected. No new dependencies. No behavioral change beyond eliminating the crash.

## Test Plan

- Call `execute_command` with any command (e.g., `send_appstart`) — confirm no `AttributeError` in logs
- Verify the command still executes and returns the expected result
