### PR TITLE
fix(map): correct ADV_TYPE_CHAT and point uploader at meshcore.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Auth-token mode is easy install by default:
 - Signing key is pulled from the connected node via `export_private_key()`.
 - If private key export is disabled/blocked on firmware, auth-token upload cannot start.
 
-## Map Auto Uploader (map.meshcore.dev)
+## Map Auto Uploader (map.meshcore.io)
 
-When enabled (off by default), the integration automatically uploads repeater and room server adverts to [map.meshcore.dev](https://map.meshcore.dev) when your Companion hears them. This integrates the [map.meshcore.dev-uploader](https://github.com/recrof/map.meshcore.dev-uploader) bot directly into the MeshCore Home Assistant integration—no separate bot needed. Enable in Global Settings if you want Map Auto Uploader.
+When enabled (off by default), the integration automatically uploads repeater and room server adverts to [map.meshcore.io](https://map.meshcore.io) when your Companion hears them. A standalone alternative is [map.meshcore.io-uploader](https://github.com/recrof/map.meshcore.io-uploader). Enable in Global Settings if you want Map Auto Uploader.
 
 - Uses the same connection as Home Assistant (USB, BLE, or TCP)
 - Requires private key export on firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`)

--- a/custom_components/meshcore/map_uploader.py
+++ b/custom_components/meshcore/map_uploader.py
@@ -20,7 +20,9 @@ except ImportError:
     HAS_NACL = False
 
 MAP_API_URL = "https://map.meshcore.io/api/v1/uploader/node"
-ADVERT_TYPE_CHAT = 0
+
+# MeshCore AdvertDataHelpers.h — low 4 bits of advert flags (meshcore_py meshcore_parser.py)
+ADV_TYPE_CHAT = 1
 
 REPLAY_COOLDOWN_SECONDS = 3600
 _SEEN_ADVERTS_MAX_SIZE = 1000
@@ -279,8 +281,8 @@ class MeshCoreMapUploader:
         payload_type = payload.get("payload_type")
         if payload_type != 4:
             return
-        adv_type = payload.get("adv_type", 0)
-        if adv_type == ADVERT_TYPE_CHAT:
+        adv_type = int(payload.get("adv_type", 0))
+        if adv_type == ADV_TYPE_CHAT:
             return
         adv_key = payload.get("adv_key")
         adv_timestamp = payload.get("adv_timestamp")

--- a/custom_components/meshcore/map_uploader.py
+++ b/custom_components/meshcore/map_uploader.py
@@ -1,7 +1,4 @@
-"""Map Auto Uploader for MeshCore integration - uploads repeater/room server adverts to map.meshcore.dev.
-
-Matches working of recrof/map.meshcore.dev-uploader.
-"""
+"""Map Auto Uploader for MeshCore integration — uploads repeater and room server adverts to map.meshcore.io."""
 from __future__ import annotations
 
 import hashlib
@@ -22,8 +19,9 @@ try:
 except ImportError:
     HAS_NACL = False
 
-MAP_API_URL = "https://map.meshcore.dev/api/v1/uploader/node"
+MAP_API_URL = "https://map.meshcore.io/api/v1/uploader/node"
 ADVERT_TYPE_CHAT = 0
+
 REPLAY_COOLDOWN_SECONDS = 3600
 _SEEN_ADVERTS_MAX_SIZE = 1000
 
@@ -105,7 +103,7 @@ def _verify_advert_signature(log_data: dict, logger=None) -> bool:
 
 
 class MeshCoreMapUploader:
-    """Upload repeater/room server adverts to map.meshcore.dev."""
+    """Upload repeater and room server adverts to map.meshcore.io."""
 
     def __init__(
         self,

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -133,11 +133,11 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
-          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
-          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
@@ -241,11 +241,11 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
-          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.dev)",
+          "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
-          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.dev. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
+          "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",

--- a/custom_components/meshcore/translations/nl.json
+++ b/custom_components/meshcore/translations/nl.json
@@ -103,10 +103,10 @@
           "max_discovered_contacts": "Maximum aantal Ontdekte Contacten",
           "self_telemetry_enabled": "Schakel Zelf-telemetrie in",
           "self_telemetry_interval": "Zelf-telemetrie-interval (seconden)",
-          "map_upload_enabled": "Schakel Map Auto Uploader in (map.meshcore.dev)"
+          "map_upload_enabled": "Schakel Map Auto Uploader in (map.meshcore.io)"
         },
         "data_description": {
-          "map_upload_enabled": "Als dit is ingeschakeld, worden advertenties van repeaters en room servers die u ontvangt geüpload naar map.meshcore.dev. Die knooppunten verschijnen op de officiële MeshCore-kaart voor de community. Vereist dat export van de privésleutel op de firmware is ingeschakeld (`ENABLE_PRIVATE_KEY_EXPORT=1`); anders kunnen uploads niet worden ondertekend."
+          "map_upload_enabled": "Als dit is ingeschakeld, worden advertenties van repeaters en room servers die u ontvangt geüpload naar map.meshcore.io. Die knooppunten verschijnen op de officiële MeshCore-kaart voor de community. Vereist dat export van de privésleutel op de firmware is ingeschakeld (`ENABLE_PRIVATE_KEY_EXPORT=1`); anders kunnen uploads niet worden ondertekend."
         },
         "description": "Configureer algemene integratie-instellingen",
         "title": "Algemene Instellingen"
@@ -209,10 +209,10 @@
           "max_discovered_contacts": "Maximum aantal Ontdekte Contacten",
           "self_telemetry_enabled": "Schakel Zelf-telemetrie in",
           "self_telemetry_interval": "Zelf-telemetrie-interval (seconden)",
-          "map_upload_enabled": "Schakel Map Auto Uploader in (map.meshcore.dev)"
+          "map_upload_enabled": "Schakel Map Auto Uploader in (map.meshcore.io)"
         },
         "data_description": {
-          "map_upload_enabled": "Als dit is ingeschakeld, worden advertenties van repeaters en room servers die u ontvangt geüpload naar map.meshcore.dev. Die knooppunten verschijnen op de officiële MeshCore-kaart voor de community. Vereist dat export van de privésleutel op de firmware is ingeschakeld (`ENABLE_PRIVATE_KEY_EXPORT=1`); anders kunnen uploads niet worden ondertekend."
+          "map_upload_enabled": "Als dit is ingeschakeld, worden advertenties van repeaters en room servers die u ontvangt geüpload naar map.meshcore.io. Die knooppunten verschijnen op de officiële MeshCore-kaart voor de community. Vereist dat export van de privésleutel op de firmware is ingeschakeld (`ENABLE_PRIVATE_KEY_EXPORT=1`); anders kunnen uploads niet worden ondertekend."
         },
         "description": "Configureer algemene integratie-instellingen",
         "title": "Algemene Instellingen"

--- a/custom_components/meshcore/translations/sk.json
+++ b/custom_components/meshcore/translations/sk.json
@@ -103,10 +103,10 @@
           "max_discovered_contacts": "Maximálny počet objavených kontaktov",
           "self_telemetry_enabled": "Povoliť vlastnú telemetriu",
           "self_telemetry_interval": "Interval vlastnej telemetrie (v sekundách)",
-          "map_upload_enabled": "Povoliť Map Auto Uploader (map.meshcore.dev)"
+          "map_upload_enabled": "Povoliť Map Auto Uploader (map.meshcore.io)"
         },
         "data_description": {
-          "map_upload_enabled": "Ak je zapnuté, reklamy od repeaterov a room serverov, ktoré prijmete, sa nahrávajú na map.meshcore.dev. Tieto uzly sa zobrazia na oficiálnej mape MeshCore pre komunitu. Vyžaduje povolený export súkromného kľúča vo firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); bez toho nie je možné nahrávky podpísať."
+          "map_upload_enabled": "Ak je zapnuté, reklamy od repeaterov a room serverov, ktoré prijmete, sa nahrávajú na map.meshcore.io. Tieto uzly sa zobrazia na oficiálnej mape MeshCore pre komunitu. Vyžaduje povolený export súkromného kľúča vo firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); bez toho nie je možné nahrávky podpísať."
         },
         "description": "Konfigurácia globálnych nastavení integrácie",
         "title": "Globálne nastavenia"

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -97,7 +97,7 @@ Configure integration-wide settings:
 - **Disable Contact Discovery**: Stop automatically creating contact sensors (useful for large networks)
 - **Enable Self Telemetry**: Collect telemetry from this node
 - **Self Telemetry Interval** (60-3600 seconds): How often to collect self telemetry data
-- **Enable Map Upload (map.meshcore.dev)**: When enabled, adverts from repeaters and room servers you receive are uploaded to [map.meshcore.dev](https://map.meshcore.dev). Those nodes appear on the official MeshCore map for the community. See [Map Auto Uploader](./map-upload) for details.
+- **Enable Map Upload (map.meshcore.io)**: When enabled, adverts from repeaters and room servers you receive are uploaded to [map.meshcore.io](https://map.meshcore.io). Those nodes appear on the official MeshCore map for the community. See [Map Auto Uploader](./map-upload) for details.
 - **Adaptive Channel Message Delivery**: When enabled, incoming channel messages fire as soon as RX_LOG radio reception data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively via `meshcore_delivery_update` events. Disabled by default. See [Messaging — RX_LOG Correlation](./messaging#rx_log-correlation) for details.
 
 **Note:** Disabling contact discovery is recommended if you have 50+ contacts and only need to monitor specific tracked repeaters/clients.

--- a/docs/docs/map-upload.md
+++ b/docs/docs/map-upload.md
@@ -3,9 +3,9 @@ sidebar_position: 9
 title: Map Auto Uploader
 ---
 
-# Map Auto Uploader (map.meshcore.dev)
+# Map Auto Uploader (map.meshcore.io)
 
-When enabled, the integration automatically uploads repeater and room server adverts to [map.meshcore.dev](https://map.meshcore.dev) when your Companion hears them. No separate companion node or map uploader bot is required. This integrates the [map.meshcore.dev-uploader](https://github.com/recrof/map.meshcore.dev-uploader) bot directly into Home Assistant.
+When enabled, the integration automatically uploads repeater and room server adverts to [map.meshcore.io](https://map.meshcore.io) when your Companion hears them. No separate companion node or map uploader bot is required.
 
 ## Overview
 
@@ -19,7 +19,7 @@ When enabled, the integration automatically uploads repeater and room server adv
 
 1. Go to **Settings** → **Devices & Services**
 2. Open your **MeshCore** integration → **Configure** → **Global Settings**
-3. Enable **Enable Map Auto Uploader (map.meshcore.dev)**
+3. Enable **Enable Map Auto Uploader (map.meshcore.io)**
 
 Map Auto Uploader is **off by default**.
 
@@ -31,14 +31,14 @@ Map Auto Uploader is **off by default**.
 
 1. Your Companion receives adverts from repeaters and room servers on the mesh
 2. The integration verifies each advert and checks for replay
-3. Valid adverts are signed and uploaded to map.meshcore.dev
-4. Nodes appear on the [official map](https://map.meshcore.dev) for the community
+3. Valid adverts are signed and uploaded to map.meshcore.io
+4. Nodes appear on the [official map](https://map.meshcore.io) for the community
 
 ## Troubleshooting
 
 1. **Enable in Global Settings** — Ensure the option is enabled (see above)
 2. **Check private key export** — Firmware must have `ENABLE_PRIVATE_KEY_EXPORT=1`
-3. **Verify connectivity** — Your node must receive adverts from repeaters/room servers
+3. **Verify connectivity** — Your node must receive adverts from repeaters or room servers
 4. **Check logs** — Look for `meshcore` or Map Auto Uploader messages
 
 Common log messages:
@@ -49,7 +49,8 @@ Common log messages:
 
 ## For more info
 
-- [map.meshcore.dev-uploader](https://github.com/recrof/map.meshcore.dev-uploader) — Standalone bot (Node.js)
-- [map.meshcore.dev](https://github.com/meshcore-dev/map.meshcore.dev) — Official map (frontend)
+- [map.meshcore.io-uploader](https://github.com/recrof/map.meshcore.io-uploader) — Standalone bot (Node.js)
+- [map.meshcore.io](https://map.meshcore.io) — Official map (live site)
+- [meshcore-dev/map.meshcore.io](https://github.com/meshcore-dev/map.meshcore.io) — Map frontend source (GitHub)
 
 Many thanks to [recrof](https://github.com/recrof) for both projects.


### PR DESCRIPTION
## Summary
- Fixes companion (CHAT) adverts being uploaded to the community map because `ADVERT_TYPE_CHAT` was `0` instead of firmware `ADV_TYPE_CHAT` (`1`).
- Updates Map Auto Uploader API and user-facing strings/docs to **map.meshcore.io** and current repo links.

## Fixes
Closes #199 - *Map Uploader in 2.5.0 uploads Chat Adverts*.

## Changes
- **`map_uploader.py`**: skip uploads when `adv_type == ADV_TYPE_CHAT` (1)
- **Docs / translations / README**: `.io` domain and related GitHub URLs

## Tested
- With Map Auto Uploader enabled: repeater/room adverts still upload. Companion ADVERTs (`adv_type` 1) are not uploaded. 