### PR TITLE
Add conditional logic for recipient type selection

### DIFF
--- a/docs/docs/dashboard/basic-node.md
+++ b/docs/docs/dashboard/basic-node.md
@@ -38,19 +38,19 @@ sections:
               - entity: select.meshcore_recipient_type
                 name: Send To
               - type: conditional
-              conditions:
-                - entity: select.meshcore_recipient_type
-                  state: Channel
-              row:
-                entity: select.meshcore_channel
-                name: Channel
-            - type: conditional
-              conditions:
-                - entity: select.meshcore_recipient_type
-                  state: Contact
-              row:
-                entity: select.meshcore_contact
-                name: Contact
+                conditions:
+                  - entity: select.meshcore_recipient_type
+                    state: Channel
+                row:
+                  entity: select.meshcore_channel
+                  name: Channel
+              - type: conditional
+                conditions:
+                  - entity: select.meshcore_recipient_type
+                    state: Contact
+                row:
+                  entity: select.meshcore_contact
+                  name: Contact
               - entity: text.meshcore_message
                 name: Message
           - show_name: true

--- a/docs/docs/dashboard/basic-node.md
+++ b/docs/docs/dashboard/basic-node.md
@@ -37,9 +37,19 @@ sections:
             entities:
               - entity: select.meshcore_recipient_type
                 name: Send To
-              - entity: select.meshcore_channel
+              - type: conditional
+              conditions:
+                - entity: select.meshcore_recipient_type
+                  state: Channel
+              row:
+                entity: select.meshcore_channel
                 name: Channel
-              - entity: select.meshcore_contact
+            - type: conditional
+              conditions:
+                - entity: select.meshcore_recipient_type
+                  state: Contact
+              row:
+                entity: select.meshcore_contact
                 name: Contact
               - entity: text.meshcore_message
                 name: Message


### PR DESCRIPTION
Makes for a cleaner user experience when using this card. Conditions hide the channel selector when "send to" is "contact" and hide the contact selector when "send to" is "channel".

Also makes this part of the docs match the "overview".