### PR TITLE
Add per-conversation message store with search and bounded retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ script_venv
 __pycache__/
 *.pyc
 .pytest_cache/
-node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ script_venv
 __pycache__/
 *.pyc
 .pytest_cache/
+node_modules/

--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -44,6 +44,7 @@ from .meshcore_api import MeshCoreAPI
 from .map_uploader import MeshCoreMapUploader
 from .mqtt_uploader import MeshCoreMqttUploader
 from .services import async_setup_services, async_unload_services
+from .ws_api import async_register_ws_commands
 from .utils import (
     create_message_correlation_key,
     parse_and_decrypt_rx_log,
@@ -362,7 +363,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     
     # Set up all platforms for this device
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
+
+    # Initialize persistent message store
+    await coordinator.message_store_startup()
+    await coordinator.cleanup_old_messages()
+
+    # Register WebSocket commands for message store
+    async_register_ws_commands(hass)
+
     # Register static paths for icons
     should_cache = False
     icons_path = Path(__file__).parent / "www" / "icons"
@@ -561,6 +569,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for remove_listener in coordinator._remove_listeners:
                 remove_listener()
                 
+        # Flush message store before disconnect
+        await coordinator.flush_message_stores()
+
         # Disconnect from the device
         if getattr(coordinator, "mqtt_uploader", None):
             await coordinator.mqtt_uploader.async_stop()

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -146,6 +146,12 @@ CONF_ADAPTIVE_POLL_WAIT: Final = "adaptive_poll_wait"
 # Sensor availability timeout multiplier
 SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER: Final = 3
 
+# Message store settings
+DEFAULT_MESSAGE_RETENTION_DAYS: Final = 90
+DEFAULT_MAX_MESSAGES_PER_CONVERSATION: Final = 500
+MESSAGE_STORE_SAVE_DELAY_SECONDS: Final = 5.0
+MESSAGE_STORE_IDLE_EVICTION_SECONDS: Final = 300  # 5 minutes
+
 
 class NodeType(IntEnum):
     CLIENT = 1

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import random
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict
 
 from cachetools import TTLCache
@@ -49,8 +49,13 @@ from .const import (
     RATE_LIMITER_REFILL_RATE_SECONDS,
     RX_LOG_CACHE_MAX_SIZE,
     RX_LOG_CACHE_TTL_SECONDS,
+    DEFAULT_MESSAGE_RETENTION_DAYS,
+    DEFAULT_MAX_MESSAGES_PER_CONVERSATION,
+    MESSAGE_STORE_SAVE_DELAY_SECONDS,
+    MESSAGE_STORE_IDLE_EVICTION_SECONDS,
 )
 from .meshcore_api import MeshCoreAPI
+from .utils import generate_message_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -198,6 +203,22 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # Dirty contacts tracking for performance optimization
         # Set of pubkey prefixes that have been updated and need sensor refresh
         self._dirty_contacts = set()
+
+        # === Message Store (per-conversation lazy loading) ===
+        # Lightweight index — always in memory after startup
+        self._message_index_store = Store[dict](
+            hass, 1, f"meshcore.{config_entry.entry_id}.message_index"
+        )
+        self._message_index: dict[str, dict] = {}
+        # Per-conversation data — loaded on demand, evicted when idle
+        self._loaded_conversations: dict[str, list[dict]] = {}
+        self._conversation_stores: dict[str, Store] = {}
+        self._conversation_dirty: set[str] = set()
+        self._conversation_last_access: dict[str, float] = {}
+        # Timers for debounced saves and idle eviction
+        self._msg_save_timers: dict[str, asyncio.TimerHandle | None] = {}
+        self._index_save_timer: asyncio.TimerHandle | None = None
+        self._eviction_timer: asyncio.TimerHandle | None = None
 
     def mark_contact_dirty(self, pubkey_prefix: str):
         """Mark a contact as needing update (for performance optimization).
@@ -1144,3 +1165,325 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.warning(f"Could not find contact for client telemetry request: {pubkey_prefix}")
 
         return result_data
+
+    # ═══════════════════════════════════════════════════════════════════════
+    # Message Store — per-conversation persistent storage
+    # ═══════════════════════════════════════════════════════════════════════
+
+    async def message_store_startup(self) -> None:
+        """Load the lightweight message index at integration startup.
+
+        Called from async_setup_entry. Only loads the index (~100 bytes per
+        conversation), not any conversation message data.
+        """
+        stored = await self._message_index_store.async_load()
+        self._message_index = stored or {}
+        _LOGGER.debug(
+            "Message store index loaded: %d conversations tracked",
+            len(self._message_index),
+        )
+
+    async def _ensure_loaded(self, entity_id: str) -> list[dict]:
+        """Load a conversation's messages into memory if not already cached."""
+        if entity_id in self._loaded_conversations:
+            self._conversation_last_access[entity_id] = time.time()
+            return self._loaded_conversations[entity_id]
+
+        # Create Store instance if needed
+        if entity_id not in self._conversation_stores:
+            safe_id = entity_id.replace(".", "_")
+            self._conversation_stores[entity_id] = Store[list](
+                self.hass, 1,
+                f"meshcore.{self.config_entry.entry_id}.msgs.{safe_id}",
+            )
+
+        stored = await self._conversation_stores[entity_id].async_load()
+        messages = stored or []
+        self._loaded_conversations[entity_id] = messages
+        self._conversation_last_access[entity_id] = time.time()
+        self._schedule_eviction()
+        return messages
+
+    async def _load_for_search(self, entity_id: str) -> list[dict]:
+        """Load a conversation for read-only search without caching.
+
+        If the conversation is already cached (user has it open), returns the
+        cached copy. Otherwise loads from disk and returns a transient copy
+        that is NOT stored in _loaded_conversations — preventing search from
+        inflating memory with idle conversations.
+        """
+        # If already in memory, return the cached copy (no side effects)
+        if entity_id in self._loaded_conversations:
+            return self._loaded_conversations[entity_id]
+
+        # Load from disk without caching
+        if entity_id not in self._conversation_stores:
+            safe_id = entity_id.replace(".", "_")
+            self._conversation_stores[entity_id] = Store[list](
+                self.hass, 1,
+                f"meshcore.{self.config_entry.entry_id}.msgs.{safe_id}",
+            )
+
+        stored = await self._conversation_stores[entity_id].async_load()
+        return stored or []
+
+    async def store_message(self, entity_id: str, message: dict) -> None:
+        """Store a message record for a conversation."""
+        messages = await self._ensure_loaded(entity_id)
+
+        # Dedup by ID (check recent messages only)
+        msg_id = message.get("id", "")
+        if msg_id and any(m.get("id") == msg_id for m in messages[-50:]):
+            return
+
+        messages.append(message)
+
+        # Enforce per-conversation limit
+        max_per_conv = self.config_entry.options.get(
+            "max_messages_per_conversation",
+            DEFAULT_MAX_MESSAGES_PER_CONVERSATION,
+        )
+        if len(messages) > max_per_conv:
+            messages[:] = messages[-max_per_conv:]
+
+        self._conversation_dirty.add(entity_id)
+        self._schedule_conversation_save(entity_id)
+
+        # Update lightweight index
+        self._message_index[entity_id] = {
+            "message_count": len(messages),
+            "last_message_ts": message.get("timestamp", ""),
+            "last_sender": message.get("sender", ""),
+            "last_preview": (message.get("text", "") or "")[:50],
+        }
+        self._schedule_index_save()
+
+    async def update_message_rx_data(
+        self, entity_id: str, message_id: str, rx_log_data: list
+    ) -> None:
+        """Update rx_log_data on an existing stored message."""
+        messages = await self._ensure_loaded(entity_id)
+        for m in reversed(messages):  # search newest first
+            if m.get("id") == message_id:
+                m["rx_log_data"] = rx_log_data
+                m["repeater_count"] = len(rx_log_data)
+                self._conversation_dirty.add(entity_id)
+                self._schedule_conversation_save(entity_id)
+                return
+
+    async def update_message_delivery(
+        self, entity_id: str, message_id: str, status: str, **kwargs
+    ) -> None:
+        """Update delivery status on a stored message (ACK, round trip, etc.)."""
+        messages = await self._ensure_loaded(entity_id)
+        for m in reversed(messages):
+            if m.get("id") == message_id:
+                m["delivery_status"] = status
+                m.update(kwargs)
+                self._conversation_dirty.add(entity_id)
+                self._schedule_conversation_save(entity_id)
+                return
+
+    async def get_messages(
+        self, entity_id: str, limit: int = 50,
+        before: str | None = None, after: str | None = None
+    ) -> list[dict]:
+        """Get messages for a conversation with cursor pagination.
+
+        Args:
+            before: Return messages older than this message ID (for lazy-load scrollback).
+            after: Return messages newer than this message ID (for incremental poll).
+        """
+        messages = await self._ensure_loaded(entity_id)
+        if before:
+            idx = next(
+                (i for i, m in enumerate(messages) if m.get("id") == before),
+                len(messages),
+            )
+            messages = messages[:idx]
+        if after:
+            idx = next(
+                (i for i, m in enumerate(messages) if m.get("id") == after),
+                -1,
+            )
+            if idx >= 0:
+                messages = messages[idx + 1:]
+            # For 'after' queries, return oldest-first (up to limit)
+            return messages[:limit]
+        return messages[-limit:]
+
+    def get_message_index(self) -> dict[str, dict]:
+        """Return the lightweight message index (always in memory)."""
+        return self._message_index
+
+    # --- Save scheduling (debounced) ---
+
+    def _schedule_conversation_save(self, entity_id: str) -> None:
+        """Debounce per-conversation store writes."""
+        existing = self._msg_save_timers.get(entity_id)
+        if existing is not None:
+            existing.cancel()
+        self._msg_save_timers[entity_id] = self.hass.loop.call_later(
+            MESSAGE_STORE_SAVE_DELAY_SECONDS,
+            lambda eid=entity_id: self.hass.async_create_task(
+                self._save_conversation(eid)
+            ),
+        )
+
+    async def _save_conversation(self, entity_id: str) -> None:
+        """Save a single conversation to disk."""
+        self._msg_save_timers.pop(entity_id, None)
+        if entity_id not in self._loaded_conversations:
+            return
+        if entity_id not in self._conversation_stores:
+            return
+        try:
+            await self._conversation_stores[entity_id].async_save(
+                self._loaded_conversations[entity_id]
+            )
+            self._conversation_dirty.discard(entity_id)
+        except Exception as ex:
+            _LOGGER.error("Error saving conversation %s: %s", entity_id, ex)
+
+    def _schedule_index_save(self) -> None:
+        """Debounce index store writes."""
+        if self._index_save_timer is not None:
+            self._index_save_timer.cancel()
+        self._index_save_timer = self.hass.loop.call_later(
+            MESSAGE_STORE_SAVE_DELAY_SECONDS,
+            lambda: self.hass.async_create_task(self._save_index()),
+        )
+
+    async def _save_index(self) -> None:
+        """Save the message index to disk."""
+        self._index_save_timer = None
+        try:
+            await self._message_index_store.async_save(self._message_index)
+        except Exception as ex:
+            _LOGGER.error("Error saving message index: %s", ex)
+
+    # --- Idle eviction ---
+
+    def _schedule_eviction(self) -> None:
+        """Schedule idle conversation eviction check."""
+        if self._eviction_timer is not None:
+            self._eviction_timer.cancel()
+        self._eviction_timer = self.hass.loop.call_later(
+            MESSAGE_STORE_IDLE_EVICTION_SECONDS,
+            lambda: self.hass.async_create_task(self._evict_idle()),
+        )
+
+    async def _evict_idle(self) -> None:
+        """Save and unload conversations not accessed in 5+ minutes."""
+        self._eviction_timer = None
+        cutoff = time.time() - MESSAGE_STORE_IDLE_EVICTION_SECONDS
+        evicted = []
+        for entity_id in list(self._loaded_conversations):
+            if self._conversation_last_access.get(entity_id, 0) < cutoff:
+                # Save if dirty
+                if entity_id in self._conversation_dirty:
+                    await self._save_conversation(entity_id)
+                # Unload from memory
+                del self._loaded_conversations[entity_id]
+                self._conversation_last_access.pop(entity_id, None)
+                evicted.append(entity_id)
+
+        if evicted:
+            _LOGGER.debug("Evicted %d idle conversation(s) from memory", len(evicted))
+
+        # Reschedule if there are still loaded conversations
+        if self._loaded_conversations:
+            self._schedule_eviction()
+
+    # --- Flush / cleanup ---
+
+    async def flush_message_stores(self) -> None:
+        """Save all dirty conversations and the index to disk.
+
+        Called at integration unload to ensure no data is lost.
+        """
+        # Cancel pending timers
+        for timer in self._msg_save_timers.values():
+            if timer is not None:
+                timer.cancel()
+        self._msg_save_timers.clear()
+        if self._index_save_timer is not None:
+            self._index_save_timer.cancel()
+            self._index_save_timer = None
+        if self._eviction_timer is not None:
+            self._eviction_timer.cancel()
+            self._eviction_timer = None
+
+        # Save all dirty conversations
+        for entity_id in list(self._conversation_dirty):
+            if entity_id in self._loaded_conversations:
+                store = self._conversation_stores.get(entity_id)
+                if store:
+                    try:
+                        await store.async_save(self._loaded_conversations[entity_id])
+                    except Exception as ex:
+                        _LOGGER.error("Error flushing conversation %s: %s", entity_id, ex)
+        self._conversation_dirty.clear()
+
+        # Save index
+        try:
+            await self._message_index_store.async_save(self._message_index)
+        except Exception as ex:
+            _LOGGER.error("Error flushing message index: %s", ex)
+
+    async def cleanup_old_messages(self) -> None:
+        """Remove messages older than retention period.
+
+        Called at integration startup and can be scheduled daily.
+        Uses transient loading to avoid caching all conversations in memory.
+        """
+        retention_days = self.config_entry.options.get(
+            "message_retention_days", DEFAULT_MESSAGE_RETENTION_DAYS
+        )
+        cutoff = datetime.now() - timedelta(days=retention_days)
+        cutoff_iso = cutoff.isoformat()
+        total_pruned = 0
+
+        for entity_id in list(self._message_index.keys()):
+            # If already cached (user has conversation open), prune in-place
+            if entity_id in self._loaded_conversations:
+                messages = self._loaded_conversations[entity_id]
+                original_count = len(messages)
+                messages[:] = [m for m in messages if m.get("timestamp", "") > cutoff_iso]
+                trimmed = original_count - len(messages)
+                if trimmed > 0:
+                    total_pruned += trimmed
+                    self._conversation_dirty.add(entity_id)
+                    if messages:
+                        self._message_index[entity_id]["message_count"] = len(messages)
+                    else:
+                        del self._message_index[entity_id]
+                continue
+
+            # Not cached — load transiently, prune, save, discard
+            if entity_id not in self._conversation_stores:
+                safe_id = entity_id.replace(".", "_")
+                self._conversation_stores[entity_id] = Store[list](
+                    self.hass, 1,
+                    f"meshcore.{self.config_entry.entry_id}.msgs.{safe_id}",
+                )
+            stored = await self._conversation_stores[entity_id].async_load()
+            messages = stored or []
+            original_count = len(messages)
+            messages = [m for m in messages if m.get("timestamp", "") > cutoff_iso]
+            trimmed = original_count - len(messages)
+
+            if trimmed > 0:
+                total_pruned += trimmed
+                await self._conversation_stores[entity_id].async_save(messages)
+                if messages:
+                    self._message_index[entity_id]["message_count"] = len(messages)
+                else:
+                    del self._message_index[entity_id]
+
+        if total_pruned > 0:
+            _LOGGER.info(
+                "Message retention cleanup: pruned %d messages older than %d days",
+                total_pruned, retention_days,
+            )
+            self._schedule_index_save()

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -26,7 +26,6 @@ EVENT_MESHCORE_MESSAGE = "meshcore_message"
 # Lightweight event for progressive delivery sensor updates (not logged)
 EVENT_MESHCORE_DELIVERY_UPDATE = "meshcore_delivery_update"
 
-
 @callback
 def async_describe_events(
     hass: HomeAssistant,
@@ -87,10 +86,16 @@ async def handle_channel_message(event, coordinator) -> None:
 
                 # Use the provided coordinator for contact lookup
                 if coordinator and hasattr(coordinator, "api") and coordinator.api.mesh_core:
-                    # Try to find contact by name to get public key
+                    # Try saved contacts first (SDK), then discovered contacts
                     contact = coordinator.api.mesh_core.get_contact_by_name(sender_name)
                     if contact and isinstance(contact, dict):
                         sender_pubkey = contact.get("public_key", "")[:12]
+                    elif hasattr(coordinator, "_discovered_contacts"):
+                        # Search discovered contacts by advertised name
+                        for full_pk, disc in coordinator._discovered_contacts.items():
+                            if disc.get("adv_name") == sender_name:
+                                sender_pubkey = full_pk[:12]
+                                break
 
         # Check for Home Assistant instance
         if not hasattr(coordinator, "hass"):
@@ -178,17 +183,10 @@ async def handle_channel_message(event, coordinator) -> None:
         # Fire the meshcore_message event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)
 
-        # In adaptive mode, start background collection for late-arriving
-        # repeater RX_LOGs (progressive delivery updates).
-        if adaptive and hash_key is not None:
-            hass.async_create_task(
-                _collect_incoming_rx_logs(
-                    hass, coordinator, hash_key, event_data
-                )
-            )
-
-        # Store in persistent message store
-        msg_id = generate_message_id(event_data["timestamp"], sender_name, message_text)
+        # Store message with full metadata in the message store
+        msg_id = generate_message_id(
+            event_data["timestamp"], sender_name, message_text
+        )
         await coordinator.store_message(entity_id, {
             "id": msg_id,
             "sender": sender_name,
@@ -202,6 +200,15 @@ async def handle_channel_message(event, coordinator) -> None:
             "rx_log_data": event_data.get("rx_log_data", []),
             "delivery_status": "sent",
         })
+
+        # In adaptive mode, start background collection for late-arriving
+        # repeater RX_LOGs (progressive delivery updates).
+        if adaptive and hash_key is not None:
+            hass.async_create_task(
+                _collect_incoming_rx_logs(
+                    hass, coordinator, hash_key, event_data
+                )
+            )
 
         _LOGGER.debug(
             "Logged channel message in %s from %s%s: %s",
@@ -265,8 +272,19 @@ async def _collect_incoming_rx_logs(
             }
             hass.bus.async_fire(EVENT_MESHCORE_DELIVERY_UPDATE, update_data)
 
+        # Update the stored message with final rx_log_data
+        if all_rx_logs:
+            entity_id = base_event_data.get("entity_id", "")
+            msg_id = generate_message_id(
+                base_event_data.get("timestamp", ""),
+                base_event_data.get("sender_name", ""),
+                base_event_data.get("message", ""),
+            )
+            await coordinator.update_message_rx_data(entity_id, msg_id, all_rx_logs)
+
     except Exception as ex:
         _LOGGER.debug("Error in background RX_LOG collection: %s", ex)
+
 
 def handle_contact_message(event, coordinator) -> None:
     """Handle contact message event."""
@@ -310,6 +328,12 @@ def handle_contact_message(event, coordinator) -> None:
             pubkey_prefix[:6]
         )
 
+        # Parse the packed path_len byte from firmware:
+        # bits 6-7 = hash_size mode (add 1 for bytes), bits 0-5 = hop_count
+        path_len_raw = payload.get("path_len", 0)
+        hop_count = path_len_raw & 63 if isinstance(path_len_raw, int) else 0
+        snr = payload.get("SNR")  # V3 only, uppercase in SDK
+
         # Create event data
         event_data = {
             "message": message_text,
@@ -319,14 +343,20 @@ def handle_contact_message(event, coordinator) -> None:
             "entity_id": entity_id,
             "domain": DOMAIN,
             "timestamp": datetime.now().isoformat(),
-            "message_type": "direct"  # Explicit message type for filtering
+            "message_type": "direct",  # Explicit message type for filtering
+            "hop_count": hop_count,
         }
+
+        if snr is not None:
+            event_data["snr"] = snr
 
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)
 
-        # Store in persistent message store (sync handler — wrap in task)
-        msg_id = generate_message_id(event_data["timestamp"], contact_name, message_text)
+        # Store message with full metadata in the message store
+        msg_id = generate_message_id(
+            event_data["timestamp"], contact_name, message_text
+        )
         hass.async_create_task(
             coordinator.store_message(entity_id, {
                 "id": msg_id,
@@ -336,8 +366,9 @@ def handle_contact_message(event, coordinator) -> None:
                 "message_type": "direct",
                 "pubkey_prefix": pubkey_prefix,
                 "outgoing": False,
-                "rx_log_data": [],
+                "rx_log_data": event_data.get("rx_log_data", []),
                 "delivery_status": "sent",
+                "hop_count": hop_count,
             })
         )
 
@@ -403,8 +434,10 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
 
-        # Store in persistent message store
-        msg_id = generate_message_id(logbook_event["timestamp"], device_name, message_text)
+        # Store outgoing direct message
+        msg_id = generate_message_id(
+            logbook_event["timestamp"], device_name, message_text
+        )
         await coordinator.store_message(entity_id, {
             "id": msg_id,
             "sender": device_name,
@@ -414,8 +447,9 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "pubkey_prefix": pubkey_prefix,
             "outgoing": True,
             "rx_log_data": [],
-            "delivery_status": "acked" if ack_received else ("failed" if ack_received is False else "sent"),
+            "delivery_status": "sent" if ack_received else ("failed" if ack_received is False else "pending"),
             "ack_received": ack_received,
+            "send_id": event_data.get("send_id"),
         })
 
         _LOGGER.debug(
@@ -454,20 +488,22 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "send_id": event_data.get("send_id"),
         }
 
-        # Store in persistent message store immediately with "pending" status
-        msg_id = generate_message_id(logbook_event["timestamp"], device_name, message_text)
+        # Store outgoing channel message immediately (rx_log_data updated after collection)
+        outgoing_msg_id = generate_message_id(
+            logbook_event["timestamp"], device_name, message_text
+        )
         await coordinator.store_message(entity_id, {
-            "id": msg_id,
+            "id": outgoing_msg_id,
             "sender": device_name,
             "text": message_text,
             "timestamp": logbook_event["timestamp"],
             "message_type": "channel",
             "channel": channel_name,
             "channel_idx": channel_idx,
-            "pubkey_prefix": "",
             "outgoing": True,
             "rx_log_data": [],
             "delivery_status": "pending",
+            "send_id": event_data.get("send_id"),
         })
 
         # Correlate with RX_LOG data for outgoing channel messages.
@@ -543,25 +579,24 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
                         len(all_rx_logs)
                     )
 
-                # Update stored message with collected RX_LOG data
-                await coordinator.update_message_rx_data(entity_id, msg_id, all_rx_logs)
+                # Update the stored message with collected rx_log_data
+                if all_rx_logs:
+                    await coordinator.update_message_rx_data(
+                        entity_id, outgoing_msg_id, all_rx_logs
+                    )
+                # Update delivery status to "sent" now that collection is done
                 await coordinator.update_message_delivery(
-                    entity_id, msg_id,
-                    "delivered" if all_rx_logs else "sent",
+                    entity_id, outgoing_msg_id, "sent",
                     repeater_count=len(all_rx_logs),
                 )
             else:
                 # No timestamp available for correlation, fire single event
                 logbook_event["repeater_count"] = 0
                 hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
-                # Update stored message delivery status
-                await coordinator.update_message_delivery(entity_id, msg_id, "sent")
         except Exception as ex:
             _LOGGER.debug(f"Error correlating outgoing channel message with RX_LOG: {ex}")
             # Fire event even on error so logbook still gets the entry
             hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
-            # Update stored message delivery status on error
-            await coordinator.update_message_delivery(entity_id, msg_id, "sent")
 
         _LOGGER.debug(
             "Logged outgoing channel message to %s: %s (repeaters: %s)",

--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -14,6 +14,7 @@ from .const import (
 )
 from .utils import (
     create_message_correlation_key,
+    generate_message_id,
     get_channel_entity_id,
     get_contact_entity_id
 )
@@ -186,6 +187,22 @@ async def handle_channel_message(event, coordinator) -> None:
                 )
             )
 
+        # Store in persistent message store
+        msg_id = generate_message_id(event_data["timestamp"], sender_name, message_text)
+        await coordinator.store_message(entity_id, {
+            "id": msg_id,
+            "sender": sender_name,
+            "text": message_text,
+            "timestamp": event_data["timestamp"],
+            "message_type": "channel",
+            "channel": channel_name,
+            "channel_idx": channel_idx,
+            "pubkey_prefix": sender_pubkey or "",
+            "outgoing": False,
+            "rx_log_data": event_data.get("rx_log_data", []),
+            "delivery_status": "sent",
+        })
+
         _LOGGER.debug(
             "Logged channel message in %s from %s%s: %s",
             channel_name,
@@ -308,6 +325,22 @@ def handle_contact_message(event, coordinator) -> None:
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, event_data)
 
+        # Store in persistent message store (sync handler — wrap in task)
+        msg_id = generate_message_id(event_data["timestamp"], contact_name, message_text)
+        hass.async_create_task(
+            coordinator.store_message(entity_id, {
+                "id": msg_id,
+                "sender": contact_name,
+                "text": message_text,
+                "timestamp": event_data["timestamp"],
+                "message_type": "direct",
+                "pubkey_prefix": pubkey_prefix,
+                "outgoing": False,
+                "rx_log_data": [],
+                "delivery_status": "sent",
+            })
+        )
+
         _LOGGER.debug(
             "Logged direct message from %s (%s): %s",
             contact_name,
@@ -370,6 +403,21 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
         # Fire event
         hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
 
+        # Store in persistent message store
+        msg_id = generate_message_id(logbook_event["timestamp"], device_name, message_text)
+        await coordinator.store_message(entity_id, {
+            "id": msg_id,
+            "sender": device_name,
+            "text": message_text,
+            "timestamp": logbook_event["timestamp"],
+            "message_type": "direct",
+            "pubkey_prefix": pubkey_prefix,
+            "outgoing": True,
+            "rx_log_data": [],
+            "delivery_status": "acked" if ack_received else ("failed" if ack_received is False else "sent"),
+            "ack_received": ack_received,
+        })
+
         _LOGGER.debug(
             "Logged outgoing direct message to %s (%s): %s (ack: %s)",
             receiver_name,
@@ -405,6 +453,22 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "message_type": "channel",
             "send_id": event_data.get("send_id"),
         }
+
+        # Store in persistent message store immediately with "pending" status
+        msg_id = generate_message_id(logbook_event["timestamp"], device_name, message_text)
+        await coordinator.store_message(entity_id, {
+            "id": msg_id,
+            "sender": device_name,
+            "text": message_text,
+            "timestamp": logbook_event["timestamp"],
+            "message_type": "channel",
+            "channel": channel_name,
+            "channel_idx": channel_idx,
+            "pubkey_prefix": "",
+            "outgoing": True,
+            "rx_log_data": [],
+            "delivery_status": "pending",
+        })
 
         # Correlate with RX_LOG data for outgoing channel messages.
         # When we send a channel message, repeaters re-broadcast it and our
@@ -478,14 +542,26 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
                         "%d RX_LOG reception(s) total",
                         len(all_rx_logs)
                     )
+
+                # Update stored message with collected RX_LOG data
+                await coordinator.update_message_rx_data(entity_id, msg_id, all_rx_logs)
+                await coordinator.update_message_delivery(
+                    entity_id, msg_id,
+                    "delivered" if all_rx_logs else "sent",
+                    repeater_count=len(all_rx_logs),
+                )
             else:
                 # No timestamp available for correlation, fire single event
                 logbook_event["repeater_count"] = 0
                 hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
+                # Update stored message delivery status
+                await coordinator.update_message_delivery(entity_id, msg_id, "sent")
         except Exception as ex:
             _LOGGER.debug(f"Error correlating outgoing channel message with RX_LOG: {ex}")
             # Fire event even on error so logbook still gets the entry
             hass.bus.async_fire(EVENT_MESHCORE_MESSAGE, logbook_event)
+            # Update stored message delivery status on error
+            await coordinator.update_message_delivery(entity_id, msg_id, "sent")
 
         _LOGGER.debug(
             "Logged outgoing channel message to %s: %s (repeaters: %s)",

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -1171,6 +1171,98 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     #     schema=UI_MESSAGE_SCHEMA,
     # )
 
+    # ── Message Store Services ──
+
+    SERVICE_GET_MESSAGES = "get_messages"
+    SERVICE_SEARCH_MESSAGES = "search_messages"
+
+    GET_MESSAGES_SCHEMA = vol.Schema(
+        {
+            vol.Required("entity_id"): cv.string,
+            vol.Optional("limit", default=50): vol.Coerce(int),
+            vol.Optional("before"): cv.string,
+            vol.Optional("entry_id"): cv.string,
+        }
+    )
+
+    SEARCH_MESSAGES_SCHEMA = vol.Schema(
+        {
+            vol.Required("query"): cv.string,
+            vol.Optional("entity_id"): cv.string,
+            vol.Optional("limit", default=20): vol.Coerce(int),
+            vol.Optional("entry_id"): cv.string,
+        }
+    )
+
+    async def async_get_messages_service(call: ServiceCall) -> dict:
+        """Get stored messages for a conversation."""
+        entry_id = call.data.get("entry_id")
+        coordinator = None
+        for eid, entry_data in hass.data[DOMAIN].items():
+            if isinstance(entry_data, dict) and "coordinator" in entry_data:
+                if entry_id is None or eid == entry_id:
+                    coordinator = entry_data["coordinator"]
+                    break
+
+        if not coordinator:
+            return {"messages": [], "error": "No MeshCore coordinator found"}
+
+        entity_id = call.data["entity_id"]
+        limit = call.data.get("limit", 50)
+        before = call.data.get("before")
+
+        messages = await coordinator.get_messages(entity_id, limit=limit, before=before)
+        return {"messages": messages}
+
+    async def async_search_messages_service(call: ServiceCall) -> dict:
+        """Search stored messages across conversations."""
+        entry_id = call.data.get("entry_id")
+        coordinator = None
+        for eid, entry_data in hass.data[DOMAIN].items():
+            if isinstance(entry_data, dict) and "coordinator" in entry_data:
+                if entry_id is None or eid == entry_id:
+                    coordinator = entry_data["coordinator"]
+                    break
+
+        if not coordinator:
+            return {"results": [], "error": "No MeshCore coordinator found"}
+
+        query = call.data["query"].lower()
+        limit = call.data.get("limit", 20)
+        filter_entity = call.data.get("entity_id")
+        results = []
+
+        index = coordinator.get_message_index()
+        entity_ids = [filter_entity] if filter_entity else list(index.keys())
+
+        for eid in entity_ids:
+            messages = await coordinator.get_messages(eid, limit=500)
+            for m in messages:
+                if query in (m.get("text", "") or "").lower() or query in (m.get("sender", "") or "").lower():
+                    results.append({**m, "entity_id": eid})
+                    if len(results) >= limit:
+                        break
+            if len(results) >= limit:
+                break
+
+        return {"results": results}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_MESSAGES,
+        async_get_messages_service,
+        schema=GET_MESSAGES_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEARCH_MESSAGES,
+        async_search_messages_service,
+        schema=SEARCH_MESSAGES_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
 async def async_unload_services(hass: HomeAssistant) -> None:
     """Unload MeshCore services."""
     if hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE):
@@ -1205,6 +1297,12 @@ async def async_unload_services(hass: HomeAssistant) -> None:
 
     if hass.services.has_service(DOMAIN, SERVICE_CLEAR_DISCOVERED_CONTACTS):
         hass.services.async_remove(DOMAIN, SERVICE_CLEAR_DISCOVERED_CONTACTS)
+
+    if hass.services.has_service(DOMAIN, "get_messages"):
+        hass.services.async_remove(DOMAIN, "get_messages")
+
+    if hass.services.has_service(DOMAIN, "search_messages"):
+        hass.services.async_remove(DOMAIN, "search_messages")
 
 
 def create_service_call(

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -204,3 +204,72 @@ clear_discovered_contacts:
       example: "abc123def456"
       selector:
         text:
+
+get_messages:
+  name: Get Messages
+  description: Retrieve stored messages for a conversation entity. Returns structured message data including sender, text, timestamp, delivery status, and RX log data.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: The binary sensor entity ID of the conversation (contact or channel).
+      required: true
+      example: "binary_sensor.meshcore_abc123_def456_messages"
+      selector:
+        entity:
+          domain: binary_sensor
+    limit:
+      name: Limit
+      description: Maximum number of messages to return (default 50).
+      required: false
+      default: 50
+      selector:
+        number:
+          min: 1
+          max: 500
+          mode: box
+    before:
+      name: Before Cursor
+      description: Message ID to paginate before (returns messages older than this ID).
+      required: false
+      selector:
+        text:
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      selector:
+        text:
+
+search_messages:
+  name: Search Messages
+  description: Search stored messages across conversations by text content or sender name.
+  fields:
+    query:
+      name: Search Query
+      description: Text to search for in message content and sender names.
+      required: true
+      selector:
+        text:
+    entity_id:
+      name: Entity ID
+      description: Optionally limit search to a specific conversation entity.
+      required: false
+      selector:
+        entity:
+          domain: binary_sensor
+    limit:
+      name: Limit
+      description: Maximum number of results to return (default 20).
+      required: false
+      default: 20
+      selector:
+        number:
+          min: 1
+          max: 100
+          mode: box
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      selector:
+        text:

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -205,71 +205,75 @@ clear_discovered_contacts:
       selector:
         text:
 
+
 get_messages:
-  name: Get Messages
-  description: Retrieve stored messages for a conversation entity. Returns structured message data including sender, text, timestamp, delivery status, and RX log data.
+  name: Get messages
+  description: >-
+    Retrieve stored messages for a MeshCore conversation. Returns structured
+    message data including sender, text, timestamp, route/SNR/RSSI data,
+    and delivery status. Use response_variable in automations to access results.
   fields:
     entity_id:
-      name: Entity ID
-      description: The binary sensor entity ID of the conversation (contact or channel).
+      name: Entity
+      description: The conversation entity (channel or DM binary_sensor).
       required: true
-      example: "binary_sensor.meshcore_abc123_def456_messages"
       selector:
         entity:
+          integration: meshcore
           domain: binary_sensor
     limit:
       name: Limit
-      description: Maximum number of messages to return (default 50).
-      required: false
+      description: Maximum number of messages to return (newest first).
       default: 50
       selector:
         number:
           min: 1
           max: 500
-          mode: box
     before:
-      name: Before Cursor
-      description: Message ID to paginate before (returns messages older than this ID).
+      name: Before
+      description: Message ID cursor — return messages older than this ID for pagination.
       required: false
       selector:
         text:
     entry_id:
       name: Config Entry ID
-      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      description: The config entry ID if you have multiple MeshCore devices.
       required: false
       selector:
         text:
 
 search_messages:
-  name: Search Messages
-  description: Search stored messages across conversations by text content or sender name.
+  name: Search messages
+  description: >-
+    Search stored MeshCore messages by text content or sender name.
+    Searches across all conversations unless entity_id is specified.
+    Use response_variable in automations to access results.
   fields:
     query:
-      name: Search Query
-      description: Text to search for in message content and sender names.
+      name: Query
+      description: Search text (matched against message text and sender name, case-insensitive).
       required: true
       selector:
         text:
     entity_id:
-      name: Entity ID
-      description: Optionally limit search to a specific conversation entity.
+      name: Entity
+      description: Limit search to a specific conversation. Leave empty to search all conversations.
       required: false
       selector:
         entity:
+          integration: meshcore
           domain: binary_sensor
     limit:
       name: Limit
-      description: Maximum number of results to return (default 20).
-      required: false
+      description: Maximum number of results to return.
       default: 20
       selector:
         number:
           min: 1
           max: 100
-          mode: box
     entry_id:
       name: Config Entry ID
-      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      description: The config entry ID if you have multiple MeshCore devices.
       required: false
       selector:
         text:

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -16,6 +16,15 @@ from .const import BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, 
 _LOGGER = logging.getLogger(__name__)
 
 
+def generate_message_id(timestamp: str, sender: str, text: str) -> str:
+    """Generate deterministic message ID matching frontend generateId().
+
+    Creates a 12-char hex ID from SHA256 of timestamp|sender|text.
+    """
+    raw = f"{timestamp}|{sender}|{text}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+
 def extract_pubkey_from_selection(selection: str) -> str | None:
     """Extract pubkey from selection format 'Name (pubkey)'.
 

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -11,7 +11,9 @@ from typing import Any
 from Crypto.Cipher import AES
 from homeassistant.util import slugify
 
-from .const import BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType
+from .const import (
+    BAT_VMAX, BAT_VMIN, CHANNEL_PREFIX, DOMAIN, MESSAGES_SUFFIX, NodeType,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +21,17 @@ _LOGGER = logging.getLogger(__name__)
 def generate_message_id(timestamp: str, sender: str, text: str) -> str:
     """Generate deterministic message ID matching frontend generateId().
 
-    Creates a 12-char hex ID from SHA256 of timestamp|sender|text.
+    Uses SHA256 of 'timestamp|sender|text' truncated to 12 hex chars.
+    This ensures IDs match between real-time events and stored records,
+    and between backend and frontend.
+
+    Args:
+        timestamp: ISO timestamp string
+        sender: Sender name
+        text: Message text
+
+    Returns:
+        12-character hex string
     """
     raw = f"{timestamp}|{sender}|{text}"
     return hashlib.sha256(raw.encode()).hexdigest()[:12]
@@ -288,15 +300,21 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         if len(packet_bytes) < 2:
             return result
 
-        # Parse header and path
+        # Parse header and packed path_len byte
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
         header = packet_bytes[0]
-        path_len = packet_bytes[1]
+        path_len_raw = packet_bytes[1]
+        hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+        hop_count = path_len_raw & 63          # number of relay hops
+        path_byte_len = hop_count * hash_size
 
         # Extract payload type from header (bits 2-5)
         payload_type = (header >> 2) & 0x0F
 
         result["header"] = f"{header:02x}"
-        result["path_len"] = path_len
+        result["path_len"] = path_len_raw
+        result["hop_count"] = hop_count
+        result["hash_size"] = hash_size
         result["payload_type"] = payload_type
 
         # Check if this is GroupText (0x05)
@@ -305,7 +323,7 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
             return result
 
         # Validate packet length
-        path_end = 2 + path_len
+        path_end = 2 + path_byte_len
         if len(packet_bytes) < path_end + 3:  # Need at least channel_hash + 2-byte MAC
             return result
 
@@ -348,7 +366,9 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
                         "timestamp": timestamp,
                         "text": message_text,
                         "decrypted": True,
-                        "path_len": path_len,
+                        "path_len": path_len_raw,
+                        "hop_count": hop_count,
+                        "hash_size": hash_size,
                         "path": path_data.hex(),
                         "channel_hash": f"{channel_hash_byte:02x}"
                     }
@@ -391,16 +411,20 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
 
     RX_LOG_DATA events contain raw LoRa payload with header, path, and channel hash.
     Format:
-    - Bytes 0-1: Header/identifier
-    - Bytes 2-3: Hop count (path_len)
-    - Bytes 4+: Path data (2 hex chars per node)
+    - Byte 0: Header (route type in bits 0-1, payload type in bits 2-5)
+    - Byte 1: Packed path_len byte:
+        - Bits 6-7: path hash size encoding ((value >> 6) + 1 = bytes per hop: 1, 2, or 3)
+        - Bits 0-5: hop count (number of relay nodes in path)
+        - Actual path byte length = hop_count * hash_size
+    - Bytes 2+: Path data (hash_size bytes per hop)
     - After path: Channel hash
 
     Args:
         payload: Raw event payload (dict with 'payload' or 'raw_hex', or direct hex string)
 
     Returns:
-        Dict with parsed fields: header, path_len, path, channel_hash
+        Dict with parsed fields: header, path_len (raw byte), hop_count, hash_size,
+        path, path_nodes, channel_hash.
         Returns empty dict on parsing errors (fault tolerant)
     """
     result = {}
@@ -432,20 +456,26 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
             _LOGGER.debug(f"RX_LOG hex too short: {len(hex_str)} chars")
             return result
 
-        # Parse header (bytes 0-1)
+        # Parse header (byte 0)
         result["header"] = hex_str[0:2]
 
-        # Parse path_len (bytes 2-3)
+        # Parse packed path_len byte (byte 1)
+        # Firmware Packet.h: bits 6-7 encode hash size, bits 0-5 encode hop count
         try:
-            path_len = int(hex_str[2:4], 16)
-            result["path_len"] = path_len
+            path_len_raw = int(hex_str[2:4], 16)
+            hash_size = (path_len_raw >> 6) + 1   # 1, 2, or 3 bytes per hop
+            hop_count = path_len_raw & 63          # number of relay hops
+            result["path_len"] = path_len_raw
+            result["hash_size"] = hash_size
+            result["hop_count"] = hop_count
         except ValueError:
             _LOGGER.debug(f"Could not parse path_len from: {hex_str[2:4]}")
             return result
 
         # Calculate expected positions
         path_start = 4
-        path_end = path_start + (path_len * 2)  # Each node is 2 hex chars
+        path_byte_len = hop_count * hash_size
+        path_end = path_start + (path_byte_len * 2)  # 2 hex chars per byte
 
         # Validate length for path data
         if len(hex_str) < path_end:
@@ -456,10 +486,11 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         path_hex = hex_str[path_start:path_end]
         result["path"] = path_hex
 
-        # Parse individual nodes in path (2 chars each)
+        # Parse individual nodes in path (hash_size bytes = hash_size*2 hex chars each)
         path_nodes = []
-        for i in range(0, len(path_hex), 2):
-            node_hex = path_hex[i:i+2]
+        node_hex_len = hash_size * 2
+        for i in range(0, len(path_hex), node_hex_len):
+            node_hex = path_hex[i:i + node_hex_len]
             path_nodes.append(node_hex)
         result["path_nodes"] = path_nodes
 
@@ -469,8 +500,9 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
             if len(hex_str) >= path_end + 2:
                 result["channel_hash"] = hex_str[path_end:path_end+2]
 
-        _LOGGER.debug(f"Parsed RX_LOG: header={result.get('header')}, path_len={result.get('path_len')}, "
-                     f"path={result.get('path')}, channel_hash={result.get('channel_hash')}")
+        _LOGGER.debug(f"Parsed RX_LOG: header={result.get('header')}, hop_count={hop_count}, "
+                     f"hash_size={hash_size}, path={result.get('path')}, "
+                     f"channel_hash={result.get('channel_hash')}")
 
     except Exception as ex:
         _LOGGER.debug(f"Error parsing RX_LOG data: {ex}")

--- a/custom_components/meshcore/ws_api.py
+++ b/custom_components/meshcore/ws_api.py
@@ -1,0 +1,166 @@
+"""MeshCore WebSocket API commands."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_coordinator(hass: HomeAssistant, entry_id: str | None = None):
+    """Get coordinator for the given entry_id, or the first available one."""
+    if DOMAIN not in hass.data:
+        return None
+
+    if entry_id and entry_id in hass.data[DOMAIN]:
+        coord = hass.data[DOMAIN][entry_id]
+        if hasattr(coord, "api"):
+            return coord
+        return None
+
+    # Return first coordinator found
+    for key, value in hass.data[DOMAIN].items():
+        if hasattr(value, "api"):
+            return value
+    return None
+
+
+def async_register_ws_commands(hass: HomeAssistant) -> None:
+    """Register all MeshCore WebSocket commands."""
+    websocket_api.async_register_command(hass, ws_get_stored_messages)
+    websocket_api.async_register_command(hass, ws_get_stored_message_count)
+    websocket_api.async_register_command(hass, ws_search_stored_messages)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Message Store Commands
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meshcore/get_stored_messages",
+        vol.Required("entity_id"): str,
+        vol.Optional("limit", default=50): int,
+        vol.Optional("before"): str,
+        vol.Optional("after"): str,
+        vol.Optional("entry_id"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_get_stored_messages(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Get stored messages for a conversation with cursor pagination."""
+    coordinator = _get_coordinator(hass, msg.get("entry_id"))
+    if not coordinator:
+        connection.send_error(msg["id"], "not_found", "No MeshCore coordinator found")
+        return
+
+    messages = await coordinator.get_messages(
+        msg["entity_id"],
+        limit=msg.get("limit", 50),
+        before=msg.get("before"),
+        after=msg.get("after"),
+    )
+    connection.send_result(msg["id"], {
+        "messages": messages,
+        "has_more": len(messages) == msg.get("limit", 50),
+    })
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meshcore/get_stored_message_count",
+        vol.Required("entity_id"): str,
+        vol.Optional("entry_id"): str,
+    }
+)
+@callback
+def ws_get_stored_message_count(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Get message count for a conversation from the in-memory index."""
+    coordinator = _get_coordinator(hass, msg.get("entry_id"))
+    if not coordinator:
+        connection.send_error(msg["id"], "not_found", "No MeshCore coordinator found")
+        return
+
+    index_entry = coordinator.get_message_index().get(msg["entity_id"], {})
+    connection.send_result(msg["id"], {"count": index_entry.get("message_count", 0)})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "meshcore/search_stored_messages",
+        vol.Required("query"): str,
+        vol.Optional("entity_id"): str,
+        vol.Optional("from_date"): str,
+        vol.Optional("to_date"): str,
+        vol.Optional("limit", default=20): int,
+        vol.Optional("entry_id"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_search_stored_messages(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Search stored messages by text or sender name.
+
+    Uses _load_for_search() for non-caching disk reads — conversations
+    loaded solely for search are not kept in memory after the call returns.
+    """
+    coordinator = _get_coordinator(hass, msg.get("entry_id"))
+    if not coordinator:
+        connection.send_error(msg["id"], "not_found", "No MeshCore coordinator found")
+        return
+
+    query = msg["query"].lower()
+    from_date = msg.get("from_date")
+    to_date = msg.get("to_date")
+    results = []
+    limit = msg.get("limit", 20)
+
+    entities = (
+        [msg["entity_id"]] if msg.get("entity_id")
+        else list(coordinator.get_message_index().keys())
+    )
+    for eid in entities:
+        messages = await coordinator._load_for_search(eid)
+
+        # Resolve conversation name from HA entity state
+        state = hass.states.get(eid)
+        conv_name = state.attributes.get("friendly_name", eid) if state else eid
+
+        for m in reversed(messages):
+            ts = m.get("timestamp", "")
+
+            # Date range filtering
+            if from_date and ts < from_date:
+                continue
+            if to_date and ts > to_date:
+                continue
+
+            if query in (m.get("text", "")).lower() or query in (m.get("sender", "")).lower():
+                results.append({
+                    **m,
+                    "entity_id": eid,
+                    "conversation_name": conv_name,
+                })
+                if len(results) >= limit:
+                    break
+        if len(results) >= limit:
+            break
+
+    connection.send_result(msg["id"], {"results": results})

--- a/docs/docs/message-store.md
+++ b/docs/docs/message-store.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 5.5
+title: Message Store
+---
+
+# Message Store
+
+The integration maintains a per-conversation message store independent of the Home Assistant logbook. It records each message's text, sender, timestamp, delivery status, and RX_LOG routing data, and exposes them through two services and an internal API consumed by the sidebar panel.
+
+The design goal is explicit: keep the store small, bounded, and predictable, while giving the frontend and user automations information the logbook cannot provide.
+
+## Why a purpose-built store
+
+The logbook is a good surface for individual message *events*, but it does not work well as a backing store for a conversation UI:
+
+- **Unread tracking.** The logbook has no concept of read state. The sidebar panel needs to know which messages the user has and has not seen since the last visit — that has to live somewhere persistent.
+- **RX_LOG correlation is lost on re-read.** When a channel message is received, the integration correlates multiple RX_LOG entries (each with SNR, RSSI, hop count, routing path) onto the message event as `rx_log_data`. The logbook only stores the event summary; the routing detail is gone once the message scrolls off the event bus. The message store keeps `rx_log_data` attached to each message.
+- **Delivery status is asynchronous.** For outgoing messages, delivery acks and round-trip timing arrive after the initial send event. The store updates the existing message record in-place; the logbook would need a second entry.
+- **Bounded retention, predictable footprint.** The logbook grows with overall HA activity and is tuned for the whole system. Conversation history should roll off on its own schedule, independent of whatever the user has configured for the recorder.
+- **Efficient scrollback.** Loading a conversation in the sidebar reads a single JSON file, not a recorder query spanning months of logbook rows.
+
+## Size and retention
+
+The store is deliberately small. The following limits are enforced:
+
+| Setting | Default | Notes |
+|---|---|---|
+| Messages per conversation | **500** | When exceeded, oldest messages are dropped FIFO. Configurable via options. |
+| Retention window | **90 days** | Daily cleanup removes messages older than this. Configurable via options. |
+| Idle eviction | **5 minutes** | Conversations not accessed for 5 minutes are flushed to disk and dropped from memory. |
+
+In practice a busy public channel hits the 500-message cap well before it hits 90 days, so the store naturally stays in single-digit megabytes per conversation even on active networks. Unused conversations consume zero memory — they're written to disk and evicted.
+
+Each conversation is stored in its own file under Home Assistant's `.storage/` directory (`meshcore.<entry_id>.msgs.<entity_id>`). A lightweight index (`meshcore.<entry_id>.msgidx`) holds one row per conversation with message count, last sender, last timestamp, and a 50-character preview — this is what the conversation list in the sidebar renders from without loading any message bodies.
+
+## Services
+
+### Get Messages
+
+Retrieve stored messages for a specific conversation.
+
+**Service:** `meshcore.get_messages` — returns a response
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `entity_id` | entity | Yes | Conversation binary sensor (channel or contact messages entity) |
+| `limit` | integer | No | Max messages to return (1–500, default 50) |
+| `before` | string | No | Message ID to paginate before (returns older messages) |
+| `entry_id` | string | No | Config entry ID for multi-device setups |
+
+**Example:**
+
+```yaml
+service: meshcore.get_messages
+data:
+  entity_id: binary_sensor.meshcore_abc123_def456_messages
+  limit: 100
+response_variable: result
+```
+
+Response:
+
+```yaml
+messages:
+  - id: "..."
+    sender: "..."
+    text: "..."
+    timestamp: "2026-04-18T12:34:56"
+    delivery_status: "acked"
+    rx_log_data: [...]
+    repeater_count: 2
+```
+
+### Search Messages
+
+Substring search across message text and sender name. Scans all conversations by default, or a specific one if `entity_id` is supplied.
+
+**Service:** `meshcore.search_messages` — returns a response
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | Yes | Substring to match (case-insensitive) |
+| `entity_id` | entity | No | Limit search to a specific conversation |
+| `limit` | integer | No | Max results (1–100, default 20) |
+| `entry_id` | string | No | Config entry ID for multi-device setups |
+
+**Example:**
+
+```yaml
+service: meshcore.search_messages
+data:
+  query: "weather"
+  limit: 50
+response_variable: result
+```
+
+## Integration with the sidebar panel
+
+The sidebar panel reads from the message store over the integration's WebSocket API, with progressive loading: the conversation list is rendered from the index alone, then full message history loads on demand when a conversation is opened. The 5-minute idle eviction means closing a conversation returns its memory to the OS within a few minutes of inactivity.
+
+Outgoing messages are written to the store before the wire send completes (the "fire-then-enhance" pattern); delivery updates replace the record's `delivery_status` field once the ack arrives, and RX_LOG data is attached progressively as repeater relays report in.
+
+## Use in automations and bots
+
+Because each message is kept as a full record with `rx_log_data`, `delivery_status`, and timestamps, the store is a practical source of truth for automations that need more context than a logbook entry. Examples:
+
+- **Activity scan.** Use `search_messages` to flag if a keyword has appeared in any channel in the last N messages.
+- **Delivery verification.** After sending a message, call `get_messages` on the destination entity and check `delivery_status` on the latest entry.
+- **Mesh path analysis.** The `rx_log_data` on each incoming message lists every repeater that relayed it, with SNR and RSSI per hop — usable directly in a template sensor or python_script to track routing diversity over time.
+
+## Notes
+
+- Conversations are created lazily — the first time a message is stored for an entity, its file and index entry appear. There is no "enable" flag; the store is always on.
+- Persistence uses Home Assistant's `Store` helper, so files survive restarts and participate in HA backups.
+- The store is scoped per-integration-entry. Deleting the integration entry removes all conversation files for that entry.


### PR DESCRIPTION
### Summary

Adds a purpose-built, per-conversation message store — independent of the Home Assistant logbook — that records each message's text, sender, timestamp, delivery status, and RX_LOG routing data. Exposes two new services (`meshcore.get_messages`, `meshcore.search_messages`) and an internal WebSocket API used by the upcoming sidebar panel.

### Why the logbook isn't sufficient

The logbook is fine as a surface for individual message *events*, but it doesn't work as a backing store for a conversation UI, and it isn't ergonomic for automations that need structured per-message context:

- **No unread tracking.** The logbook has no concept of read state. A conversation UI must know which messages the user has and has not seen since the last visit — that has to live somewhere persistent.
- **RX_LOG correlation is lost.** When a channel message is received, the integration correlates multiple RX_LOG entries (each with SNR, RSSI, hop count, routing path) onto the message event as `rx_log_data`. The logbook only captures the summary; the routing detail scrolls off the event bus. The message store keeps `rx_log_data` attached to each message.
- **Delivery status is asynchronous.** For outgoing messages, delivery acks and round-trip timing arrive after the initial send. The store updates the existing record in place — the logbook would need a second entry.
- **Bounded retention, predictable footprint.** The logbook grows with overall HA activity and is tuned for the whole system. Conversation history should roll off on its own schedule, independent of the recorder's settings.
- **Efficient scrollback.** Loading a conversation in the sidebar is a single JSON read, not a recorder query across months of logbook rows.

### Size and footprint — the 500-message cap is load-bearing

The store is deliberately small. The limits are:

| Setting | Default | Notes |
|---|---|---|
| Messages per conversation | **500** | FIFO drop on overflow. Configurable via options. |
| Retention window | **90 days** | Daily cleanup; configurable. |
| Idle eviction | **5 minutes** | Conversations not accessed for 5 minutes are flushed to disk and dropped from memory. |

The 500-message ceiling matters: a busy public channel hits that cap well before it hits 90 days, so each conversation file naturally stays in single-digit megabytes even on active networks. Unused conversations cost zero memory — they live on disk until opened.

Each conversation is one JSON file under `.storage/` (`meshcore.<entry_id>.msgs.<entity_id>`). A lightweight index (`meshcore.<entry_id>.msgidx`) holds one row per conversation with count, last sender, last timestamp, and a 50-character preview — enough for the sidebar's conversation list to render without loading any message bodies.

### Changes primarily serve the frontend, but are useful on their own

Like the other PRs in this series, the proximate reason for this work is the upcoming sidebar-panel frontend ([discussion on Discord](https://discord.com/channels/1343693475589263471/1358879320248160419/1489089455045476483)) — specifically its conversation list, scrollback, and unread-indicator behaviour. But the two services and the per-record structure are first-class HA surfaces, useful on their own:

- **Activity scans.** `search_messages` lets a template or automation flag whether a keyword has appeared in any conversation in recent history.
- **Delivery verification.** After sending a message, call `get_messages` against the destination entity and inspect `delivery_status` on the latest record.
- **Mesh-path analysis.** `rx_log_data` on each incoming message lists every repeater that relayed it, with per-hop SNR and RSSI — usable directly in a template sensor or `python_script` to track routing diversity over time.
- **Bot-style integrations.** A bot can tail a conversation entity, match on message text, and reply by calling `meshcore.send_message` — no need to stand up a separate transcript database.

### What changes

**Services:**

- `meshcore.get_messages` — retrieve stored messages for a conversation. Fields: `entity_id` (required), `limit` (1–500, default 50), `before` (pagination cursor), optional `entry_id` for multi-device setups. Returns a structured response.
- `meshcore.search_messages` — substring search across text and sender name. Fields: `query` (required, case-insensitive), optional `entity_id` to limit scope, `limit` (1–100, default 20). Returns a structured response.

**Storage layer:**

- Per-conversation files plus an integration-level index, stored via HA's `Store` helper (backup-compatible, restart-durable).
- Fire-then-enhance: outgoing messages are written locally before the wire send completes; `delivery_status` updates in place when the ack lands; `rx_log_data` is attached progressively as repeater relays report in.
- Lazy conversations — no "enable" switch, no upfront allocation; a conversation file is created the first time a message is stored for that entity.

### Documentation

New page: `docs/docs/message-store.md` (sidebar position 5.5), covering the "why" motivation, retention/eviction semantics, the two services with schemas and example YAML, and automation use cases.

### Related / upcoming

Companion PRs from this series: `feature/per-device-online-sensor` (per-device connectivity sensor), `feature/repeater-neighbors` (repeater neighbor SNR/activity sensors). The sidebar-panel frontend that consumes all three is tracked separately.