### PR TITLE
Fix telemetry sensors missing device_class and unit_of_measurement

### DIFF
--- a/custom_components/meshcore/telemetry_sensor.py
+++ b/custom_components/meshcore/telemetry_sensor.py
@@ -139,6 +139,31 @@ LPP_TYPE_MAPPINGS: dict[int | str, dict] = {
     },
 }
 
+# The meshcore SDK's lpp_json_encoder converts integer LPP type codes to string
+# names (e.g. 103 -> "temperature") during JSON serialization. Add string aliases
+# so the lookup works regardless of whether the type arrives as int or str.
+# String names sourced from meshcore.lpp_json_encoder.my_lpp_types.
+_LPP_STRING_TO_INT: dict[str, int] = {
+    "digital input": 0,
+    "digital output": 1,
+    "analog input": 2,
+    "analog output": 3,
+    "generic sensor": 100,
+    "illuminance": 101,
+    "presence": 102,
+    "temperature": 103,
+    "humidity": 104,
+    "accelerometer": 113,
+    "voltage": 116,
+    "current": 117,
+    "power": 128,
+    "colour": 135,
+}
+
+for _str_name, _int_key in _LPP_STRING_TO_INT.items():
+    if _int_key in LPP_TYPE_MAPPINGS:
+        LPP_TYPE_MAPPINGS[_str_name] = LPP_TYPE_MAPPINGS[_int_key]
+
 
 class TelemetrySensorManager:
     """Manages dynamic creation and updates of telemetry sensors."""
@@ -294,7 +319,7 @@ class TelemetrySensorManager:
         self,
         pubkey_prefix: str,
         channel: int,
-        lpp_type: int,
+        lpp_type: int | str,
         value: Any,
         node_info: Dict[str, Any],
     ) -> list[MeshCoreTelemetrySensor]:
@@ -448,7 +473,7 @@ class MeshCoreTelemetrySensor(CoordinatorEntity, SensorEntity):
         description: SensorEntityDescription,
         pubkey_prefix: str,
         channel: int,
-        lpp_type: int,
+        lpp_type: int | str,
         node_info: Dict[str, Any],
         field: str = None,  # type: ignore
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes telemetry sensors being created without `device_class` or `native_unit_of_measurement`, which prevents Home Assistant from offering unit conversion (e.g. °C → °F) in entity settings.

Resolves #162

## Root cause

The meshcore SDK's `lpp_json_encoder` converts integer LPP type codes to string names during JSON serialization (e.g. `103` → `"temperature"`, `116` → `"voltage"`). `LPP_TYPE_MAPPINGS` in `telemetry_sensor.py` only had integer keys, so when a telemetry event arrived with `"type": "temperature"`, the lookup missed and fell through to a generic fallback sensor with no `device_class`, no `native_unit_of_measurement`, and a generic `mdi:gauge` icon.

This affected all telemetry sensor types (temperature, voltage, humidity, current, power, etc.) on all device types (repeaters, clients, root node).

## Fix

Added string aliases to `LPP_TYPE_MAPPINGS` that reference the same config dicts as their integer counterparts. A `_LPP_STRING_TO_INT` mapping table (sourced from the SDK's `meshcore.lpp_json_encoder.my_lpp_types`) is used to programmatically add string keys at module load time, keeping the mapping DRY.

Also corrected `lpp_type` type hints from `int` to `int | str` on `_create_sensors_for_channel()` and `MeshCoreTelemetrySensor.__init__()` to reflect actual SDK output.

## Testing

Deployed to a live HA instance with repeater and client telemetry active. After restart, temperature sensors show `device_class: temperature` and `unit_of_measurement: °C`, and HA entity settings now offer °F conversion. Voltage sensors show `device_class: voltage` and `unit_of_measurement: V`. No errors in HA logs.