### PR TITLE
Add structured query services: get_contacts, get_channels, trace

### DIFF
--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -36,6 +36,9 @@ SERVICE_REMOVE_SELECTED_CONTACT: Final = "remove_selected_contact"
 SERVICE_REMOVE_DISCOVERED_CONTACT: Final = "remove_discovered_contact"
 SERVICE_CLEANUP_UNAVAILABLE_CONTACTS: Final = "cleanup_unavailable_contacts"
 SERVICE_CLEAR_DISCOVERED_CONTACTS: Final = "clear_discovered_contacts"
+SERVICE_GET_CONTACTS: Final = "get_contacts"
+SERVICE_GET_CHANNELS: Final = "get_channels"
+SERVICE_TRACE: Final = "trace"
 
 # Select entity placeholders
 SELECT_NO_CONTACTS: Final = "Select a contact..."

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -3,6 +3,7 @@ import ast
 import asyncio
 import inspect
 import logging
+import random
 import re
 import shlex
 import time
@@ -47,6 +48,9 @@ from .const import (
     SERVICE_REMOVE_DISCOVERED_CONTACT,
     SERVICE_CLEANUP_UNAVAILABLE_CONTACTS,
     SERVICE_CLEAR_DISCOVERED_CONTACTS,
+    SERVICE_GET_CONTACTS,
+    SERVICE_GET_CHANNELS,
+    SERVICE_TRACE,
     SELECT_NO_CONTACTS,
     SELECT_NO_DISCOVERED,
     SELECT_NO_ADDED,
@@ -1155,6 +1159,388 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         }),
     )
 
+    # ── Structured query services (get_contacts, get_channels, trace) ──
+    # These services return structured responses (SupportsResponse.ONLY) so
+    # companion integrations don't have to string-scrape execute_command output.
+    # See docs/docs/companion-integration-api.md for the published surface.
+
+    def _resolve_coordinator(entry_id: Optional[str]) -> Any:
+        """Locate a MeshCore coordinator by entry_id, or the first available one."""
+        if entry_id:
+            coord = hass.data[DOMAIN].get(entry_id)
+            if coord is not None and hasattr(coord, "api"):
+                return coord
+            return None
+        for _eid, coord in hass.data[DOMAIN].items():
+            if hasattr(coord, "api"):
+                return coord
+        return None
+
+    async def async_get_contacts_service(call: ServiceCall) -> dict:
+        """Return the device's known contacts as a structured list.
+
+        Delegates to ``coordinator.get_all_contacts()`` so the result includes
+        both contacts saved to the device and those only discovered via
+        advertisements. ``added_to_node`` and ``pubkey_prefix`` are set by
+        the coordinator; ``out_path_hash_mode`` is backfilled for older
+        records via ``_ensure_contact_compat``.
+        """
+        entry_id = call.data.get(ATTR_ENTRY_ID)
+        coordinator = _resolve_coordinator(entry_id)
+        if coordinator is None:
+            return {"contacts": [], "error": "no_coordinator"}
+
+        try:
+            raw_contacts = coordinator.get_all_contacts() or []
+        except Exception as ex:
+            _LOGGER.error("get_contacts: coordinator access failed: %s", ex)
+            return {"contacts": [], "error": "coordinator_error"}
+
+        contacts_out = []
+        for contact in raw_contacts:
+            if not isinstance(contact, dict):
+                continue
+            c = _ensure_contact_compat(dict(contact))
+            # get_all_contacts populates pubkey_prefix; double-check for
+            # older records that somehow made it through without one.
+            if "pubkey_prefix" not in c:
+                pk = c.get("public_key") or ""
+                if pk:
+                    c["pubkey_prefix"] = pk[:12]
+            contacts_out.append(c)
+
+        return {"contacts": contacts_out}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_CONTACTS,
+        async_get_contacts_service,
+        schema=vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string}),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def async_get_channels_service(call: ServiceCall) -> dict:
+        """Return the device's configured channels as a structured list.
+
+        Reads cached info from ``coordinator._channel_info`` (same source the
+        sidebar-panel's ``ws_get_channels`` uses) so this is a pure query
+        that never issues an on-device request. Unused channel slots
+        (empty name or ``(unused)``) are filtered out. The shared secret is
+        never returned — only its presence via ``shared_secret_present``.
+        """
+        entry_id = call.data.get(ATTR_ENTRY_ID)
+        coordinator = _resolve_coordinator(entry_id)
+        if coordinator is None:
+            return {"channels": [], "error": "no_coordinator"}
+
+        try:
+            max_ch = int(getattr(coordinator, "max_channels", 0) or 0)
+        except Exception:
+            max_ch = 0
+
+        channel_info_map = getattr(coordinator, "_channel_info", {}) or {}
+
+        channels_out = []
+        for channel_idx in range(max_ch):
+            info = channel_info_map.get(channel_idx) or {}
+            if not info:
+                continue
+            channel_name = info.get("channel_name", "") or ""
+            # Skip unused/unconfigured channel slots so companions only see
+            # real channels the user could actually send to.
+            if not channel_name or channel_name == "(unused)":
+                continue
+            entry = {
+                "channel_idx": channel_idx,
+                "channel_name": channel_name,
+                # Don't leak the shared secret; only surface presence.
+                "shared_secret_present": bool(info.get("channel_secret")),
+            }
+            channels_out.append(entry)
+
+        return {"channels": channels_out}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_CHANNELS,
+        async_get_channels_service,
+        schema=vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string}),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def async_trace_service(call: ServiceCall) -> dict:
+        """Trace the route to a contact and return hop/path/round-trip info.
+
+        Ported from the sidebar-panel's ``ws_trace`` so the service honours
+        the same validated behavior:
+
+          * Only contacts saved to the device can be traced — firmware's
+            path-discovery handler rejects discovered-only contacts with
+            ERR_CODE_NOT_FOUND, so fail fast with ``contact_not_on_device``.
+          * Flood contacts (``out_path_len == -1``) run a path-discovery
+            pass first. The PATH_RESPONSE listener is registered before the
+            PATH_REQ is sent to close the race where the response could
+            arrive before the subscription was live. Firmware rejection
+            (ERROR) and timeout surface as distinct error strings.
+          * The trace packet is built as outbound_hops + target + reverse
+            (outbound_hops) with 1-byte per-hop hashes (flags=0). The
+            round-trip hash list is required by the firmware TRACE
+            handler (Mesh.cpp:41-66) for the sender to receive the echo,
+            and 1-byte hashes are empirically the only width that
+            completes reliably in production meshes.
+          * Every failure mode returns a structured ``{"trace": null,
+            "error": "..."}`` dict so automations never see an exception.
+        """
+        entry_id = call.data.get(ATTR_ENTRY_ID)
+        pubkey_prefix = call.data[ATTR_PUBKEY_PREFIX]
+        requested_timeout_s = float(call.data.get("timeout", 15))
+
+        coordinator = _resolve_coordinator(entry_id)
+        if coordinator is None:
+            return {"trace": None, "error": "no_coordinator"}
+
+        api = coordinator.api
+        if not api or not api.connected or not api.mesh_core:
+            return {"trace": None, "error": "not_connected"}
+
+        # Prefer coordinator.get_contact_by_prefix (searches added +
+        # discovered), fall back to the SDK lookup used elsewhere. This
+        # matches the sidebar-panel's behavior so discovered-only contacts
+        # can be recognised and rejected with a clear error.
+        contact = None
+        get_by_prefix = getattr(coordinator, "get_contact_by_prefix", None)
+        if callable(get_by_prefix):
+            contact = get_by_prefix(pubkey_prefix) or None
+        if not contact:
+            contact = _resolve_contact(pubkey_prefix, "trace", api, coordinator)
+        if not contact:
+            return {"trace": None, "error": "contact_not_found"}
+
+        # Firmware CMD_SEND_PATH_DISCOVERY_REQ memcmps the target pubkey
+        # against the on-device contact table; discovered-only contacts are
+        # rejected with ERR_CODE_NOT_FOUND. Fail fast with an actionable
+        # error instead of paying for the firmware round-trip.
+        if not contact.get("added_to_node"):
+            return {"trace": None, "error": "contact_not_on_device"}
+
+        public_key = contact.get("public_key") or ""
+        if not public_key:
+            return {"trace": None, "error": "contact_missing_pubkey"}
+
+        mesh_core = api.mesh_core
+        tag = random.randint(0, 0xFFFFFFFF)
+
+        out_path_len = contact.get("out_path_len", -1)
+        out_path_hash_mode = contact.get("out_path_hash_mode", 0)
+        out_path_hex = contact.get("out_path", "") or ""
+
+        # ── Flood contact: run path discovery first ──
+        if out_path_len == -1:
+            try:
+                dst_bytes = bytes.fromhex(public_key)
+            except (ValueError, TypeError) as ex:
+                _LOGGER.error("trace: bad pubkey hex for path discovery: %s", ex)
+                return {"trace": None, "error": "contact_missing_pubkey"}
+
+            # Pre-register the PATH_RESPONSE listener so the response can't
+            # arrive and be dispatched before our subscription is live.
+            # Filter by pubkey_pre so concurrent path-discovery traffic
+            # for other contacts can't satisfy this wait. Mirrors
+            # Remote-Terminal-for-MeshCore's approach.
+            path_response_task = asyncio.create_task(
+                mesh_core.dispatcher.wait_for_event(
+                    EventType.PATH_RESPONSE,
+                    attribute_filters={"pubkey_pre": pubkey_prefix},
+                    timeout=30.0,  # outer safety; real bound applied below
+                )
+            )
+
+            pd_data = b"\x34\x00" + dst_bytes
+            try:
+                send_result = await mesh_core.commands.send(
+                    pd_data,
+                    [EventType.MSG_SENT, EventType.ERROR],
+                )
+            except Exception as ex:
+                path_response_task.cancel()
+                _LOGGER.error("trace: path discovery send raised: %s", ex)
+                return {"trace": None, "error": "path_discovery_failed"}
+
+            if send_result is None:
+                path_response_task.cancel()
+                return {
+                    "trace": None,
+                    "error": "path_discovery_failed",
+                    "reason": "no_firmware_ack",
+                }
+
+            if getattr(send_result, "type", None) == EventType.ERROR:
+                path_response_task.cancel()
+                # Firmware PacketType.ERROR carries {"error_code",
+                # "code_string"} when mapped, or {"reason"} for reader
+                # parse-failures. Accept either shape.
+                reason = "unknown"
+                if isinstance(send_result.payload, dict):
+                    p = send_result.payload
+                    reason = (
+                        p.get("code_string")
+                        or p.get("reason")
+                        or (f"error_code={p['error_code']}" if "error_code" in p else "unknown")
+                    )
+                elif send_result.payload is not None:
+                    reason = repr(send_result.payload)
+                return {
+                    "trace": None,
+                    "error": "path_discovery_rejected",
+                    "reason": reason,
+                }
+
+            # MSG_SENT — firmware accepted and broadcast the request.
+            # Apply a 15s floor on the PATH_RESPONSE wait — two-hop flood
+            # round-trips routinely run 5-12s under real LoRa conditions,
+            # and a shorter timeout gives up before the mesh has had time
+            # to answer. Honour firmware's suggested_timeout if it ever
+            # exceeds 15s.
+            suggested_ms = 0
+            if isinstance(send_result.payload, dict):
+                suggested_ms = send_result.payload.get("suggested_timeout", 0) or 0
+            pd_timeout = max(suggested_ms / 800.0, 15.0)
+
+            try:
+                path_event = await asyncio.wait_for(
+                    path_response_task, timeout=pd_timeout,
+                )
+            except asyncio.TimeoutError:
+                path_response_task.cancel()
+                path_event = None
+            except Exception as ex:
+                path_response_task.cancel()
+                _LOGGER.error("trace: PATH_RESPONSE wait raised: %s", ex)
+                return {"trace": None, "error": "path_discovery_failed"}
+
+            if path_event is None:
+                return {"trace": None, "error": "path_discovery_timeout"}
+
+            discovered = path_event.payload or {}
+            out_path_len = discovered.get("out_path_len", -1)
+            if out_path_len < 0:
+                return {
+                    "trace": None,
+                    "error": "path_discovery_failed",
+                    "reason": "malformed_path_response",
+                }
+
+            out_path_hash_len = discovered.get("out_path_hash_len", 1)
+            out_path_hash_mode = {1: 0, 2: 1, 4: 2}.get(out_path_hash_len, 0)
+            out_path_hex = discovered.get("out_path", "") or ""
+
+        # ── Build the round-trip 1-byte-hash path ──
+        # Force flags=0 (1-byte hashes) regardless of the contact's cached
+        # hash mode: 2-byte traces empirically fail to complete round-trip
+        # in production meshes. Truncate each stored hop to its first byte
+        # to match.
+        flags = 0
+        target_hash_hex = public_key[:2]  # first 1 byte
+        if not target_hash_hex:
+            return {"trace": None, "error": "contact_missing_pubkey"}
+
+        stored_hop_width = {0: 2, 1: 4, 2: 8}.get(out_path_hash_mode, 2)
+        outbound_hops = []
+        for i in range(out_path_len):
+            start = i * stored_hop_width
+            stored_hop = out_path_hex[start : start + stored_hop_width]
+            if len(stored_hop) >= 2:
+                outbound_hops.append(stored_hop[:2])
+        return_hops = list(reversed(outbound_hops))
+        full_path_hex = (
+            "".join(outbound_hops) + target_hash_hex + "".join(return_hops)
+        )
+
+        try:
+            trace_path_bytes = bytes.fromhex(full_path_hex)
+        except ValueError as ex:
+            _LOGGER.error("trace: bad hex in path construction: %s", ex)
+            return {"trace": None, "error": "internal_error"}
+
+        _LOGGER.debug(
+            "trace: sending tag=%08x flags=%d path=%s (hops=%d, target=%s)",
+            tag, flags, full_path_hex, len(outbound_hops), target_hash_hex,
+        )
+
+        # ── Send trace and await TRACE_DATA with our tag ──
+        start_time = time.monotonic()
+        try:
+            send_result = await mesh_core.commands.send_trace(
+                0, tag, flags, trace_path_bytes
+            )
+        except Exception as ex:
+            _LOGGER.error("trace: send_trace raised: %s", ex)
+            return {"trace": None, "error": "send_failed"}
+
+        if send_result is None or getattr(send_result, "type", None) == EventType.ERROR:
+            reason = "no_response"
+            if send_result is not None and isinstance(send_result.payload, dict):
+                reason = send_result.payload.get("reason", "unknown")
+            return {"trace": None, "error": reason}
+
+        # Bound the TRACE_DATA wait using (in order of preference) the
+        # user's requested timeout, the device's self-reported suggested
+        # timeout, and sensible floor/ceiling. Use firmware-suggested *1.2
+        # like ws_trace so near-timeout responses aren't cut off.
+        self_info = getattr(api, "self_info", None) or {}
+        fw_suggested_ms = self_info.get("suggested_timeout", 15000) if isinstance(self_info, dict) else 15000
+        try:
+            fw_suggested_s = float(fw_suggested_ms) / 1000.0 * 1.2
+        except Exception:
+            fw_suggested_s = 18.0
+        effective_timeout = min(max(requested_timeout_s, fw_suggested_s, 5.0), 60.0)
+
+        try:
+            trace_event = await mesh_core.dispatcher.wait_for_event(
+                EventType.TRACE_DATA,
+                attribute_filters={"tag": tag},
+                timeout=effective_timeout,
+            )
+        except Exception as ex:
+            _LOGGER.error("trace: awaiting TRACE_DATA raised: %s", ex)
+            return {"trace": None, "error": "await_failed"}
+
+        rtt_ms = int((time.monotonic() - start_time) * 1000)
+        if trace_event is None:
+            return {"trace": None, "error": "timeout", "round_trip_ms": rtt_ms}
+
+        payload = trace_event.payload or {}
+        path_nodes = payload.get("path") or []
+        # Final path entry is the local device on receiving the echo; its
+        # SNR tells callers how strong the return leg was.
+        final_snr = None
+        if path_nodes and isinstance(path_nodes[-1], dict) and "snr" in path_nodes[-1]:
+            final_snr = path_nodes[-1]["snr"]
+
+        return {
+            "trace": {
+                "hops": payload.get("path_len", 0),
+                "path": path_nodes,
+                "round_trip_ms": rtt_ms,
+                "final_snr": final_snr,
+                "tag": payload.get("tag"),
+            }
+        }
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_TRACE,
+        async_trace_service,
+        schema=vol.Schema({
+            vol.Required(ATTR_PUBKEY_PREFIX): cv.string,
+            vol.Optional(ATTR_ENTRY_ID): cv.string,
+            vol.Optional("timeout", default=15): vol.All(
+                vol.Coerce(float), vol.Range(min=1, max=120)
+            ),
+        }),
+        supports_response=SupportsResponse.ONLY,
+    )
+
     # Create CLI command execution service from UI helper
     # async def async_execute_cli_command_ui(call: ServiceCall) -> None:
     #     """Execute CLI command from the text helper entity."""
@@ -1235,6 +1621,15 @@ async def async_unload_services(hass: HomeAssistant) -> None:
 
     if hass.services.has_service(DOMAIN, SERVICE_CLEAR_DISCOVERED_CONTACTS):
         hass.services.async_remove(DOMAIN, SERVICE_CLEAR_DISCOVERED_CONTACTS)
+
+    if hass.services.has_service(DOMAIN, SERVICE_GET_CONTACTS):
+        hass.services.async_remove(DOMAIN, SERVICE_GET_CONTACTS)
+
+    if hass.services.has_service(DOMAIN, SERVICE_GET_CHANNELS):
+        hass.services.async_remove(DOMAIN, SERVICE_GET_CHANNELS)
+
+    if hass.services.has_service(DOMAIN, SERVICE_TRACE):
+        hass.services.async_remove(DOMAIN, SERVICE_TRACE)
 
 
 def create_service_call(

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -179,6 +179,76 @@ cleanup_unavailable_contacts:
       selector:
         text:
 
+get_contacts:
+  name: Get Contacts
+  description: >-
+    Return the device's known contacts as a structured list.
+    Use this instead of string-scraping execute_command output — the response
+    shape is stable across releases. See the companion-integration API docs for
+    the full schema.
+  response: optional
+  fields:
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+
+get_channels:
+  name: Get Channels
+  description: >-
+    Return the device's configured channels as a structured list. The shared
+    secret is never leaked — only its presence is reported via
+    shared_secret_present.
+  response: optional
+  fields:
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+
+trace:
+  name: Trace Contact
+  description: >-
+    Trace the route to a contact and return hop count, per-hop path, and
+    round-trip time. The contact must be saved to the device — discovered-only
+    contacts return {"trace": null, "error": "contact_not_on_device"}. For
+    flood contacts a path-discovery pass runs first; the result is used to
+    build the trace. On timeout or any failure, returns {"trace": null,
+    "error": "..."} so automations always get a structured response.
+  response: optional
+  fields:
+    pubkey_prefix:
+      name: Public Key Prefix
+      description: The public key prefix (at least 6 characters) of the contact to trace.
+      required: true
+      example: "f293ac"
+      selector:
+        text:
+    timeout:
+      name: Timeout
+      description: Maximum seconds to wait for the trace response. The effective timeout also respects the firmware's suggested_timeout.
+      required: false
+      default: 15
+      example: 15
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: seconds
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+
 clear_discovered_contacts:
   name: Clear Discovered Contacts
   description: >-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ _MOCKS = [
     "custom_components.meshcore.meshcore_api",
     "custom_components.meshcore.utils",
     "custom_components.meshcore.mqtt_uploader",
+    "custom_components.meshcore.binary_sensor",
 ]
 
 for _mod in _MOCKS:

--- a/tests/test_query_services.py
+++ b/tests/test_query_services.py
@@ -1,0 +1,741 @@
+"""Tests for structured query services (get_contacts, get_channels, trace).
+
+These tests exercise the service handlers registered by async_setup_services
+in services.py. To avoid pulling the full Home Assistant package graph, we
+load services.py directly via importlib (same pattern as
+test_services_parsing.py) and then drive the registered handlers by
+capturing them from a stubbed hass.services.async_register call.
+
+The trace service was ported from the sidebar-panel's ``ws_trace`` — these
+tests match that validated behavior:
+
+  * get_contacts uses ``coordinator.get_all_contacts()``
+  * get_channels reads ``coordinator._channel_info`` directly
+  * trace enforces ``added_to_node``, uses a pre-registered
+    PATH_RESPONSE listener + ``commands.send(b"\\x34\\x00"+pubkey)`` for
+    flood contacts, and issues ``send_trace(0, tag, 0, bytes)`` with a
+    round-trip 1-byte-hash path.
+"""
+import asyncio
+import importlib.util
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ─── Module loading ────────────────────────────────────────────────────
+# Patch meshcore.events.EventType with the handful of members services.py
+# references. conftest.py already inserts a MagicMock for meshcore.events,
+# but the module-level `from meshcore.events import EventType` grabs
+# whatever attribute is on that mock at import time.
+class _ET:
+    ERROR = "error"
+    TRACE_DATA = "trace_data"
+    PATH_RESPONSE = "path_response"
+    MSG_SENT = "msg_sent"
+    CONTACTS = "contacts"
+    ACK = "ack"
+
+_mc_events = sys.modules.get("meshcore.events")
+if _mc_events is not None:
+    _mc_events.EventType = _ET
+
+_SERVICES_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "custom_components", "meshcore", "services.py",
+)
+_spec = importlib.util.spec_from_file_location(
+    "custom_components.meshcore.services", _SERVICES_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+_module.__package__ = "custom_components.meshcore"
+_spec.loader.exec_module(_module)
+
+async_setup_services = _module.async_setup_services
+
+# The const module is MagicMock-mocked in conftest, so when services.py does
+# `from .const import ATTR_ENTRY_ID` etc., it captures MagicMock attributes
+# rather than strings. Dict lookups inside the service handlers use those
+# MagicMocks as keys — so we must use the exact same MagicMocks as our test
+# data keys.
+DOMAIN = _module.DOMAIN
+ATTR_ENTRY_ID = _module.ATTR_ENTRY_ID
+ATTR_PUBKEY_PREFIX = _module.ATTR_PUBKEY_PREFIX
+
+
+# ─── Shared fixtures ───────────────────────────────────────────────────
+class _Event:
+    """Mimic meshcore.events.Event just enough for the services to unpack."""
+
+    def __init__(self, type_, payload, attributes=None):
+        self.type = type_
+        self.payload = payload
+        self.attributes = attributes or {}
+
+
+def _build_coordinator(
+    *,
+    contacts_dict=None,          # dict[pubkey→contact] for both get_all_contacts and by-prefix lookup
+    contacts_list=None,          # explicit list (overrides contacts_dict if provided)
+    max_channels=0,
+    channel_info=None,           # dict keyed by channel_idx → {channel_name, channel_secret?}
+    connected=True,
+    trace_send_event=None,       # commands.send_trace return value
+    trace_event=None,            # dispatcher.wait_for_event(TRACE_DATA) return
+    path_send_event=None,        # commands.send return value for PATH_REQ
+    path_send_exc=None,          # commands.send side_effect exception
+    path_response_event=None,    # dispatcher.wait_for_event(PATH_RESPONSE) return
+    self_info=None,              # api.self_info dict (for trace effective_timeout calc)
+):
+    """Build a MagicMock coordinator matching the new ws_trace-aligned service logic."""
+    coord = MagicMock()
+    coord.api = MagicMock()
+    coord.api.connected = connected
+    coord.api.self_info = (
+        self_info if self_info is not None else {"suggested_timeout": 1000}
+    )
+    coord.max_channels = max_channels
+    coord._channel_info = channel_info or {}
+
+    # get_all_contacts returns a list; source is contacts_list if given, else
+    # the values of contacts_dict.
+    if contacts_list is not None:
+        all_list = list(contacts_list)
+    else:
+        all_list = list((contacts_dict or {}).values())
+    coord.get_all_contacts = MagicMock(return_value=all_list)
+
+    # get_contact_by_prefix: matches by pubkey prefix, mirroring the
+    # real coordinator helper that searches added + discovered.
+    def _by_prefix(prefix):
+        for c in all_list:
+            pk = c.get("public_key") or ""
+            if pk.startswith(prefix):
+                return c
+        return None
+    coord.get_contact_by_prefix = MagicMock(side_effect=_by_prefix)
+
+    mesh_core = MagicMock()
+    mesh_core.contacts = contacts_dict or {}
+
+    # Legacy _resolve_contact fallbacks (not normally hit when
+    # coordinator.get_contact_by_prefix resolves first).
+    def _by_sdk_prefix(prefix):
+        return _by_prefix(prefix)
+    def _by_name(name):
+        for c in all_list:
+            if c.get("adv_name") == name:
+                return c
+        return None
+    mesh_core.get_contact_by_key_prefix = MagicMock(side_effect=_by_sdk_prefix)
+    mesh_core.get_contact_by_name = MagicMock(side_effect=_by_name)
+
+    mesh_core.commands = MagicMock()
+    mesh_core.commands.send_trace = AsyncMock(return_value=trace_send_event)
+
+    # commands.send is used for PATH_REQ (flood contacts).
+    if path_send_exc is not None:
+        mesh_core.commands.send = AsyncMock(side_effect=path_send_exc)
+    else:
+        mesh_core.commands.send = AsyncMock(return_value=path_send_event)
+
+    # dispatcher.wait_for_event dispatches by event type:
+    #   PATH_RESPONSE → path_response_event (via pre-registered task)
+    #   TRACE_DATA    → trace_event
+    async def _wait_for_event(event_type, attribute_filters=None, timeout=None):
+        if event_type == _ET.PATH_RESPONSE:
+            return path_response_event
+        if event_type == _ET.TRACE_DATA:
+            return trace_event
+        return None
+
+    mesh_core.dispatcher = MagicMock()
+    mesh_core.dispatcher.wait_for_event = AsyncMock(side_effect=_wait_for_event)
+
+    coord.api.mesh_core = mesh_core
+
+    coord._discovered_contacts = {}
+    return coord
+
+
+async def _setup_and_get_handlers(coordinator):
+    """Run async_setup_services with a stubbed hass and capture handlers.
+
+    Services are keyed by their handler function's __name__ because the const
+    module is MagicMock-mocked in conftest — so SERVICE_GET_CONTACTS etc. are
+    MagicMock attributes at registration time, not strings.
+    """
+    registered = {}
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+
+    def _register(domain, service_const, handler, **kwargs):
+        name = getattr(handler, "__name__", repr(handler))
+        registered[name] = (handler, kwargs)
+
+    hass.services.async_register = _register
+    hass.services.has_service = MagicMock(return_value=False)
+
+    await async_setup_services(hass)
+    aliases = {
+        "get_contacts": "async_get_contacts_service",
+        "get_channels": "async_get_channels_service",
+        "trace": "async_trace_service",
+    }
+    for short, fn in aliases.items():
+        if fn in registered:
+            registered[short] = registered[fn]
+    return hass, registered
+
+
+def _call(data):
+    """Build a minimal ServiceCall-like object."""
+    call = MagicMock()
+    call.data = data
+    return call
+
+
+# ─── get_contacts ──────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_get_contacts_returns_structured_list():
+    """get_contacts returns the coordinator's merged added+discovered list."""
+    pk_a = "abcdef1234567890" + "0" * 48
+    pk_b = "fedcba0987654321" + "0" * 48
+    contacts = {
+        pk_a: {
+            "adv_name": "node-a",
+            "public_key": pk_a,
+            "type": 1,
+            "out_path_len": 2,
+            "out_path": "aabb",
+            "added_to_node": True,
+            "pubkey_prefix": pk_a[:12],
+        },
+        pk_b: {
+            "adv_name": "node-b",
+            "public_key": pk_b,
+            "type": 2,
+            "out_path_len": -1,
+            "added_to_node": False,
+            "pubkey_prefix": pk_b[:12],
+        },
+    }
+    coord = _build_coordinator(contacts_dict=contacts)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, kwargs = regs["get_contacts"]
+    assert "supports_response" in kwargs
+
+    response = await handler(_call({}))
+    assert "contacts" in response
+    assert len(response["contacts"]) == 2
+
+    names = {c["adv_name"] for c in response["contacts"]}
+    assert names == {"node-a", "node-b"}
+
+    # _ensure_contact_compat should have filled out_path_hash_mode on both,
+    # and pubkey_prefix is preserved from what the coordinator supplied.
+    by_name = {c["adv_name"]: c for c in response["contacts"]}
+    assert by_name["node-a"]["out_path_hash_mode"] == 0   # out_path_len=2
+    assert by_name["node-b"]["out_path_hash_mode"] == -1  # flood
+    assert by_name["node-a"]["pubkey_prefix"] == pk_a[:12]
+    assert by_name["node-b"]["pubkey_prefix"] == pk_b[:12]
+    # added_to_node survives the roundtrip.
+    assert by_name["node-a"]["added_to_node"] is True
+    assert by_name["node-b"]["added_to_node"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_backfills_pubkey_prefix_if_missing():
+    """If a coordinator record is missing pubkey_prefix, service derives it from public_key."""
+    pk = "deadbeef" + "c0" * 28  # 32 bytes
+    contacts = {
+        pk: {
+            "adv_name": "bare",
+            "public_key": pk,
+            "out_path_len": 1,
+            "out_path": "aa",
+            # no pubkey_prefix, no added_to_node
+        }
+    }
+    coord = _build_coordinator(contacts_dict=contacts)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["get_contacts"]
+
+    response = await handler(_call({}))
+    assert len(response["contacts"]) == 1
+    assert response["contacts"][0]["pubkey_prefix"] == pk[:12]
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_no_coordinator():
+    """No coordinator registered for the entry_id → structured error."""
+    registered = {}
+    hass = MagicMock()
+    hass.data = {DOMAIN: {}}
+
+    def _register(domain, service_const, handler, **kwargs):
+        registered[getattr(handler, "__name__", repr(handler))] = (handler, kwargs)
+
+    hass.services.async_register = _register
+    hass.services.has_service = MagicMock(return_value=False)
+    await async_setup_services(hass)
+    handler, _ = registered["async_get_contacts_service"]
+
+    response = await handler(_call({}))
+    assert response == {"contacts": [], "error": "no_coordinator"}
+
+
+@pytest.mark.asyncio
+async def test_get_contacts_coordinator_raises_returns_structured_error():
+    """If coordinator.get_all_contacts raises, service returns coordinator_error."""
+    coord = _build_coordinator(contacts_dict={})
+    coord.get_all_contacts = MagicMock(side_effect=RuntimeError("boom"))
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["get_contacts"]
+
+    response = await handler(_call({}))
+    assert response == {"contacts": [], "error": "coordinator_error"}
+
+
+# ─── get_channels ──────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_get_channels_returns_structured_list_without_secret():
+    """Each channel entry has {channel_idx, channel_name, shared_secret_present}."""
+    channel_info = {
+        0: {"channel_name": "Public", "channel_secret": b"\x00" * 16},
+        1: {"channel_name": "Private", "channel_secret": b"\x11" * 16},
+        2: {"channel_name": "NoSecret"},  # name but no secret
+    }
+    coord = _build_coordinator(max_channels=3, channel_info=channel_info)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["get_channels"]
+
+    response = await handler(_call({}))
+    assert "channels" in response
+    assert len(response["channels"]) == 3
+
+    by_idx = {c["channel_idx"]: c for c in response["channels"]}
+    assert by_idx[0]["channel_name"] == "Public"
+    assert by_idx[0]["shared_secret_present"] is True
+    assert "channel_secret" not in by_idx[0]  # never leak the raw secret
+
+    assert by_idx[1]["channel_name"] == "Private"
+    assert by_idx[1]["shared_secret_present"] is True
+
+    assert by_idx[2]["channel_name"] == "NoSecret"
+    assert by_idx[2]["shared_secret_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_channels_skips_unused_and_empty_slots():
+    """Empty dicts, None slots, empty names, and ``(unused)`` names are filtered."""
+    channel_info = {
+        0: {"channel_name": "Real"},
+        1: {},                               # empty dict → skipped
+        2: None,                             # None → skipped
+        3: {"channel_name": ""},             # empty name → skipped
+        4: {"channel_name": "(unused)"},     # sentinel → skipped
+        5: {"channel_name": "AlsoReal"},
+    }
+    coord = _build_coordinator(max_channels=6, channel_info=channel_info)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["get_channels"]
+
+    response = await handler(_call({}))
+    returned_names = {c["channel_name"] for c in response["channels"]}
+    assert returned_names == {"Real", "AlsoReal"}
+    returned_idxs = {c["channel_idx"] for c in response["channels"]}
+    assert returned_idxs == {0, 5}
+
+
+@pytest.mark.asyncio
+async def test_get_channels_max_channels_zero_returns_empty():
+    """max_channels=0 yields an empty channel list without error."""
+    coord = _build_coordinator(max_channels=0, channel_info={0: {"channel_name": "X"}})
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["get_channels"]
+
+    response = await handler(_call({}))
+    assert response == {"channels": []}
+
+
+# ─── trace ─────────────────────────────────────────────────────────────
+# pubkey format note: public_key[:2] = first 1 byte = target hash.
+# With out_path="aabb" and out_path_hash_mode=0 (1-byte width, 2 hex chars):
+#   outbound_hops = ["aa", "bb"]
+#   target_hash    = "ab"      (first byte of "abcdef...")
+#   return_hops    = ["bb", "aa"]
+#   full_path_hex  = "aa" + "bb" + "ab" + "bb" + "aa" = "aabbabbbaa"
+#   trace bytes    = bytes.fromhex("aabbabbbaa") (5 bytes)
+
+
+@pytest.mark.asyncio
+async def test_trace_happy_path_returns_structured_response(monkeypatch):
+    """Non-flood contact: send_trace is issued with round-trip 1-byte-hash path."""
+    # Fix the tag so we can assert the call args exactly.
+    monkeypatch.setattr(_module, "random", MagicMock(randint=lambda lo, hi: 42))
+
+    pubkey = "abcdef" + "12" * 29  # 32 bytes; first byte = "ab"
+    contacts = {
+        pubkey: {
+            "adv_name": "target",
+            "public_key": pubkey,
+            "out_path_len": 2,
+            "out_path": "aabb",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    send_event = _Event(_ET.MSG_SENT, {"tag": 42, "suggested_timeout": 2000})
+    trace_event = _Event(
+        _ET.TRACE_DATA,
+        {
+            "tag": 42,
+            "path_len": 2,
+            "path": [
+                {"hash": "aa", "snr": -5.5},
+                {"hash": "bb", "snr": -4.0},
+                {"snr": -3.0},
+            ],
+        },
+    )
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        trace_send_event=send_event,
+        trace_event=trace_event,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, kwargs = regs["trace"]
+    assert "supports_response" in kwargs
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef", "timeout": 5}))
+    assert response["trace"] is not None
+    t = response["trace"]
+    assert t["hops"] == 2
+    assert len(t["path"]) == 3
+    assert t["tag"] == 42
+    assert t["final_snr"] == -3.0
+    assert isinstance(t["round_trip_ms"], int)
+
+    # send_trace(0, tag, flags=0, bytes.fromhex("aabbabbbaa"))
+    sent_call = coord.api.mesh_core.commands.send_trace.call_args
+    assert sent_call.args == (0, 42, 0, bytes.fromhex("aabbabbbaa"))
+
+    # No path discovery on a non-flood contact.
+    coord.api.mesh_core.commands.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_flood_contact_runs_path_discovery_then_traces(monkeypatch):
+    """Flood contact: send(PATH_REQ) → PATH_RESPONSE → send_trace along discovered path."""
+    monkeypatch.setattr(_module, "random", MagicMock(randint=lambda lo, hi: 99))
+
+    pubkey = "abcdef" + "34" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    # PATH_REQ accepted (MSG_SENT).
+    path_send = _Event(_ET.MSG_SENT, {"suggested_timeout": 2000})
+    # Path discovery resolves to a 2-hop path (out_path_hash_len=1 → mode 0).
+    path_response = _Event(
+        _ET.PATH_RESPONSE,
+        {"out_path": "aabb", "out_path_len": 2, "out_path_hash_len": 1},
+    )
+    send_event = _Event(_ET.MSG_SENT, {"tag": 99, "suggested_timeout": 2000})
+    trace_event = _Event(
+        _ET.TRACE_DATA,
+        {
+            "tag": 99,
+            "path_len": 2,
+            "path": [
+                {"hash": "aa", "snr": -5.0},
+                {"hash": "bb", "snr": -4.0},
+                {"snr": -3.5},
+            ],
+        },
+    )
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_event=path_send,
+        path_response_event=path_response,
+        trace_send_event=send_event,
+        trace_event=trace_event,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response["trace"] is not None
+    assert response["trace"]["hops"] == 2
+    assert response["trace"]["tag"] == 99
+    assert response["trace"]["final_snr"] == -3.5
+
+    # PATH_REQ was sent as b"\x34\x00" + pubkey bytes, awaiting MSG_SENT/ERROR.
+    path_call = coord.api.mesh_core.commands.send.call_args
+    assert path_call.args[0] == b"\x34\x00" + bytes.fromhex(pubkey)
+    assert path_call.args[1] == [_ET.MSG_SENT, _ET.ERROR]
+
+    # send_trace used the discovered path, truncated to 1-byte hashes.
+    sent_call = coord.api.mesh_core.commands.send_trace.call_args
+    assert sent_call.args == (0, 99, 0, bytes.fromhex("aabbabbbaa"))
+
+
+@pytest.mark.asyncio
+async def test_trace_path_discovery_timeout_returns_structured_error():
+    """PATH_REQ acked (MSG_SENT) but no PATH_RESPONSE arrives → path_discovery_timeout."""
+    pubkey = "abcdef" + "35" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    # Firmware accepted the request but never emits PATH_RESPONSE.
+    path_send = _Event(_ET.MSG_SENT, {"suggested_timeout": 2000})
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_event=path_send,
+        path_response_event=None,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response == {"trace": None, "error": "path_discovery_timeout"}
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_path_discovery_rejected_surfaces_reason():
+    """Firmware ERROR on PATH_REQ → path_discovery_rejected with reason."""
+    pubkey = "abcdef" + "42" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    err_event = _Event(
+        _ET.ERROR,
+        {"code_string": "ERR_CODE_NOT_FOUND", "error_code": 1},
+    )
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_event=err_event,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response["trace"] is None
+    assert response["error"] == "path_discovery_rejected"
+    assert response["reason"] == "ERR_CODE_NOT_FOUND"
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_path_discovery_send_returns_none_is_failed():
+    """commands.send returning None (no firmware ack) → path_discovery_failed."""
+    pubkey = "abcdef" + "43" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_event=None,  # commands.send returns None
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response["trace"] is None
+    assert response["error"] == "path_discovery_failed"
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_path_discovery_send_raises_is_failed():
+    """commands.send raising → path_discovery_failed."""
+    pubkey = "abcdef" + "37" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_exc=RuntimeError("boom"),
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response == {"trace": None, "error": "path_discovery_failed"}
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_path_discovery_malformed_response():
+    """PATH_RESPONSE arrives but out_path_len<0 → path_discovery_failed (malformed)."""
+    pubkey = "abcdef" + "44" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "flood",
+            "public_key": pubkey,
+            "out_path_len": -1,
+            "out_path": "",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    path_send = _Event(_ET.MSG_SENT, {"suggested_timeout": 2000})
+    bad_response = _Event(
+        _ET.PATH_RESPONSE,
+        {"out_path": "", "out_path_len": -1},
+    )
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        path_send_event=path_send,
+        path_response_event=bad_response,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response["trace"] is None
+    assert response["error"] == "path_discovery_failed"
+    assert response.get("reason") == "malformed_path_response"
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_contact_not_on_device_short_circuits():
+    """Discovered-only contact (added_to_node=False) → contact_not_on_device."""
+    pubkey = "abcdef" + "55" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "ghost",
+            "public_key": pubkey,
+            "out_path_len": 2,
+            "out_path": "aabb",
+            "added_to_node": False,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    coord = _build_coordinator(contacts_dict=contacts)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response == {"trace": None, "error": "contact_not_on_device"}
+    coord.api.mesh_core.commands.send.assert_not_called()
+    coord.api.mesh_core.commands.send_trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trace_timeout_returns_structured_error(monkeypatch):
+    """send_trace MSG_SENT but TRACE_DATA never arrives → timeout with round_trip_ms."""
+    monkeypatch.setattr(_module, "random", MagicMock(randint=lambda lo, hi: 7))
+
+    pubkey = "abcdef" + "56" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "slow",
+            "public_key": pubkey,
+            "out_path_len": 1,
+            "out_path": "cc",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    send_event = _Event(_ET.MSG_SENT, {"tag": 7, "suggested_timeout": 1000})
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        trace_send_event=send_event,
+        trace_event=None,  # dispatcher returns None → timeout
+        self_info={"suggested_timeout": 100},  # keeps effective_timeout small
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef", "timeout": 2}))
+    assert response["trace"] is None
+    assert response["error"] == "timeout"
+    assert "round_trip_ms" in response
+
+
+@pytest.mark.asyncio
+async def test_trace_contact_not_found_returns_structured_error():
+    """No matching contact anywhere → contact_not_found."""
+    coord = _build_coordinator(contacts_dict={})
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "deadbe"}))
+    assert response == {"trace": None, "error": "contact_not_found"}
+
+
+@pytest.mark.asyncio
+async def test_trace_send_error_propagates_reason():
+    """send_trace returning an ERROR event → error string from payload.reason."""
+    pubkey = "abcdef" + "78" * 29
+    contacts = {
+        pubkey: {
+            "adv_name": "broken",
+            "public_key": pubkey,
+            "out_path_len": 1,
+            "out_path": "dd",
+            "added_to_node": True,
+            "pubkey_prefix": pubkey[:12],
+        }
+    }
+    err_event = _Event(_ET.ERROR, {"reason": "invalid_path_format"})
+    coord = _build_coordinator(
+        contacts_dict=contacts,
+        trace_send_event=err_event,
+    )
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response == {"trace": None, "error": "invalid_path_format"}
+
+
+@pytest.mark.asyncio
+async def test_trace_not_connected_returns_structured_error():
+    """api.connected=False → not_connected error."""
+    coord = _build_coordinator(contacts_dict={}, connected=False)
+    _, regs = await _setup_and_get_handlers(coord)
+    handler, _ = regs["trace"]
+
+    response = await handler(_call({ATTR_PUBKEY_PREFIX: "abcdef"}))
+    assert response == {"trace": None, "error": "not_connected"}


### PR DESCRIPTION
### Summary

Three new services under the `meshcore.*` domain that return typed responses for companion integrations and automations to consume directly — no string-scraping `execute_command` output, no private-attribute access on the coordinator.

| Service | Purpose | Response shape |
|---|---|---|
| `meshcore.get_contacts` | Device's known contacts (added + discovered) | `{contacts: [{adv_name, public_key, pubkey_prefix, type, added_to_node, out_path_len, out_path, out_path_hash_mode}]}` |
| `meshcore.get_channels` | Configured channels | `{channels: [{channel_idx, channel_name, shared_secret_present}]}` (the shared secret itself is never returned) |
| `meshcore.trace` | Path-trace to a contact | `{trace: {hops, path, round_trip_ms, final_snr, tag}}` on success; `{trace: null, error: "<code>"}` on any failure |

All accept an optional `entry_id` for multi-device installs.

### Why

Companion integrations (such as [MeshCore-HA-UI](https://github.com/Ratty7198/MeshCore-HA-UI) and [meshcore-ha-chat](https://github.com/mwolter805/meshcore-ha-chat)) currently reach into `coordinator._channel_info` / `coordinator.get_all_contacts()` / direct SDK calls to populate UI surfaces. That's brittle (private attributes can move) and forces companions to re-implement filtering and validation that already exists in the integration. These three services move the logic into a stable, typed surface.

`trace` is a full port of `ws_trace` from the sidebar-panel branch (15s flood-discovery floor, pre-registered `PATH_RESPONSE` listener, round-trip 1-byte-hash path construction per `Mesh.cpp:41-66`, `added_to_node` gate, structured `{trace: null, error: "..."}` failure shape).

### What changes

- `custom_components/meshcore/const.py` — three `SERVICE_*` constants.
- `custom_components/meshcore/services.py` — three handlers + `_resolve_coordinator` helper + registration; ~+395 lines net.
- `custom_components/meshcore/services.yaml` — UI descriptions for the new services.
- `tests/conftest.py` — adds `binary_sensor` to the mock list so `services.py` imports under test.
- `tests/test_query_services.py` — 19 new tests covering happy paths, every error branch, and the exact byte construction for round-trip path discovery.

5 files, +1210 lines.

### Testing

- `pytest tests/` — **53/53 pass** (19 new + 34 existing) in 0.14s.

### Stability and compatibility

Pure additions. No existing service or event changes. Documented as `stable` in the companion integration API page (sibling PR).

### Related

Sibling branches landing alongside this one:
- `feature/dm-signal-metadata` — adds SNR + hop_count to incoming DM events.
- `docs/companion-integration-api` — new docs page that includes the response-shape tables for the three services in this PR.