### PR TITLE
Fix entity identity model violation and config change propagation

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import (
     DOMAIN,
     CONF_CONNECTION_TYPE,
+    CONF_NAME,
     CONF_USB_PATH,
     CONF_BLE_ADDRESS,
     CONF_TCP_HOST,
@@ -38,6 +39,7 @@ from .const import (
     DEFAULT_MAX_DISCOVERED_CONTACTS,
     CONF_MESSAGES_INTERVAL,
     DEFAULT_UPDATE_TICK,
+    REPAIR_PUBKEY_CHANGED,
 )
 from .coordinator import MeshCoreDataUpdateCoordinator
 from .meshcore_api import MeshCoreAPI
@@ -161,6 +163,90 @@ def _migrate_entity_ids(
     )
 
 
+def _migrate_unique_ids_remove_name(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> None:
+    """One-time migration: remove device name from unique_ids.
+
+    Entity unique_ids previously included the device name, which made them
+    unstable across name changes. This migration strips the name suffix
+    so unique_ids use only stable identifiers (entry_id, key, pubkey).
+    """
+    entity_registry = er.async_get(hass)
+    migrated = 0
+
+    # Get the current companion name from config entry
+    companion_name = entry.data.get(CONF_NAME, "")
+
+    # Build list of all names that might appear in unique_ids
+    # (companion + all tracked repeaters + all tracked clients).
+    # Sorted longest-first so that if one name is a suffix of another
+    # (e.g., "mytest" vs "test"), the longer name matches first via
+    # endswith(), preventing partial stripping.
+    names_raw: set[str] = set()
+    if companion_name:
+        names_raw.add(companion_name)
+    for sub in entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, []):
+        name = sub.get("name", "")
+        if name:
+            names_raw.add(name)
+    for sub in entry.data.get(CONF_TRACKED_CLIENTS, []):
+        name = sub.get("name", "")
+        if name:
+            names_raw.add(name)
+
+    names_to_strip = sorted(names_raw, key=len, reverse=True)
+
+    if not names_to_strip:
+        return
+
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry.entry_id:
+            continue
+
+        new_unique_id = entity.unique_id
+        for name in names_to_strip:
+            # unique_ids have the name appended with underscore separator
+            suffix = f"_{name}"
+            if new_unique_id.endswith(suffix):
+                new_unique_id = new_unique_id[: -len(suffix)]
+                break
+
+        if new_unique_id == entity.unique_id:
+            continue
+
+        # Verify the new unique_id doesn't already exist
+        existing = entity_registry.async_get_entity_id(
+            entity.domain, DOMAIN, new_unique_id
+        )
+        if existing and existing != entity.entity_id:
+            _LOGGER.warning(
+                "Cannot migrate unique_id for %s: target %s already exists (%s)",
+                entity.entity_id, new_unique_id, existing,
+            )
+            continue
+
+        try:
+            entity_registry.async_update_entity(
+                entity.entity_id,
+                new_unique_id=new_unique_id,
+            )
+            _LOGGER.info(
+                "Stabilized unique_id: %s -> %s",
+                entity.unique_id, new_unique_id,
+            )
+            migrated += 1
+        except Exception as ex:
+            _LOGGER.error(
+                "Failed to stabilize unique_id for %s: %s",
+                entity.entity_id, ex,
+            )
+
+    if migrated:
+        _LOGGER.info("Stabilized %d entity unique_ids (removed name)", migrated)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeshCore from a config entry."""
     # Home Assistant can trigger a duplicate setup during rapid reload/update cycles.
@@ -254,7 +340,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             is_fixable=False,
             is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
-            translation_key="pubkey_changed",
+            translation_key=REPAIR_PUBKEY_CHANGED,
             translation_placeholders={
                 "old_key": stored_pubkey[:12],
                 "new_key": live_pubkey[:12],
@@ -266,6 +352,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_data[CONF_PUBKEY] = live_pubkey
         hass.config_entries.async_update_entry(entry, data=new_data)
         _LOGGER.info("Stored initial public key: %s...", live_pubkey[:12])
+
+    # One-time migration: remove device name from unique_ids
+    _migrate_unique_ids_remove_name(hass, entry)
 
     # TODO: remove this with contact refresh interval migration?
     # Get the messages interval for base update frequency

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -552,7 +552,6 @@ class RateLimiterSensor(CoordinatorEntity, SensorEntity):
             coordinator.config_entry.entry_id,
             "rate_limiter_tokens",
             public_key_short,
-            raw_device_name
         ])
 
         self.entity_id = format_entity_id(
@@ -622,7 +621,6 @@ class LastMessageDeliverySensor(CoordinatorEntity, SensorEntity):
             coordinator.config_entry.entry_id,
             "last_message_delivery",
             public_key_short,
-            raw_device_name
         ])
 
         self.entity_id = format_entity_id(
@@ -814,7 +812,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
         public_key_short = coordinator.pubkey[:6] if coordinator.pubkey else ""
 
         # Set unique ID using consistent format - filter out any empty parts
-        parts = [part for part in [coordinator.config_entry.entry_id, description.key, public_key_short, raw_device_name] if part]
+        parts = [part for part in [coordinator.config_entry.entry_id, description.key, public_key_short] if part]
         self._attr_unique_id = "_".join(parts)
 
         self.entity_id = format_entity_id(
@@ -888,47 +886,52 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
         elif key == "tx_power":
             def update_tx(event: Event):
                 self._native_value = event.payload.get("tx_power")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_tx,
             )
-            
+
         elif key == "latitude":
             def update_lat(event: Event):
                 self._native_value = event.payload.get("adv_lat")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_lat,
             )
-            
+
         elif key == "longitude":
             def update_lon(event: Event):
                 self._native_value = event.payload.get("adv_lon")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_lon,
             )
-            
+
         elif key == "frequency":
             def update_freq(event: Event):
                 self._native_value = event.payload.get("radio_freq")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_freq,
             )
-            
-            
+
         elif key == "bandwidth":
             def update_bw(event: Event):
                 self._native_value = event.payload.get("radio_bw")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_bw,
             )
-            
+
         elif key == "spreading_factor":
             def update_sf(event: Event):
                 self._native_value = event.payload.get("radio_sf")
+                self.async_write_ha_state()
             meshcore.dispatcher.subscribe(
                 EventType.SELF_INFO,
                 update_sf,
@@ -1056,8 +1059,8 @@ class MeshCoreReliabilitySensor(CoordinatorEntity, SensorEntity):
 
         self.device_id = f"{coordinator.config_entry.entry_id}_{node_type}_{self.pubkey_prefix}"
         device_name = f"MeshCore {node_type.title()}: {self.node_name} ({self.public_key_short})"
-        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}_{self.node_name}"
-        
+        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}"
+
         self.entity_id = format_entity_id(
             ENTITY_DOMAIN_SENSOR,
             self.pubkey_prefix[:10],
@@ -1123,8 +1126,8 @@ class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
         device_name = f"MeshCore {node_type.title()}: {self.node_name} ({self.public_key_short})"
         
         # Set unique ID
-        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}_{self.node_name}"
-        
+        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}"
+
         # Set entity ID
         self.entity_id = format_entity_id(
             ENTITY_DOMAIN_SENSOR,
@@ -1222,7 +1225,7 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
         device_name = f"MeshCore Repeater: {self.repeater_name} ({self.public_key_short})"
         
         # Set unique ID
-        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}_{self.repeater_name}"
+        self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}"
         
         # Set entity ID
         self.entity_id = format_entity_id(

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -16,6 +16,24 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.const import MAJOR_VERSION
 from meshcore.events import EventType
 
+# Commands that modify values reported in SELF_INFO.
+# After these succeed, send_appstart() refreshes cached self_info
+# so sensors and name-change detection pick up the new values.
+_SELF_INFO_COMMANDS = frozenset({
+    "set_radio",
+    "set_tx_power",
+    "set_name",
+    "set_coords",
+    "set_multi_acks",
+    "set_advert_loc_policy",
+    "set_path_hash_mode",
+    "set_telemetry_mode_base",
+    "set_telemetry_mode_loc",
+    "set_telemetry_mode_env",
+    "set_manual_add_contacts",
+    "import_private_key",
+})
+
 from .const import (
     ATTR_PUBKEY_PREFIX,
     DOMAIN,
@@ -628,6 +646,18 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
                     _LOGGER.debug("Executing %s args=%s kwargs=%s", command_name, prepared_args, prepared_kwargs)
                     result = await command_method(*prepared_args, **prepared_kwargs)
+
+                    # Refresh SELF_INFO after commands that modify config values
+                    # so HA sensors immediately reflect the new state.
+                    if command_name in _SELF_INFO_COMMANDS and result.type != EventType.ERROR:
+                        try:
+                            appstart_result = await api.mesh_core.commands.send_appstart()
+                            api._cache_self_info_event(appstart_result)
+                        except Exception as ex:
+                            _LOGGER.warning(
+                                "Failed to refresh SELF_INFO after %s: %s",
+                                command_name, ex,
+                            )
 
                     # Update coordinator channel info after set_channel
                     if command_name == "set_channel" and result.type != EventType.ERROR:


### PR DESCRIPTION
## Summary

Six entity classes include the device name in their `unique_id`, which violates Home Assistant's entity identity model. HA requires `unique_id` to be immutable for the lifetime of an entity — it's the permanent key in the entity registry. Because device names can change (via `set_name`, repeater renames, etc.), any name change either orphans existing entities or creates duplicates, depending on how reconstruction happens.

This PR stabilizes `unique_id` by removing the name component, ensures runtime config changes propagate to sensors immediately (no restart required), and fixes missing state-write calls in six SELF_INFO sensor handlers.

A detailed forensics report documenting the original investigation is available here: https://gist.github.com/mwolter805/060566596c3951d45f5acdcf90293dc6

## The Problem

### Entity identity violation

HA's [entity registry documentation](https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements) states that `unique_id` must be stable and never change. The following entity classes currently include the device name in their `unique_id`:

| Entity Class | Current `unique_id` | Fixed `unique_id` |
|---|---|---|
| `MeshCoreSensor` | `{entry_id}_{key}_{pubkey[:6]}_{name}` | `{entry_id}_{key}_{pubkey[:6]}` |
| `RateLimiterSensor` | `{entry_id}_rate_limiter_tokens_{pubkey[:6]}_{name}` | `{entry_id}_rate_limiter_tokens_{pubkey[:6]}` |
| `LastMessageDeliverySensor` | `{entry_id}_last_message_delivery_{pubkey[:6]}_{name}` | `{entry_id}_last_message_delivery_{pubkey[:6]}` |
| `MeshCoreReliabilitySensor` | `{entry_id}_{type}_{pubkey}_{key}_{pubkey[:6]}_{name}` | `{entry_id}_{type}_{pubkey}_{key}_{pubkey[:6]}` |
| `MeshCorePathSensor` | `{entry_id}_{type}_{pubkey}_{key}_{pubkey[:6]}_{name}` | `{entry_id}_{type}_{pubkey}_{key}_{pubkey[:6]}` |
| `MeshCoreRepeaterSensor` | `{entry_id}_repeater_{pubkey}_{key}_{pubkey[:6]}_{name}` | `{entry_id}_repeater_{pubkey}_{key}_{pubkey[:6]}` |

When a user renames their companion device or a tracked repeater changes its advertised name, HA sees a "new" entity (different `unique_id`) and orphans the old one. Over time this silently accumulates dead entities in the registry.

### No SELF_INFO refresh after config commands

When a user changes device configuration at runtime via `execute_command` (e.g., `set_radio`, `set_tx_power`, `set_name`, `set_coords`), the firmware applies the change immediately. But the integration never requests the device's updated configuration afterward, so HA sensors continue showing stale values until the next restart or reload.

### Missing `async_write_ha_state()` in sensor handlers

Six SELF_INFO-driven sensors (`tx_power`, `latitude`, `longitude`, `frequency`, `bandwidth`, `spreading_factor`) update their internal `_native_value` when a SELF_INFO event arrives, but never call `async_write_ha_state()` to notify HA. The updated values sit in memory until an unrelated coordinator cycle happens to trigger a state write. Dashboard cards and automations see stale data for an unpredictable duration.

## The Fix

### 1. `unique_id` stabilization (one-time migration)

`_migrate_unique_ids_remove_name()` runs at startup and strips the device name suffix from all entity `unique_id` values in the entity registry. After migration, `unique_id` uses only stable identifiers (`entry_id`, `key`, `pubkey`) and survives name changes without duplication or orphaning.

The migration is safe to re-run (idempotent) and checks for collisions before updating.

### 2. SELF_INFO refresh after config commands

A `_SELF_INFO_COMMANDS` set identifies commands that modify values reported in SELF_INFO (`set_radio`, `set_tx_power`, `set_name`, `set_coords`, and others). After any of these succeed, `send_appstart()` is called to refresh the cached SELF_INFO so sensors pick up the new values immediately.

### 3. `async_write_ha_state()` added to 6 sensor handlers

The `tx_power`, `latitude`, `longitude`, `frequency`, `bandwidth`, and `spreading_factor` SELF_INFO event handlers now call `self.async_write_ha_state()` after updating `_native_value`, matching the pattern used by other sensors in the same codebase (`node_count`, `CompanionPrefixSensor`).

## Changes

| File | What changed |
|---|---|
| `__init__.py` | Added `_migrate_unique_ids_remove_name()` idempotent startup migration |
| `sensor.py` | Removed name from `unique_id` in 6 entity classes, added `async_write_ha_state()` to 6 SELF_INFO handlers |
| `services.py` | Added `_SELF_INFO_COMMANDS` set and post-command `send_appstart()` refresh |

Net diff against `main`: 3 files, +137 / -15.

## Testing

Tested on a live HA host with a MeshCore companion device and multiple tracked repeaters:

- Changed radio frequency via `set_radio` — frequency sensor updated within seconds (previously required restart)
- Exercised each of the 6 SELF_INFO sensors — all wrote state immediately after the value changed
- Verified one-time `unique_id` migration stripped name suffix from all affected entities on first startup after update
- Confirmed migration is idempotent — no changes on subsequent restarts
- Renamed companion via `set_name` — display name updates via `has_entity_name`; entity_ids stay put (intentional); no duplication or orphaning, since `unique_id` no longer carries the name

## Known limitation: pubkey in unique_id

The companion device's `pubkey[:6]` (and in some entity classes the full `pubkey`) remains in `unique_id` after this PR. This is also technically a mutable value — a firmware reflash or factory reset changes the public key. However, this is already mitigated by the existing `_migrate_entity_ids()` function, which detects pubkey changes at startup and rewrites all entity IDs and unique IDs to use the new prefix.

For companion entities, `entry_id` alone already uniquely scopes to one device, making the pubkey in `unique_id` redundant. Removing it would make companion entity `unique_id` values truly immutable. For tracked repeaters/clients, pubkey is structurally necessary to distinguish entities under the same config entry. This could be addressed in a follow-up PR — scoped out of this one to keep the change focused on the name-related identity violation and config propagation fixes.

## No breaking changes

- The `unique_id` migration is transparent — HA preserves entity history, customizations, and automation references through `unique_id` updates
- Entity IDs (the user-facing identifiers) are unchanged by this PR. `has_entity_name` continues to update the display name when a device is renamed; the entity_id itself stays put. This is intentional — silently renaming entity_ids would break existing automations, dashboards, and scripts.