### PR TITLE
Add per-device online binary sensor for managed repeaters and clients

### DIFF
--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -26,6 +26,7 @@ from .const import (
     MESSAGES_SUFFIX,
     CHANNEL_PREFIX,
     CONTACT_SUFFIX,
+    ONLINE_SUFFIX,
     NodeType,
 )
 from .utils import (
@@ -259,6 +260,21 @@ async def async_setup_entry(
         ]
         if mqtt_entities:
             async_add_entities(mqtt_entities)
+
+    # Create online status binary sensors for managed devices
+    online_entities = []
+    for repeater_config in coordinator._tracked_repeaters:
+        if repeater_config.get("pubkey_prefix"):
+            online_entities.append(
+                MeshCoreDeviceOnlineBinarySensor(coordinator, repeater_config, "repeater")
+            )
+    for client_config in coordinator._tracked_clients:
+        if client_config.get("pubkey_prefix"):
+            online_entities.append(
+                MeshCoreDeviceOnlineBinarySensor(coordinator, client_config, "client")
+            )
+    if online_entities:
+        async_add_entities(online_entities)
 
     # Subscribe to our internal message sent event for outgoing messages
     @callback
@@ -669,5 +685,76 @@ class MeshCoreContactDiagnosticBinarySensor(CoordinatorEntity, BinarySensorEntit
         if last_advert > 0:
             last_advert_time = datetime.fromtimestamp(last_advert)
             attributes["last_advert_formatted"] = last_advert_time.isoformat()
-            
+
         return attributes
+
+
+class MeshCoreDeviceOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor indicating whether a managed device (repeater/client) is online.
+
+    Derives status from coordinator._last_successful_request timing rather than
+    the global companion BLE/serial connected flag.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        node_config: dict,
+        node_type: str,
+    ) -> None:
+        """Initialize the device online binary sensor."""
+        super().__init__(coordinator)
+
+        self._node_type = node_type
+        self._node_name = node_config.get("name", "Unknown")
+        self.pubkey_prefix = node_config.get("pubkey_prefix", "")
+
+        entry_id = coordinator.config_entry.entry_id
+        device_id = f"{entry_id}_{node_type}_{self.pubkey_prefix}"
+        pubkey_short = self.pubkey_prefix[:10]
+        safe_name = sanitize_name(self._node_name)
+
+        self._attr_unique_id = f"{device_id}_{ONLINE_SUFFIX}_{pubkey_short}_{safe_name}"
+        self._attr_name = "Online"
+
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_BINARY_SENSOR,
+            pubkey_short,
+            ONLINE_SUFFIX,
+            safe_name,
+        )
+
+    @property
+    def device_info(self):
+        """Attach to the existing managed device."""
+        entry_id = self.coordinator.config_entry.entry_id
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{entry_id}_{self._node_type}_{self.pubkey_prefix}")},
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if device is online, False if offline, None if unknown."""
+        if not self.coordinator.api.connected:
+            return False
+        last_success = self.coordinator._last_successful_request.get(self.pubkey_prefix)
+        if last_success is None:
+            return None  # renders as "unknown" in HA
+        update_interval = self.coordinator.get_device_update_interval(self.pubkey_prefix)
+        staleness_window = max(update_interval, 300) * 2.5
+        return (time.time() - last_success) < staleness_window
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Return timing context for the online status."""
+        attrs: Dict[str, Any] = {}
+        last_success = self.coordinator._last_successful_request.get(self.pubkey_prefix)
+        if last_success is not None:
+            attrs["last_successful_request"] = datetime.fromtimestamp(last_success).isoformat()
+        update_interval = self.coordinator.get_device_update_interval(self.pubkey_prefix)
+        attrs["update_interval"] = update_interval
+        attrs["staleness_window"] = max(update_interval, 300) * 2.5
+        return attrs

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -57,6 +57,7 @@ ENTITY_DOMAIN_SENSOR: Final = "sensor"
 DEFAULT_DEVICE_NAME: Final = "meshcore"
 MESSAGES_SUFFIX: Final = "messages"
 CONTACT_SUFFIX: Final = "contact"
+ONLINE_SUFFIX: Final = "online"
 CHANNEL_PREFIX: Final = "ch_"
 
 # Repeater subscription constants

--- a/docs/docs/sensors.md
+++ b/docs/docs/sensors.md
@@ -222,6 +222,26 @@ Binary sensors showing node freshness:
   - On = Fresh (recent activity within 12 hours)
   - Off = Stale (no recent activity)
 
+#### Device Online Status
+
+A per-device connectivity sensor for each managed repeater and client. Unlike the integration-level connection sensor (which reports whether the companion device itself is reachable via USB/TCP/BLE), this sensor reflects whether a specific managed node is being successfully polled.
+
+- **Entity**: `binary_sensor.meshcore_<pubkey>_online_<name>`
+- **Device Class**: Connectivity
+- **States**:
+  - **On** — the last successful poll for this device was within the staleness window
+  - **Off** — the companion device is disconnected, or no successful poll within the staleness window
+  - **Unknown** — the device has never been successfully polled this session
+
+**Staleness window**: `2.5 × max(device_update_interval, 300s)`. Defaults to 12.5 minutes for a device on the default 5-minute update cadence. Increases proportionally for devices configured with slower refresh rates.
+
+**Attributes**
+- `last_successful_request` — ISO 8601 timestamp of the most recent successful poll
+- `update_interval` — the device's configured telemetry refresh rate, in seconds
+- `staleness_window` — the current threshold, in seconds
+
+**Why this exists alongside the node status sensor**: The `sensor.meshcore_..._node_status` entity reports the companion device's own connection state (USB / TCP / BLE link up). A repeater or client tracked by the integration can stop responding while the companion stays connected — for example, when the remote node is out of range, powered off, or when its routing path has degraded. This sensor distinguishes those two failure modes.
+
 #### Message Tracking
 Binary sensors created on first message:
 


### PR DESCRIPTION
### Summary

Adds a per-device connectivity binary sensor (`binary_sensor.meshcore_<pubkey>_online_<name>`) for every managed repeater and client. It reports whether that *specific remote node* is currently being polled successfully — which is different from whether the companion device's USB/TCP/BLE link is up.

### Why

The existing `sensor.meshcore_..._node_status` entity reports the **companion** device's connection state — i.e., is the LoRa radio itself reachable from Home Assistant. That's useful, but it's not a per-node health signal: a tracked repeater or client can stop responding (out of range, powered off, degraded routing path) while the companion stays connected, and today there is no cheap way to alert on that.

This PR adds a dedicated sensor per managed device with a staleness-based definition of "online," so users can build the obvious automations (notify when node X goes silent, dashboard cards that grey-out offline nodes, conditional routing in scripts) without custom templates.

The sensor is consumed by the upcoming MeshCore sidebar panel for its connection-state indicators, but it's a fully native HA entity on its own — no frontend required to use it.

### What changes

**New entity (one per tracked repeater/client):**

- `binary_sensor.meshcore_<pubkey>_online_<name>`
- Device class: `connectivity`
- States:
  - **On** — last successful poll for this device was within the staleness window
  - **Off** — companion device is disconnected, OR no successful poll within the staleness window
  - **Unknown** — device has never been successfully polled this session

**Staleness window:** `2.5 × max(device_update_interval, 300s)` — scales with each device's configured refresh rate. A node on the default 5-minute update cadence becomes "off" after 12.5 minutes of no successful polls. A device configured to poll every 10 minutes gets a 25-minute window.

**Attributes:**

- `last_successful_request` — ISO 8601 timestamp of the most recent successful poll
- `update_interval` — device's configured telemetry refresh rate (seconds)
- `staleness_window` — current threshold (seconds)

### Changes primarily serve the frontend, but are useful on their own

This series of PRs (along with `feature/message-store` and `feature/repeater-neighbors`) exists mainly to support the upcoming sidebar-panel frontend work. That said, each new entity, service, or attribute is a first-class HA object and is fully usable from YAML automations, templates, scripts, and REST/WebSocket consumers. You do not need the sidebar panel to benefit from this PR.

Concrete non-frontend use cases for this sensor:

- **Alerting** — trigger a notification when a critical repeater goes `off` for more than N minutes.
- **Conditional automations** — only run an automation if the target node has been `on` recently.
- **Dashboard health grids** — colour entity cards by `state` of the online sensor across all nodes.
- **Template fan-in** — count online vs total managed devices and publish a mesh-uptime percentage sensor.

### Documentation

Adds a "Device Online Status" section to `docs/docs/sensors.md` under Binary Sensors, covering the entity naming pattern, state semantics, staleness formula, and the distinction vs `sensor.meshcore_..._node_status`.

### Related / upcoming

Companion PRs planned from this work: `feature/message-store` (persistent per-conversation message store), `feature/repeater-neighbors` (repeater neighbor SNR/activity sensors). The sidebar-panel frontend that consumes all three is tracked separately and will follow.