### PR TITLE
Add repeater neighbor SNR and activity sensors with auto-cleanup

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -360,6 +360,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("Map Auto Uploader failed to initialize: %s - continuing without it", ex)
         coordinator.map_uploader = None
     
+    # Load persisted neighbor data before sensor platform setup so that
+    # sensor.py can recreate neighbor sensor entities from the stored data.
+    await coordinator.async_load_neighbor_data()
+
     # Set up all platforms for this device
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_REPEATER_UPDATE_INTERVAL,
     CONF_REPEATER_TELEMETRY_ENABLED,
     CONF_REPEATER_DISABLE_PATH_RESET,
+    CONF_REPEATER_NEIGHBORS_ENABLED,
     DEFAULT_REPEATER_UPDATE_INTERVAL,
     MIN_UPDATE_INTERVAL,
     CONF_TRACKED_CLIENTS,
@@ -55,6 +56,9 @@ from .const import (
     CONF_STALE_CONTACT_DAYS,
     DEFAULT_STALE_CONTACT_DAYS,
     CONF_ADAPTIVE_POLL_WAIT,
+    CONF_AUTO_CLEANUP_STALE_NEIGHBORS,
+    CONF_STALE_NEIGHBOR_DAYS,
+    DEFAULT_STALE_NEIGHBOR_DAYS,
     CONF_MQTT_IATA,
     CONF_MQTT_TOKEN_TTL_SECONDS,
     CONF_MQTT_BROKERS,
@@ -574,19 +578,22 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         default_interval = DEFAULT_REPEATER_UPDATE_INTERVAL
         default_telemetry = False
         default_disable_path_reset = False
-        
+        default_neighbors_enabled = False
+
         if user_input:
             default_password = user_input.get(CONF_REPEATER_PASSWORD, "")
             default_interval = user_input.get(CONF_REPEATER_UPDATE_INTERVAL, DEFAULT_REPEATER_UPDATE_INTERVAL)
             default_telemetry = user_input.get(CONF_REPEATER_TELEMETRY_ENABLED, False)
             default_disable_path_reset = user_input.get(CONF_REPEATER_DISABLE_PATH_RESET, False)
-            
+            default_neighbors_enabled = user_input.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)
+
         return self.async_show_form(
             step_id="add_repeater",
             data_schema=vol.Schema({
                 vol.Required(CONF_REPEATER_NAME): vol.In(repeater_dict.keys()),
                 vol.Optional(CONF_REPEATER_PASSWORD, default=default_password): str,
                 vol.Optional(CONF_REPEATER_TELEMETRY_ENABLED, default=default_telemetry): bool,
+                vol.Optional(CONF_REPEATER_NEIGHBORS_ENABLED, default=default_neighbors_enabled): bool,
                 vol.Optional(CONF_REPEATER_UPDATE_INTERVAL, default=default_interval): vol.All(cv.positive_int, vol.Range(min=MIN_UPDATE_INTERVAL)),
                 vol.Optional(CONF_REPEATER_DISABLE_PATH_RESET, default=default_disable_path_reset): bool,
             }),
@@ -628,6 +635,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         update_interval = user_input.get(CONF_REPEATER_UPDATE_INTERVAL, DEFAULT_REPEATER_UPDATE_INTERVAL)
         telemetry_enabled = user_input.get(CONF_REPEATER_TELEMETRY_ENABLED, True)
         disable_path_reset = user_input.get(CONF_REPEATER_DISABLE_PATH_RESET, False)
+        neighbors_enabled = user_input.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)
 
         # The selected_repeater has format: "Name (prefix)"
         selected_str = selected_repeater
@@ -703,6 +711,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             "firmware_version": ver,
             CONF_REPEATER_PASSWORD: password,
             CONF_REPEATER_TELEMETRY_ENABLED: telemetry_enabled,
+            CONF_REPEATER_NEIGHBORS_ENABLED: neighbors_enabled,
             CONF_REPEATER_UPDATE_INTERVAL: update_interval,
             CONF_REPEATER_DISABLE_PATH_RESET: disable_path_reset,
         })
@@ -887,6 +896,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             new_data[CONF_AUTO_CLEANUP_STALE_CONTACTS] = user_input[CONF_AUTO_CLEANUP_STALE_CONTACTS]
             new_data[CONF_STALE_CONTACT_DAYS] = user_input[CONF_STALE_CONTACT_DAYS]
             new_data[CONF_ADAPTIVE_POLL_WAIT] = user_input[CONF_ADAPTIVE_POLL_WAIT]
+            new_data[CONF_AUTO_CLEANUP_STALE_NEIGHBORS] = user_input[CONF_AUTO_CLEANUP_STALE_NEIGHBORS]
+            new_data[CONF_STALE_NEIGHBOR_DAYS] = user_input[CONF_STALE_NEIGHBOR_DAYS]
             self.hass.config_entries.async_update_entry(self.config_entry, data=new_data) # type: ignore
 
             if new_data[CONF_LIMIT_DISCOVERED_CONTACTS]:
@@ -907,6 +918,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_auto_cleanup = self.config_entry.data.get(CONF_AUTO_CLEANUP_STALE_CONTACTS, False)
         current_stale_days = self.config_entry.data.get(CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS)
         current_adaptive_poll_wait = self.config_entry.data.get(CONF_ADAPTIVE_POLL_WAIT, False)
+        current_auto_cleanup_neighbors = self.config_entry.data.get(CONF_AUTO_CLEANUP_STALE_NEIGHBORS, False)
+        current_stale_neighbor_days = self.config_entry.data.get(CONF_STALE_NEIGHBOR_DAYS, DEFAULT_STALE_NEIGHBOR_DAYS)
 
         return self.async_show_form(
             step_id="global_settings",
@@ -920,6 +933,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_AUTO_CLEANUP_STALE_CONTACTS, default=current_auto_cleanup): cv.boolean,
                 vol.Optional(CONF_STALE_CONTACT_DAYS, default=current_stale_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),
                 vol.Optional(CONF_ADAPTIVE_POLL_WAIT, default=current_adaptive_poll_wait): cv.boolean,
+                vol.Optional(CONF_AUTO_CLEANUP_STALE_NEIGHBORS, default=current_auto_cleanup_neighbors): cv.boolean,
+                vol.Optional(CONF_STALE_NEIGHBOR_DAYS, default=current_stale_neighbor_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),
             }),
         )
 
@@ -1199,11 +1214,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         _LOGGER.debug("User_input for editing repeater: %s", user_input)
         if user_input is not None:
+            # Capture old state for change detection
+            old_neighbors_enabled = repeater.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)
+
             # Update repeater settings
             new_password = user_input.get(CONF_REPEATER_PASSWORD, "")
             if new_password:
                 repeater[CONF_REPEATER_PASSWORD] = new_password
             repeater[CONF_REPEATER_TELEMETRY_ENABLED] = user_input[CONF_REPEATER_TELEMETRY_ENABLED]
+            repeater[CONF_REPEATER_NEIGHBORS_ENABLED] = user_input[CONF_REPEATER_NEIGHBORS_ENABLED]
             repeater[CONF_REPEATER_UPDATE_INTERVAL] = user_input[CONF_REPEATER_UPDATE_INTERVAL]
             repeater[CONF_REPEATER_DISABLE_PATH_RESET] = user_input[CONF_REPEATER_DISABLE_PATH_RESET]
             repeater[CONF_DEVICE_DISABLED] = user_input[CONF_DEVICE_DISABLED]
@@ -1231,6 +1250,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.debug("Updating repeater subscriptions: %s", new_data[CONF_REPEATER_SUBSCRIPTIONS])
             self.hass.config_entries.async_update_entry(self.config_entry, data=new_data) # type: ignore
 
+            # If neighbors was just disabled, clean up existing entities
+            now_neighbors_enabled = user_input.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)
+            if old_neighbors_enabled and not now_neighbors_enabled:
+                coordinator = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+                if coordinator and hasattr(coordinator, "cleanup_neighbor_entities"):
+                    removed = coordinator.cleanup_neighbor_entities(prefix)
+                    _LOGGER.info(
+                        "Disabled neighbors for %s: removed %d entities",
+                        repeater.get("name"), removed,
+                    )
+
             return await self.async_step_init()
 
         # Show current settings
@@ -1242,6 +1272,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     description={"suggested_value": repeater.get(CONF_REPEATER_PASSWORD, "")}
                 ): str,
                 vol.Optional(CONF_REPEATER_TELEMETRY_ENABLED, default=repeater.get(CONF_REPEATER_TELEMETRY_ENABLED, False)): bool,
+                vol.Optional(CONF_REPEATER_NEIGHBORS_ENABLED, default=repeater.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)): bool,
                 vol.Optional(CONF_REPEATER_UPDATE_INTERVAL, default=repeater.get(CONF_REPEATER_UPDATE_INTERVAL, DEFAULT_REPEATER_UPDATE_INTERVAL)): vol.All(cv.positive_int, vol.Range(min=MIN_UPDATE_INTERVAL)),
                 vol.Optional(CONF_REPEATER_DISABLE_PATH_RESET, default=repeater.get(CONF_REPEATER_DISABLE_PATH_RESET, False)): bool,
                 vol.Optional(CONF_DEVICE_DISABLED, default=repeater.get(CONF_DEVICE_DISABLED, False)): bool,

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -66,6 +66,7 @@ CONF_REPEATER_PASSWORD: Final = "password"
 CONF_REPEATER_UPDATE_INTERVAL: Final = "update_interval"
 CONF_REPEATER_TELEMETRY_ENABLED: Final = "telemetry_enabled"
 CONF_REPEATER_DISABLE_PATH_RESET: Final = "disable_path_reset"
+CONF_REPEATER_NEIGHBORS_ENABLED: Final = "neighbors_enabled"
 DEFAULT_REPEATER_UPDATE_INTERVAL: Final = 7200  # 2 hours in seconds
 MIN_UPDATE_INTERVAL: Final = 300  # 5 minutes minimum
 MAX_REPEATER_FAILURES_BEFORE_LOGIN: Final = 5  # After this many failures, try login
@@ -113,6 +114,14 @@ REPEATER_BACKOFF_MAX_MULTIPLIER: Final = 120  # Maximum backoff multiplier (10 m
 MAX_FAILURES_BEFORE_PATH_RESET: Final = 3  # Reset path after this many failures
 MAX_RETRY_ATTEMPTS: Final = 5  # Maximum retry attempts within refresh window
 MAX_RANDOM_DELAY: Final = 30  # Maximum random delay in seconds
+
+# Repeater neighbor settings
+NEIGHBOR_PUBKEY_PREFIX_LENGTH: Final = 6  # Bytes requested from firmware (12 hex chars)
+NEIGHBOR_STALE_THRESHOLD: Final = 259200  # 72 hours in seconds — neighbor goes unavailable after this
+SEEN_WINDOW_SECS: Final = 172800  # 48-hour rolling window for seen count
+CONF_AUTO_CLEANUP_STALE_NEIGHBORS: Final = "auto_cleanup_stale_neighbors"
+CONF_STALE_NEIGHBOR_DAYS: Final = "stale_neighbor_days"
+DEFAULT_STALE_NEIGHBOR_DAYS: Final = 7
 
 
 # Generic battery voltage to percentage lookup table

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -49,6 +49,13 @@ from .const import (
     RATE_LIMITER_REFILL_RATE_SECONDS,
     RX_LOG_CACHE_MAX_SIZE,
     RX_LOG_CACHE_TTL_SECONDS,
+    NEIGHBOR_PUBKEY_PREFIX_LENGTH,
+    NEIGHBOR_STALE_THRESHOLD,
+    SEEN_WINDOW_SECS,
+    CONF_REPEATER_NEIGHBORS_ENABLED,
+    CONF_AUTO_CLEANUP_STALE_NEIGHBORS,
+    CONF_STALE_NEIGHBOR_DAYS,
+    DEFAULT_STALE_NEIGHBOR_DAYS,
 )
 from .meshcore_api import MeshCoreAPI
 
@@ -88,6 +95,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Storage for discovered contacts
         self._store = Store[dict[str, dict]](hass, 1, f"meshcore.{config_entry.entry_id}.discovered_contacts")
+        # Storage for neighbor data (persists SNR, seen_timestamps, etc. across restarts)
+        self._neighbor_store = Store[dict[str, dict]](
+            hass, 1, f"meshcore.{config_entry.entry_id}.neighbor_data"
+        )
+        self._neighbor_data_loaded = False
         # Get name and pubkey from config_entry.data (not options)
         self.name = config_entry.data.get(CONF_NAME)
         self.pubkey = config_entry.data.get(CONF_PUBKEY)
@@ -176,6 +188,22 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # safety-net poll only fires after MSG_SAFETY_NET_INTERVAL of silence.
         self._last_msg_activity: float = 0.0
         self._initial_drain_done: bool = False
+
+        # Repeater neighbor tracking
+        # Key: repeater pubkey_prefix, Value: dict of neighbor data keyed by neighbor pubkey
+        # Each neighbor entry: {pubkey, snr, secs_ago, last_updated, resolved_name}
+        self._repeater_neighbors: Dict[str, Dict[str, dict]] = {}
+        # Track which neighbor sensor entities have been created: set of "repeater_pubkey:neighbor_pubkey"
+        self._created_neighbor_sensors: set = set()
+
+        # Auto-cleanup of stale neighbors (daily)
+        self._auto_cleanup_stale_neighbors = config_entry.data.get(
+            CONF_AUTO_CLEANUP_STALE_NEIGHBORS, False
+        )
+        self._stale_neighbor_days = config_entry.data.get(
+            CONF_STALE_NEIGHBOR_DAYS, DEFAULT_STALE_NEIGHBOR_DAYS
+        )
+        self._last_stale_neighbor_cleanup = 0.0
 
         # RX_LOG correlation cache: auto-evicts after TTL expires
         # Key: correlation hash, Value: list of RX_LOG data (multiple receptions possible)
@@ -536,13 +564,390 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         self._stale_contact_days = config_entry.data.get(
             CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS
         )
+        self._auto_cleanup_stale_neighbors = config_entry.data.get(
+            CONF_AUTO_CLEANUP_STALE_NEIGHBORS, False
+        )
+        self._stale_neighbor_days = config_entry.data.get(
+            CONF_STALE_NEIGHBOR_DAYS, DEFAULT_STALE_NEIGHBOR_DAYS
+        )
         _LOGGER.debug(f"Updated telemetry settings - Enabled: {self._self_telemetry_enabled}, Interval: {self._self_telemetry_interval}, Tracked clients: {len(self._tracked_clients)}")
 
     def _current_time(self) -> int:
         """Return current time as integer seconds since epoch."""
         return int(time.time())
-    
-        
+
+    def resolve_neighbor_name(self, neighbor_pubkey: str) -> str:
+        """Resolve a neighbor pubkey prefix to a contact name.
+
+        Searches the merged contacts list (added + discovered) for a
+        public_key that starts with the neighbor's prefix.
+        Returns the hex prefix (uppercase) if no match is found.
+        """
+        for contact in (self.data or {}).get("contacts", []):
+            pk = contact.get("public_key", "") or contact.get("pubkey_prefix", "")
+            if pk and pk.lower().startswith(neighbor_pubkey.lower()):
+                return contact.get("adv_name") or contact.get("name") or neighbor_pubkey[:6].upper()
+        return neighbor_pubkey[:6].upper()
+
+    async def _fetch_repeater_neighbors(self, contact, repeater_name: str, pubkey_prefix: str):
+        """Fetch neighbor data for a repeater after a successful status request.
+
+        Calls the SDK's fetch_all_neighbours() binary command and stores the
+        result in self._repeater_neighbors. Creates new sensor entities for
+        any neighbors not previously seen. Tracks sightings as timestamps in
+        a rolling 48h window (seen_timestamps). Persists neighbor data to
+        storage for survival across restarts.
+        """
+        try:
+            # Check rate limiter before making mesh request
+            if not self._rate_limiter.try_consume(1):
+                self.logger.debug(f"Rate limited: skipping neighbor fetch for {repeater_name}")
+                return
+
+            self.logger.debug(f"Fetching neighbors for repeater {repeater_name} ({pubkey_prefix})")
+            result = await self.api.mesh_core.commands.fetch_all_neighbours(
+                contact, pubkey_prefix_length=NEIGHBOR_PUBKEY_PREFIX_LENGTH
+            )
+
+            if not result or "neighbours" not in result:
+                self.logger.debug(f"No neighbor data returned for {repeater_name}")
+                return
+
+            neighbours = result["neighbours"]
+            now = time.time()
+            updated_neighbors = {}
+
+            # Get existing data before iteration (for seen_timestamps carry-over)
+            existing = self._repeater_neighbors.get(pubkey_prefix, {})
+            cutoff = now - SEEN_WINDOW_SECS
+
+            for neighbour in neighbours:
+                if not neighbour or not isinstance(neighbour, dict):
+                    continue
+                n_pubkey = neighbour.get("pubkey", "")
+                if not n_pubkey:
+                    continue
+                n_snr = neighbour.get("snr", 0)
+                n_secs_ago = neighbour.get("secs_ago", 0)
+
+                # Track sightings as timestamps in a rolling 48h window.
+                # The firmware computes secs_ago from its own RTC, so if secs_ago
+                # decreased since last poll, heard_timestamp was refreshed — the
+                # neighbor was heard again. If secs_ago grew or stayed the same,
+                # nothing new happened.
+                existing_data = existing.get(n_pubkey, {})
+                prev_secs_ago = existing_data.get("secs_ago")
+
+                # Carry forward existing timestamps, pruning entries older than 48h
+                prev_timestamps = existing_data.get("seen_timestamps", [])
+                seen_timestamps = [t for t in prev_timestamps if t > cutoff]
+
+                # Only record a sighting if the neighbor was actually heard
+                # within the 48h window.  After an HA restart the stored
+                # secs_ago is inflated by the elapsed downtime, so the
+                # "n_secs_ago < prev_secs_ago" comparison would incorrectly
+                # treat every stale neighbor as newly heard.
+                if n_secs_ago <= SEEN_WINDOW_SECS:
+                    if prev_secs_ago is None:
+                        # First sighting — always record it
+                        seen_timestamps.append(now)
+                    elif n_secs_ago < prev_secs_ago:
+                        # secs_ago decreased — firmware heard this neighbor again
+                        seen_timestamps.append(now)
+                # else: stale (>48h) or secs_ago grew/stayed same — don't record
+
+                updated_neighbors[n_pubkey] = {
+                    "pubkey": n_pubkey,
+                    "snr": n_snr,
+                    "secs_ago": n_secs_ago,
+                    "last_updated": now,
+                    "resolved_name": self.resolve_neighbor_name(n_pubkey),
+                    "seen_timestamps": seen_timestamps,
+                }
+
+            # Preserve neighbors from previous polls that aren't in this response
+            # (they may still be valid, just not in the current page)
+            for n_pubkey, n_data in existing.items():
+                if n_pubkey not in updated_neighbors:
+                    # Keep old data but don't update last_updated — staleness
+                    # is tracked via secs_ago from the most recent poll that included it.
+                    # Prune seen_timestamps so stale entries don't inflate the count.
+                    prev_ts = n_data.get("seen_timestamps", [])
+                    n_data["seen_timestamps"] = [t for t in prev_ts if t > cutoff]
+                    updated_neighbors[n_pubkey] = n_data
+
+            self._repeater_neighbors[pubkey_prefix] = updated_neighbors
+
+            # Persist neighbor data (strip resolved_name — resolved live from contacts)
+            await self._save_neighbor_data()
+
+            # Create sensor entities for any new neighbors
+            new_neighbors = []
+            for n_pubkey in updated_neighbors:
+                sensor_key = f"{pubkey_prefix}:{n_pubkey}"
+                if sensor_key not in self._created_neighbor_sensors:
+                    new_neighbors.append(n_pubkey)
+                    self._created_neighbor_sensors.add(sensor_key)
+
+            if new_neighbors and hasattr(self, "sensor_add_entities") and self.sensor_add_entities:
+                from .sensor import MeshCoreNeighborSensor, MeshCoreNeighborSeenSensor
+                new_entities = []
+                for n_pubkey in new_neighbors:
+                    try:
+                        snr_sensor = MeshCoreNeighborSensor(
+                            coordinator=self,
+                            repeater_pubkey=pubkey_prefix,
+                            repeater_name=repeater_name,
+                            neighbor_pubkey=n_pubkey,
+                        )
+                        seen_sensor = MeshCoreNeighborSeenSensor(
+                            coordinator=self,
+                            repeater_pubkey=pubkey_prefix,
+                            repeater_name=repeater_name,
+                            neighbor_pubkey=n_pubkey,
+                        )
+                        new_entities.extend([snr_sensor, seen_sensor])
+                        self.logger.info(
+                            "Creating neighbor sensors: %s -> %s (%s)",
+                            repeater_name,
+                            updated_neighbors[n_pubkey]["resolved_name"],
+                            n_pubkey[:6],
+                        )
+                    except Exception as ex:
+                        self.logger.error(f"Error creating neighbor sensors for {n_pubkey}: {ex}")
+                if new_entities:
+                    self.sensor_add_entities(new_entities)
+
+            self.logger.debug(
+                f"Updated {len(neighbours)} neighbors for {repeater_name} "
+                f"({len(new_neighbors)} new sensors created)"
+            )
+
+        except Exception as ex:
+            self.logger.warning(f"Exception fetching neighbors for {repeater_name}: {ex}")
+
+    def _persistable_neighbors(self) -> dict:
+        """Return neighbor data suitable for persistence (no transient fields)."""
+        result = {}
+        for rptr_prefix, neighbors in self._repeater_neighbors.items():
+            result[rptr_prefix] = {}
+            for n_pubkey, n_data in neighbors.items():
+                result[rptr_prefix][n_pubkey] = {
+                    k: v for k, v in n_data.items() if k != "resolved_name"
+                }
+        return result
+
+    async def _save_neighbor_data(self) -> None:
+        """Save current neighbor data to persistent storage."""
+        try:
+            await self._neighbor_store.async_save(self._persistable_neighbors())
+        except Exception as ex:
+            _LOGGER.error("Error saving neighbor data: %s", ex)
+
+    async def _cleanup_stale_neighbors(self, days_threshold: int) -> int:
+        """Remove neighbors whose last_heard exceeds the age threshold.
+
+        Uses last_heard = last_updated - secs_ago (the actual time the repeater
+        heard the neighbor, not the poll time).
+
+        Three-phase approach mirroring stale contacts cleanup:
+        1. Collect stale neighbors (no side effects)
+        2. Remove entities + in-memory data in batches
+        3. Persist and refresh state
+
+        Returns the number of neighbors removed.
+        """
+        from homeassistant.helpers import entity_registry as er
+
+        now = time.time()
+        threshold_seconds = days_threshold * 86400
+        entity_registry = er.async_get(self.hass)
+
+        # Phase 1: Collect stale neighbors across all repeaters
+        stale_entries: list[tuple[str, str, str]] = []  # (repeater_prefix, neighbor_pubkey, resolved_name)
+        for rptr_prefix, neighbors in self._repeater_neighbors.items():
+            for n_pubkey, n_data in neighbors.items():
+                last_updated = n_data.get("last_updated", 0)
+                secs_ago = n_data.get("secs_ago", 0)
+
+                # Skip neighbors with no data yet (just loaded from storage
+                # without a poll)
+                if last_updated == 0 and secs_ago == 0:
+                    continue
+
+                last_heard = last_updated - secs_ago
+                if last_heard > 0 and (now - last_heard) > threshold_seconds:
+                    resolved = n_data.get("resolved_name", n_pubkey[:6])
+                    stale_entries.append((rptr_prefix, n_pubkey, resolved))
+
+        if not stale_entries:
+            _LOGGER.debug(
+                "Stale neighbor cleanup: 0 neighbors older than %d days",
+                days_threshold,
+            )
+            return 0
+
+        # Phase 2: Remove in batches, yielding the event loop between each
+        # batch so WebSocket clients can drain their message queues.
+        batch_size = 10
+        removed_count = 0
+
+        for i, (rptr_prefix, n_pubkey, resolved_name) in enumerate(stale_entries):
+            # Remove both sensor entities (SNR + Seen) from entity registry
+            unique_id_prefix = (
+                f"{self.config_entry.entry_id}_repeater_{rptr_prefix}"
+                f"_neighbor_{n_pubkey[:12]}"
+            )
+            for entity in list(entity_registry.entities.values()):
+                if entity.platform == DOMAIN and (entity.unique_id or "").startswith(unique_id_prefix):
+                    entity_registry.async_remove(entity.entity_id)
+
+            # Remove from created sensors tracking
+            sensor_key = f"{rptr_prefix}:{n_pubkey}"
+            self._created_neighbor_sensors.discard(sensor_key)
+
+            # Remove from in-memory neighbor data
+            repeater_neighbors = self._repeater_neighbors.get(rptr_prefix, {})
+            repeater_neighbors.pop(n_pubkey, None)
+
+            removed_count += 1
+            _LOGGER.debug(
+                "Removed stale neighbor: %s (%s) on repeater %s",
+                resolved_name, n_pubkey[:6], rptr_prefix[:6],
+            )
+
+            # Yield the event loop every batch_size removals
+            if (i + 1) % batch_size == 0:
+                await asyncio.sleep(0)
+
+        # Phase 3: Persist and refresh once after all removals
+        if removed_count > 0:
+            await self._save_neighbor_data()
+
+            updated_data = dict(self.data) if self.data else {}
+            self.async_set_updated_data(updated_data)
+
+        _LOGGER.info(
+            "Stale neighbor cleanup: removed %d neighbors older than %d days",
+            removed_count, days_threshold,
+        )
+        return removed_count
+
+    async def async_load_neighbor_data(self) -> None:
+        """Load persisted neighbor data from storage.
+
+        Must be called before sensor platform setup so that sensor.py can
+        recreate neighbor sensor entities from the persisted data. Does NOT
+        populate _created_neighbor_sensors — that is done by sensor.py when
+        it actually instantiates the sensor objects.
+        """
+        if self._neighbor_data_loaded:
+            return
+        try:
+            stored = await self._neighbor_store.async_load()
+            if stored:
+                now = time.time()
+                for rptr_prefix, neighbors in stored.items():
+                    for n_pubkey, n_data in neighbors.items():
+                        last_updated = n_data.get("last_updated", now)
+                        elapsed = now - last_updated
+                        n_data["secs_ago"] = n_data.get("secs_ago", 0) + int(elapsed)
+                        n_data["resolved_name"] = self.resolve_neighbor_name(n_pubkey)
+                        # Migrate from seen_count (integer) to seen_timestamps (list)
+                        if "seen_count" in n_data and "seen_timestamps" not in n_data:
+                            n_data["seen_timestamps"] = []
+                            del n_data["seen_count"]
+                self._repeater_neighbors = stored
+                self.logger.info(
+                    "Loaded persisted neighbor data for %d repeaters (%d total neighbors)",
+                    len(stored),
+                    sum(len(n) for n in stored.values()),
+                )
+        except Exception as ex:
+            self.logger.error("Error loading persisted neighbor data: %s", ex)
+        self._neighbor_data_loaded = True
+
+    def remove_single_neighbor(self, repeater_pubkey: str, neighbor_pubkey: str) -> int:
+        """Remove a single neighbor's sensor entities from HA and coordinator tracking.
+
+        Removes both SNR and Seen sensor entities for the specified neighbor,
+        removes from in-memory data and created sensors set, and persists.
+        Returns the number of entities removed.
+        """
+        from homeassistant.helpers import entity_registry as er
+
+        entity_registry = er.async_get(self.hass)
+        # Unique IDs end with _neighbor_{pubkey[:12]}_snr or _seen
+        unique_id_prefix = (
+            f"{self.config_entry.entry_id}_repeater_{repeater_pubkey}"
+            f"_neighbor_{neighbor_pubkey[:12]}"
+        )
+        removed = 0
+
+        for entity in list(entity_registry.entities.values()):
+            if entity.platform == DOMAIN and (entity.unique_id or "").startswith(unique_id_prefix):
+                _LOGGER.info("Removing neighbor entity: %s", entity.entity_id)
+                entity_registry.async_remove(entity.entity_id)
+                removed += 1
+
+        # Remove from in-memory neighbor data
+        repeater_neighbors = self._repeater_neighbors.get(repeater_pubkey, {})
+        if neighbor_pubkey in repeater_neighbors:
+            del repeater_neighbors[neighbor_pubkey]
+
+        # Remove from created sensors tracking
+        sensor_key = f"{repeater_pubkey}:{neighbor_pubkey}"
+        self._created_neighbor_sensors.discard(sensor_key)
+
+        # Persist updated data
+        self.hass.async_create_task(self._save_neighbor_data())
+
+        if removed:
+            _LOGGER.info(
+                "Removed %d entities for neighbor %s on repeater %s",
+                removed, neighbor_pubkey[:6], repeater_pubkey[:6]
+            )
+
+        return removed
+
+    def cleanup_neighbor_entities(self, pubkey_prefix: str) -> int:
+        """Remove all neighbor sensor entities for a repeater from the entity registry.
+
+        Called when the neighbors_enabled toggle is turned off for a repeater.
+        Removes both SNR and Seen sensor entities, clears in-memory tracking,
+        and removes persisted data for this repeater.
+        Returns the number of entities removed.
+        """
+        from homeassistant.helpers import entity_registry as er
+
+        entity_registry = er.async_get(self.hass)
+        unique_id_prefix = f"{self.config_entry.entry_id}_repeater_{pubkey_prefix}_neighbor_"
+        removed = 0
+
+        for entity in list(entity_registry.entities.values()):
+            if entity.platform == DOMAIN and (entity.unique_id or "").startswith(unique_id_prefix):
+                _LOGGER.info("Removing neighbor entity: %s", entity.entity_id)
+                entity_registry.async_remove(entity.entity_id)
+                removed += 1
+
+        # Clear in-memory tracking for this repeater's neighbors
+        self._repeater_neighbors.pop(pubkey_prefix, None)
+        self._created_neighbor_sensors = {
+            k for k in self._created_neighbor_sensors
+            if not k.startswith(f"{pubkey_prefix}:")
+        }
+
+        # Remove persisted data for this repeater and save
+        self.hass.async_create_task(self._save_neighbor_data())
+
+        if removed:
+            _LOGGER.info(
+                "Cleaned up %d neighbor entities for repeater %s",
+                removed, pubkey_prefix[:6]
+            )
+
+        return removed
+
     async def _update_repeater(self, repeater_config):
         """Update a repeater and schedule the next update.
 
@@ -669,15 +1074,19 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                 # Reset failure count on success
                 self._repeater_consecutive_failures[pubkey_prefix] = 0
                 self._increment_success(pubkey_prefix)
-                
+
+                # Fetch neighbor data while we have a good connection (if enabled)
+                if repeater_config.get(CONF_REPEATER_NEIGHBORS_ENABLED, False):
+                    await self._fetch_repeater_neighbors(contact, repeater_name, pubkey_prefix)
+
                 # Trigger state updates for any entities listening for this repeater
                 self.async_set_updated_data(self.data)
-                
+
                 # Schedule next update based on configured interval
                 update_interval = repeater_config.get(CONF_REPEATER_UPDATE_INTERVAL, DEFAULT_REPEATER_UPDATE_INTERVAL)
                 next_update_time = self._current_time() + update_interval
                 self._next_repeater_update_times[pubkey_prefix] = next_update_time
-            
+
         except Exception as ex:
             self.logger.warning(f"Exception updating repeater {repeater_name}: {ex}")
             # Increment failure count and apply backoff
@@ -1142,5 +1551,20 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                     telemetry_task.set_name(f"client_telemetry_{client_name}")
                 else:
                     _LOGGER.warning(f"Could not find contact for client telemetry request: {pubkey_prefix}")
+
+        # Auto-cleanup stale neighbors (once per day)
+        if self._auto_cleanup_stale_neighbors and self._stale_neighbor_days > 0:
+            now_ts = time.time()
+            if now_ts - self._last_stale_neighbor_cleanup >= 86400:  # 24 hours
+                self._last_stale_neighbor_cleanup = now_ts
+                removed = await self._cleanup_stale_neighbors(
+                    self._stale_neighbor_days
+                )
+                if removed > 0:
+                    _LOGGER.info(
+                        "Auto-cleanup removed %d stale neighbors "
+                        "(older than %d days)",
+                        removed, self._stale_neighbor_days,
+                    )
 
         return result_data

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -867,49 +867,6 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             self.logger.error("Error loading persisted neighbor data: %s", ex)
         self._neighbor_data_loaded = True
 
-    def remove_single_neighbor(self, repeater_pubkey: str, neighbor_pubkey: str) -> int:
-        """Remove a single neighbor's sensor entities from HA and coordinator tracking.
-
-        Removes both SNR and Seen sensor entities for the specified neighbor,
-        removes from in-memory data and created sensors set, and persists.
-        Returns the number of entities removed.
-        """
-        from homeassistant.helpers import entity_registry as er
-
-        entity_registry = er.async_get(self.hass)
-        # Unique IDs end with _neighbor_{pubkey[:12]}_snr or _seen
-        unique_id_prefix = (
-            f"{self.config_entry.entry_id}_repeater_{repeater_pubkey}"
-            f"_neighbor_{neighbor_pubkey[:12]}"
-        )
-        removed = 0
-
-        for entity in list(entity_registry.entities.values()):
-            if entity.platform == DOMAIN and (entity.unique_id or "").startswith(unique_id_prefix):
-                _LOGGER.info("Removing neighbor entity: %s", entity.entity_id)
-                entity_registry.async_remove(entity.entity_id)
-                removed += 1
-
-        # Remove from in-memory neighbor data
-        repeater_neighbors = self._repeater_neighbors.get(repeater_pubkey, {})
-        if neighbor_pubkey in repeater_neighbors:
-            del repeater_neighbors[neighbor_pubkey]
-
-        # Remove from created sensors tracking
-        sensor_key = f"{repeater_pubkey}:{neighbor_pubkey}"
-        self._created_neighbor_sensors.discard(sensor_key)
-
-        # Persist updated data
-        self.hass.async_create_task(self._save_neighbor_data())
-
-        if removed:
-            _LOGGER.info(
-                "Removed %d entities for neighbor %s on repeater %s",
-                removed, neighbor_pubkey[:6], repeater_pubkey[:6]
-            )
-
-        return removed
-
     def cleanup_neighbor_entities(self, pubkey_prefix: str) -> int:
         """Remove all neighbor sensor entities for a repeater from the entity registry.
 

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -1608,6 +1608,19 @@ class MeshCoreNeighborSensor(CoordinatorEntity, SensorEntity):
         """Update the friendly name based on current resolved name."""
         self._attr_name = f"Neighbor {self._resolved_name} SNR"
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator updates — re-resolve friendly name before state write.
+
+        Picks up name changes when a neighbor later shows up in the contact list,
+        without depending on the frontend reading extra_state_attributes.
+        """
+        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
+        if new_name != self._resolved_name:
+            self._resolved_name = new_name
+            self._update_friendly_name()
+        super()._handle_coordinator_update()
+
     @property
     def _neighbor_data(self) -> dict | None:
         """Get current neighbor data from coordinator."""
@@ -1653,12 +1666,6 @@ class MeshCoreNeighborSensor(CoordinatorEntity, SensorEntity):
             days = secs_ago // 86400
             hours = (secs_ago % 86400) // 3600
             last_seen = f"{days}d {hours}h ago"
-
-        # Re-resolve name on each attribute read (picks up newly discovered contacts)
-        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
-        if new_name != self._resolved_name:
-            self._resolved_name = new_name
-            self._update_friendly_name()
 
         last_updated = data.get("last_updated")
         last_updated_str = (
@@ -1739,6 +1746,19 @@ class MeshCoreNeighborSeenSensor(CoordinatorEntity, SensorEntity):
         """Update the friendly name based on current resolved name."""
         self._attr_name = f"Neighbor {self._resolved_name} Seen"
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator updates — re-resolve friendly name before state write.
+
+        Picks up name changes when a neighbor later shows up in the contact list,
+        without depending on the frontend reading extra_state_attributes.
+        """
+        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
+        if new_name != self._resolved_name:
+            self._resolved_name = new_name
+            self._update_friendly_name()
+        super()._handle_coordinator_update()
+
     @property
     def _neighbor_data(self) -> dict | None:
         """Get current neighbor data from coordinator."""
@@ -1766,12 +1786,6 @@ class MeshCoreNeighborSeenSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
-        # Re-resolve name on each attribute read
-        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
-        if new_name != self._resolved_name:
-            self._resolved_name = new_name
-            self._update_friendly_name()
-
         return {
             "pubkey_prefix": self._neighbor_pubkey,
             "resolved_name": self._resolved_name,

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -28,8 +28,11 @@ from .const import (
     DOMAIN,
     ENTITY_DOMAIN_SENSOR,
     CONF_REPEATER_SUBSCRIPTIONS,
+    CONF_REPEATER_NEIGHBORS_ENABLED,
     CONF_TRACKED_CLIENTS,
     SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER,
+    NEIGHBOR_STALE_THRESHOLD,
+    SEEN_WINDOW_SECS,
 )
 from .utils import (
     format_entity_id,
@@ -533,6 +536,52 @@ async def async_setup_entry(
     entry.async_on_unload(unsub_sent)
     entry.async_on_unload(unsub_delivery)
     entry.async_on_unload(unsub_logbook)
+
+    # Recreate sensor entities for any persisted neighbors (survives restarts)
+    if coordinator._repeater_neighbors:
+        persisted_entities = []
+        for rptr_prefix, neighbors in coordinator._repeater_neighbors.items():
+            # Look up repeater name and check if neighbors are enabled
+            rptr_name = "Unknown"
+            neighbors_enabled = False
+            for sub in repeater_subscriptions:
+                if sub.get("pubkey_prefix") == rptr_prefix:
+                    rptr_name = sub.get("name", "Unknown")
+                    neighbors_enabled = sub.get(CONF_REPEATER_NEIGHBORS_ENABLED, False)
+                    break
+
+            if not neighbors_enabled:
+                continue
+
+            for n_pubkey in neighbors:
+                try:
+                    snr_sensor = MeshCoreNeighborSensor(
+                        coordinator=coordinator,
+                        repeater_pubkey=rptr_prefix,
+                        repeater_name=rptr_name,
+                        neighbor_pubkey=n_pubkey,
+                    )
+                    seen_sensor = MeshCoreNeighborSeenSensor(
+                        coordinator=coordinator,
+                        repeater_pubkey=rptr_prefix,
+                        repeater_name=rptr_name,
+                        neighbor_pubkey=n_pubkey,
+                    )
+                    persisted_entities.extend([snr_sensor, seen_sensor])
+                    # Mark as created so _fetch_repeater_neighbors doesn't
+                    # try to duplicate them on the next poll cycle
+                    coordinator._created_neighbor_sensors.add(
+                        f"{rptr_prefix}:{n_pubkey}"
+                    )
+                except Exception as ex:
+                    _LOGGER.error("Error recreating neighbor sensor for %s: %s", n_pubkey, ex)
+
+        if persisted_entities:
+            async_add_entities(persisted_entities)
+            _LOGGER.info(
+                "Recreated %d neighbor sensor entities from persisted data",
+                len(persisted_entities),
+            )
 
 
 class RateLimiterSensor(CoordinatorEntity, SensorEntity):
@@ -1493,7 +1542,239 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
         return attributes
 
 
+class MeshCoreNeighborSensor(CoordinatorEntity, SensorEntity):
+    """Sensor tracking SNR from a repeater to one of its neighbors.
+
+    Created dynamically by the coordinator when a new neighbor is discovered
+    during a repeater update cycle. The sensor reads its state from
+    coordinator._repeater_neighbors[repeater_pubkey][neighbor_pubkey].
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "dB"
+    _attr_icon = "mdi:signal-variant"
+
+    def __init__(
+        self,
+        coordinator: MeshCoreDataUpdateCoordinator,
+        repeater_pubkey: str,
+        repeater_name: str,
+        neighbor_pubkey: str,
+    ) -> None:
+        """Initialize the neighbor SNR sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._repeater_pubkey = repeater_pubkey
+        self._repeater_name = repeater_name
+        self._neighbor_pubkey = neighbor_pubkey
+        self._repeater_pubkey_short = repeater_pubkey[:6] if repeater_pubkey else ""
+        self._neighbor_pubkey_short = neighbor_pubkey[:6].lower() if neighbor_pubkey else ""
+
+        # Build device_id matching the repeater's existing device
+        self._device_id = f"{coordinator.config_entry.entry_id}_repeater_{repeater_pubkey}"
+
+        # Unique ID uses 12-char neighbor prefix for stability
+        self._attr_unique_id = (
+            f"{self._device_id}_neighbor_{neighbor_pubkey[:12]}_snr"
+        )
+
+        # Entity ID: sensor.meshcore_{repeater_pubkey[:10]}_neighbor_{neighbor_pubkey[:6]}
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR,
+            repeater_pubkey[:10],
+            "neighbor",
+            self._neighbor_pubkey_short,
+        )
+
+        # Resolve initial name
+        self._resolved_name = coordinator.resolve_neighbor_name(neighbor_pubkey)
+
+        # Friendly name: "{Repeater} Neighbor {Name} SNR"
+        self._update_friendly_name()
+
+        # Device info — attach to the repeater's existing device
+        device_name = f"MeshCore Repeater: {repeater_name} ({self._repeater_pubkey_short})"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer="MeshCore",
+            model="Mesh Repeater",
+            via_device=(DOMAIN, coordinator.config_entry.entry_id),
+        )
+
+    def _update_friendly_name(self):
+        """Update the friendly name based on current resolved name."""
+        self._attr_name = f"Neighbor {self._resolved_name} SNR"
+
+    @property
+    def _neighbor_data(self) -> dict | None:
+        """Get current neighbor data from coordinator."""
+        repeater_neighbors = self.coordinator._repeater_neighbors.get(self._repeater_pubkey, {})
+        return repeater_neighbors.get(self._neighbor_pubkey)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the neighbor was heard within the stale threshold."""
+        data = self._neighbor_data
+        if data is None:
+            return False
+        secs_ago = data.get("secs_ago", 0)
+        return secs_ago < NEIGHBOR_STALE_THRESHOLD
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the SNR value."""
+        data = self._neighbor_data
+        if data is None:
+            return None
+        return data.get("snr")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes for the neighbor."""
+        data = self._neighbor_data
+        if data is None:
+            return {}
+
+        secs_ago = data.get("secs_ago", 0)
+
+        # Human-readable last seen
+        if secs_ago < 60:
+            last_seen = f"{secs_ago}s ago"
+        elif secs_ago < 3600:
+            last_seen = f"{secs_ago // 60}m {secs_ago % 60}s ago"
+        elif secs_ago < 86400:
+            hours = secs_ago // 3600
+            mins = (secs_ago % 3600) // 60
+            last_seen = f"{hours}h {mins}m ago"
+        else:
+            days = secs_ago // 86400
+            hours = (secs_ago % 86400) // 3600
+            last_seen = f"{days}d {hours}h ago"
+
+        # Re-resolve name on each attribute read (picks up newly discovered contacts)
+        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
+        if new_name != self._resolved_name:
+            self._resolved_name = new_name
+            self._update_friendly_name()
+
+        last_updated = data.get("last_updated")
+        last_updated_str = (
+            datetime.fromtimestamp(last_updated).isoformat()
+            if last_updated
+            else "Unknown"
+        )
+
+        return {
+            "secs_ago": secs_ago,
+            "last_seen": last_seen,
+            "pubkey_prefix": self._neighbor_pubkey,
+            "resolved_name": self._resolved_name,
+            "last_updated": last_updated_str,
+            "seen_48h": len([t for t in data.get("seen_timestamps", []) if t > time.time() - SEEN_WINDOW_SECS]),
+        }
 
 
+class MeshCoreNeighborSeenSensor(CoordinatorEntity, SensorEntity):
+    """Sensor tracking how many times a neighbor has been seen in the last 48 hours.
+
+    Uses state_class MEASUREMENT since the 48h rolling window can decrease
+    as old sightings age out.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:counter"
+
+    def __init__(
+        self,
+        coordinator: MeshCoreDataUpdateCoordinator,
+        repeater_pubkey: str,
+        repeater_name: str,
+        neighbor_pubkey: str,
+    ) -> None:
+        """Initialize the neighbor seen counter sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._repeater_pubkey = repeater_pubkey
+        self._repeater_name = repeater_name
+        self._neighbor_pubkey = neighbor_pubkey
+        self._repeater_pubkey_short = repeater_pubkey[:6] if repeater_pubkey else ""
+        self._neighbor_pubkey_short = neighbor_pubkey[:6].lower() if neighbor_pubkey else ""
+
+        # Build device_id matching the repeater's existing device
+        self._device_id = f"{coordinator.config_entry.entry_id}_repeater_{repeater_pubkey}"
+
+        # Unique ID: distinct from the SNR sensor (_seen vs _snr suffix)
+        self._attr_unique_id = (
+            f"{self._device_id}_neighbor_{neighbor_pubkey[:12]}_seen"
+        )
+
+        # Entity ID: sensor.meshcore_{repeater_short}_neighbor_{neighbor_short}_seen
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR,
+            repeater_pubkey[:10],
+            "neighbor",
+            f"{self._neighbor_pubkey_short}_seen",
+        )
+
+        # Resolve initial name
+        self._resolved_name = coordinator.resolve_neighbor_name(neighbor_pubkey)
+        self._update_friendly_name()
+
+        # Device info — attach to the repeater's existing device
+        device_name = f"MeshCore Repeater: {repeater_name} ({self._repeater_pubkey_short})"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer="MeshCore",
+            model="Mesh Repeater",
+            via_device=(DOMAIN, coordinator.config_entry.entry_id),
+        )
+
+    def _update_friendly_name(self):
+        """Update the friendly name based on current resolved name."""
+        self._attr_name = f"Neighbor {self._resolved_name} Seen"
+
+    @property
+    def _neighbor_data(self) -> dict | None:
+        """Get current neighbor data from coordinator."""
+        repeater_neighbors = self.coordinator._repeater_neighbors.get(self._repeater_pubkey, {})
+        return repeater_neighbors.get(self._neighbor_pubkey)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the neighbor was heard within the stale threshold."""
+        data = self._neighbor_data
+        if data is None:
+            return False
+        secs_ago = data.get("secs_ago", 0)
+        return secs_ago < NEIGHBOR_STALE_THRESHOLD
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number of sightings in the last 48 hours."""
+        data = self._neighbor_data
+        if data is None:
+            return None
+        cutoff = time.time() - SEEN_WINDOW_SECS
+        return len([t for t in data.get("seen_timestamps", []) if t > cutoff])
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes."""
+        # Re-resolve name on each attribute read
+        new_name = self.coordinator.resolve_neighbor_name(self._neighbor_pubkey)
+        if new_name != self._resolved_name:
+            self._resolved_name = new_name
+            self._update_friendly_name()
+
+        return {
+            "pubkey_prefix": self._neighbor_pubkey,
+            "resolved_name": self._resolved_name,
+        }
 
 

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -93,7 +93,7 @@
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
         },
         "data_description": {
-          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.0."
         },
         "description": "Monitor a repeater for telemetry and status",
         "title": "Add Repeater Station"
@@ -122,7 +122,7 @@
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
         },
         "data_description": {
-          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.0."
         },
         "description": "Edit settings for {device_name}",
         "title": "Edit Repeater"
@@ -211,7 +211,7 @@
           "disable_path_reset": "Disable Path Reset"
         },
         "data_description": {
-          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.0."
         },
         "description": "Monitor a repeater for telemetry and status",
         "title": "Add Repeater Station"
@@ -243,7 +243,7 @@
           "disabled": "Disable Device"
         },
         "data_description": {
-          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.0."
         },
         "description": "Edit settings for {device_name}",
         "title": "Edit Repeater"

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -92,6 +92,9 @@
           "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
         },
+        "data_description": {
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+        },
         "description": "Monitor a repeater for telemetry and status",
         "title": "Add Repeater Station"
       },
@@ -117,6 +120,9 @@
           "telemetry_enabled": "Enable Telemetry Polling (automatically polls and discovers telemetry data)",
           "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
+        },
+        "data_description": {
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
         },
         "description": "Edit settings for {device_name}",
         "title": "Edit Repeater"
@@ -204,6 +210,9 @@
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)",
           "disable_path_reset": "Disable Path Reset"
         },
+        "data_description": {
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
+        },
         "description": "Monitor a repeater for telemetry and status",
         "title": "Add Repeater Station"
       },
@@ -232,6 +241,9 @@
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)",
           "disable_path_reset": "Disable Path Reset",
           "disabled": "Disable Device"
+        },
+        "data_description": {
+          "neighbors_enabled": "Queries this repeater for its neighbor list on each poll cycle and exposes each neighbor as two sensors. Airtime cost is one direct request and response per cycle — at the default 2-hour `Update Interval` that's roughly one exchange every 2 hours per enabled repeater, comparable to one extra telemetry request. Requires MeshCore firmware \u2265 1.14.1."
         },
         "description": "Edit settings for {device_name}",
         "title": "Edit Repeater"

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -89,6 +89,7 @@
           "repeater_name": "Available Repeaters",
           "repeater_password": "Repeater Password",
           "telemetry_enabled": "Enable Telemetry Polling (automatically polls and discovers telemetry data)",
+          "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
         },
         "description": "Monitor a repeater for telemetry and status",
@@ -114,6 +115,7 @@
         "data": {
           "repeater_password": "Update Password (leave blank to keep current)",
           "telemetry_enabled": "Enable Telemetry Polling (automatically polls and discovers telemetry data)",
+          "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)"
         },
         "description": "Edit settings for {device_name}",
@@ -136,11 +138,15 @@
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
           "stale_contact_days": "Stale Contact Threshold (days)",
+          "auto_cleanup_stale_neighbors": "Auto-Remove Stale Neighbors",
+          "stale_neighbor_days": "Stale Neighbor Threshold (days)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
+          "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
+          "stale_neighbor_days": "Number of days without hearing a neighbor before it is automatically removed (1–365).",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",
@@ -194,6 +200,7 @@
           "repeater_name": "Available Repeaters",
           "repeater_password": "Repeater Password",
           "telemetry_enabled": "Enable Telemetry Polling",
+          "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)",
           "disable_path_reset": "Disable Path Reset"
         },
@@ -221,6 +228,7 @@
         "data": {
           "repeater_password": "Update Password (leave blank to keep current)",
           "telemetry_enabled": "Enable Telemetry Polling",
+          "neighbors_enabled": "Enable Neighbor Entities (creates SNR and activity sensors for each neighbor seen by the repeater)",
           "repeater_update_interval": "Telemetry Refresh Rate (seconds)",
           "disable_path_reset": "Disable Path Reset",
           "disabled": "Disable Device"
@@ -247,11 +255,15 @@
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
           "stale_contact_days": "Stale Contact Threshold (days)",
+          "auto_cleanup_stale_neighbors": "Auto-Remove Stale Neighbors",
+          "stale_neighbor_days": "Stale Neighbor Threshold (days)",
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
+          "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
+          "stale_neighbor_days": "Number of days without hearing a neighbor before it is automatically removed (1–365).",
           "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
         },
         "description": "Configure global integration settings",

--- a/docs/docs/repeater-neighbors.md
+++ b/docs/docs/repeater-neighbors.md
@@ -40,6 +40,26 @@ The friendly name for both sensors resolves to the neighbor's advertised name wh
 
 The next repeater update cycle will query the firmware for the neighbor list and create sensors. Disabling the toggle removes all neighbor sensors for that repeater, clears in-memory state, and deletes persisted data.
 
+## Airtime cost
+
+Enabling neighbor entities for a repeater adds a small, bounded amount of mesh traffic. The integration sends one binary request to the repeater on every poll cycle (default: every 2 hours, set by **Update Interval** on the repeater subscription) and the repeater replies with its current neighbor list.
+
+**Per cycle, per enabled repeater:**
+
+- **Request**: ~10 bytes of binary payload.
+- **Response**: 4-byte header plus ~11 bytes per neighbor in the list (6-byte pubkey prefix + 4-byte last-heard + 1-byte SNR). A repeater with 25 neighbors returns ~280 bytes; 50 neighbors returns ~550 bytes.
+
+**How this travels on the mesh.** The request and response are direct, path-routed messages between your Home Assistant gateway node and the repeater — not flood adverts. Only the nodes on the established path between the gateway and the repeater re-transmit the packets. The footprint therefore scales with the hop count to that specific repeater, not with the size of the mesh.
+
+- **Zero-hop repeater** (your gateway hears the repeater directly): only those two nodes are on-air for the exchange. The cheapest case.
+- **N-hop repeater**: each of the N intermediate repeaters also re-transmits. Airtime events per cycle are roughly `2 × (N + 1)`.
+
+In practical terms, the cost per cycle is comparable to sending one extra telemetry request to the same repeater, and substantially lower than a single flood advert or a group-channel message — both of which are re-transmitted by every repeater in range of any participant regardless of who the target is.
+
+**Cadence.** At the default 2-hour `Update Interval` this is about one exchange every 2 hours per enabled repeater, or ~12 per day per repeater. Shortening `Update Interval` scales the cost linearly.
+
+**Firmware requirement.** The repeater must run firmware that supports the neighbors binary request (MeshCore firmware ≥ 1.14.1). Older firmware will not respond and the sensors will remain unavailable until the repeater is updated.
+
 ## Persistence
 
 Neighbor data is stored through Home Assistant's `Store` helper. After a restart, all neighbor sensors are recreated from disk and the 48-hour activity window continues seamlessly. The integration guards `seen_timestamps` against the inflated `secs_ago` values the firmware reports during its own startup, so the rolling window remains accurate across both HA and repeater reboots.
@@ -54,10 +74,6 @@ Separate from the per-repeater enable toggle, an integration-wide option automat
 When enabled, a daily task removes matching neighbors from every tracked repeater. The sensors are removed from the entity registry, in-memory state is cleared, and the persisted data is rewritten. This prevents the sensor count from growing without bound in mobile or dense deployments where nodes come and go.
 
 Configure under **Configure → Global Settings**.
-
-## Removing a single neighbor
-
-The frontend sidebar panel exposes a button to remove an individual neighbor — useful when you want to prune a single stale entry without waiting for the daily cleanup or adjusting the global threshold. The removal is handled by a WebSocket API command consumed by the panel UI. It is not a Home Assistant service call and is not usable from YAML automations.
 
 ## Use cases
 

--- a/docs/docs/repeater-neighbors.md
+++ b/docs/docs/repeater-neighbors.md
@@ -58,7 +58,9 @@ In practical terms, the cost per cycle is comparable to sending one extra teleme
 
 **Cadence.** At the default 2-hour `Update Interval` this is about one exchange every 2 hours per enabled repeater, or ~12 per day per repeater. Shortening `Update Interval` scales the cost linearly.
 
-**Firmware requirement.** The repeater must run firmware that supports the neighbors binary request (MeshCore firmware ≥ 1.14.1). Older firmware will not respond and the sensors will remain unavailable until the repeater is updated.
+**Shared rate limiter.** The neighbor request consumes one token from the integration's shared mesh-request rate limiter — the same token bucket used for repeater status polls, login retries, and tracked-node telemetry (surfaced as the `rate_limiter_tokens` sensor). If the bucket is empty when a neighbor fetch is due, the fetch is skipped for that cycle and retries on the next poll; enabling neighbors therefore slightly increases contention for this shared pool in deployments that already track many repeaters and clients.
+
+**Firmware requirement.** The repeater must run firmware that supports the neighbors binary request (MeshCore firmware ≥ 1.14.0). Older firmware will not respond and the sensors will remain unavailable until the repeater is updated.
 
 ## Persistence
 

--- a/docs/docs/repeater-neighbors.md
+++ b/docs/docs/repeater-neighbors.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 2.5
+title: Repeater Neighbors
+---
+
+# Repeater Neighbors
+
+Each repeater in a MeshCore network keeps an in-firmware list of other nodes it has recently heard. The integration can surface that list to Home Assistant as a pair of sensors per neighbor — signal quality and activity — giving you a view of the mesh topology and health from the perspective of each repeater.
+
+This feature is **disabled by default** on every repeater. It has to be turned on explicitly for each repeater that you want to track neighbors for.
+
+## What gets created
+
+When enabled for a repeater, every distinct neighbor the repeater reports produces two sensors, both attached to that repeater's existing HA device:
+
+### SNR sensor
+
+- **Entity**: `sensor.meshcore_<repeater>_neighbor_<neighbor>`
+- **Unit**: dB
+- **State class**: Measurement
+- **Value**: Most recent signal-to-noise ratio the repeater measured from that neighbor
+- **Availability**: Becomes unavailable if the neighbor has not been heard in the last 72 hours
+
+### Activity sensor (`seen_48h`)
+
+- **Entity**: `sensor.meshcore_<repeater>_neighbor_<neighbor>_seen`
+- **Unit**: count
+- **State class**: Measurement (the value decreases as old sightings age out)
+- **Value**: Number of times this neighbor was heard by the repeater in the last 48 hours
+- **Availability**: Same 72-hour threshold as the SNR sensor
+
+The friendly name for both sensors resolves to the neighbor's advertised name when available, and falls back to a public-key prefix otherwise. Names update if the neighbor later shows up in the contact list.
+
+## Enabling neighbors for a repeater
+
+1. Go to **Settings → Devices & Services → Meshcore → Configure**
+2. Open the per-repeater subscription for the repeater you want to track
+3. Toggle **Enable Neighbor Entities**
+4. Save
+
+The next repeater update cycle will query the firmware for the neighbor list and create sensors. Disabling the toggle removes all neighbor sensors for that repeater, clears in-memory state, and deletes persisted data.
+
+## Persistence
+
+Neighbor data is stored through Home Assistant's `Store` helper. After a restart, all neighbor sensors are recreated from disk and the 48-hour activity window continues seamlessly. The integration guards `seen_timestamps` against the inflated `secs_ago` values the firmware reports during its own startup, so the rolling window remains accurate across both HA and repeater reboots.
+
+## Integration-level stale cleanup
+
+Separate from the per-repeater enable toggle, an integration-wide option automatically removes neighbors that haven't been heard in a configurable number of days. This is also **disabled by default**.
+
+- **Auto-Remove Stale Neighbors** — on/off
+- **Stale Neighbor Threshold (days)** — 1 to 365, default 7
+
+When enabled, a daily task removes matching neighbors from every tracked repeater. The sensors are removed from the entity registry, in-memory state is cleared, and the persisted data is rewritten. This prevents the sensor count from growing without bound in mobile or dense deployments where nodes come and go.
+
+Configure under **Configure → Global Settings**.
+
+## Removing a single neighbor
+
+The frontend sidebar panel exposes a button to remove an individual neighbor — useful when you want to prune a single stale entry without waiting for the daily cleanup or adjusting the global threshold. The removal is handled by a WebSocket API command consumed by the panel UI. It is not a Home Assistant service call and is not usable from YAML automations.
+
+## Use cases
+
+**Mesh health at a glance**
+: Each repeater's neighbor SNR sensors form a snapshot of its local radio environment. Graphing them over time shows degradation, new arrivals, or links dropping out before they become network-wide problems.
+
+**Activity-based alerts**
+: The `seen_48h` sensors make it easy to flag a repeater that has stopped hearing a neighbor it normally hears dozens of times a day.
+
+**Coverage mapping**
+: Combining neighbor lists from multiple repeaters gives you a first-order view of which nodes are within direct earshot of which, without having to correlate RX_LOG entries yourself.
+
+## Notes
+
+- Sensors are only created for repeaters the integration actively tracks (i.e., ones you've subscribed to). Neighbors of a repeater you haven't subscribed to will not appear.
+- The neighbor list comes from the repeater firmware's own tracking. Nodes the repeater has never heard will not appear even if they exist elsewhere in the mesh.
+- Turning the per-repeater toggle off cleans up immediately — you don't need to restart Home Assistant.


### PR DESCRIPTION
### Summary

Each repeater in a MeshCore network keeps an in-firmware list of the other nodes it has recently heard. This PR surfaces that list to Home Assistant as a pair of sensors per neighbor — one for signal quality, one for activity — giving a first-order view of mesh topology and health from the perspective of each repeater.

The feature is **disabled by default** on every repeater and must be turned on explicitly per-repeater.

### Why

Today the integration has no view into *who each repeater is hearing*. You can infer some of this by correlating RX_LOG entries yourself, but that's heavy-handed for anything an operator would want from a dashboard. Exposing the firmware's own neighbor list directly gives a bounded, structured view of local radio environment per repeater — which is exactly the information needed to answer "is this repeater still hearing the nodes it used to hear" or "did we pick up a new node nearby."

The sensors are consumed by the upcoming sidebar-panel frontend for its mesh-health views, but they are fully native HA entities usable on their own for automations, alerts, and long-term graphing.

### What changes

**Two sensors per neighbor, attached to that repeater's existing HA device:**

- **SNR sensor** — `sensor.meshcore_<repeater>_neighbor_<neighbor>`
  - Unit: dB, state class: measurement
  - Value: most recent signal-to-noise ratio the repeater measured from that neighbor
  - Availability: unavailable if the neighbor has not been heard in the last 72 hours

- **Activity sensor (`seen_48h`)** — `sensor.meshcore_<repeater>_neighbor_<neighbor>_seen`
  - Unit: count, state class: measurement (the value decreases as old sightings age out of the 48h window)
  - Value: number of times this neighbor was heard by the repeater in the last 48 hours
  - Availability: same 72-hour threshold

Friendly names resolve to the neighbor's advertised name when available, with a public-key prefix fallback. Names update if the neighbor later appears in the contact list.

**Per-repeater enable toggle** (disabled by default):

Settings → Devices & Services → Meshcore → Configure → open the per-repeater subscription → toggle **Enable Neighbor Entities**. On the next repeater update cycle the integration queries firmware for the neighbor list and creates sensors. Disabling the toggle removes all neighbor sensors for that repeater, clears in-memory state, and deletes persisted data.

**Persistence and restart-robustness:**

Neighbor data persists via HA's `Store` helper. After a restart, sensors are recreated from disk and the 48-hour activity window continues seamlessly. The integration guards `seen_timestamps` against inflated `secs_ago` values that firmware reports during its own startup, so the rolling window stays accurate across both HA and repeater reboots.

**Integration-level auto-cleanup (also disabled by default):**

A daily task can remove neighbors that haven't been heard within a configurable threshold. Configurable under Configure → Global Settings:

- **Auto-Remove Stale Neighbors** — on/off (default off)
- **Stale Neighbor Threshold (days)** — 1 to 365, default 7

Prevents unbounded neighbor growth in mobile or dense deployments where nodes come and go.

### Changes primarily serve the frontend, but are useful on their own

As with the other PRs in this series, the direct motivation is the upcoming sidebar-panel frontend. But the SNR and `seen_48h` sensors are first-class HA entities and are useful outside of any frontend:

- **Mesh health at a glance.** Each repeater's neighbor SNR sensors form a snapshot of its local radio environment. Graphing over time shows degradation, new arrivals, or links dropping out before they become network-wide problems.
- **Activity-based alerts.** `seen_48h` sensors make it easy to flag a repeater that has stopped hearing a neighbor it normally hears dozens of times a day.
- **Coverage mapping.** Combining neighbor lists from multiple repeaters gives a first-order view of which nodes are within direct earshot of which — without hand-correlating RX_LOG entries.

### Documentation

New page: `docs/docs/repeater-neighbors.md` (sidebar position 2.5), covering the per-repeater enable flow, the two sensors, persistence semantics, integration-level auto-cleanup, and use cases.

### Related / upcoming

Companion PRs from this series: `feature/per-device-online-sensor`, `feature/message-store`. The sidebar-panel frontend that consumes all three is tracked separately.