### PR TITLE
chore: bump meshcore_py floor to 2.3.7

### DIFF
--- a/custom_components/meshcore/manifest.json
+++ b/custom_components/meshcore/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["logbook"],
   "codeowners": ["@awolden"],
   "loggers": ["custom_components.meshcore"],
-  "requirements": ["meshcore>=2.2.24", "meshcore-cli>=0.0.0", "pycryptodome>=3.20.0", "cachetools>=5.3.0", "paho-mqtt>=1.6.0", "pynacl>=1.5.0"],
+  "requirements": ["meshcore>=2.3.7", "meshcore-cli>=0.0.0", "pycryptodome>=3.20.0", "cachetools>=5.3.0", "paho-mqtt>=1.6.0", "pynacl>=1.5.0"],
   "iot_class": "local_polling",
   "version": "2.6.0",
   "config_flow": true


### PR DESCRIPTION
## Summary

Bump the `meshcore` (meshcore_py SDK) requirement floor in `manifest.json` from `>=2.2.24` to `>=2.3.7` to reflect the actual minimum the integration needs for correct behavior on current `main`.

## Why

`meshcore_py` 2.3.7 (released 2026-04-25) shipped a series of fixes that the current meshcore-ha integration actively exercises. The existing `>=2.2.24` floor predates these fixes, so anyone with a strict lockfile pinning `meshcore_py < 2.3.7` hits the bugs listed below. Pip's default resolver already picks 2.3.7+ on a fresh install — bumping the floor doesn't force any user to upgrade who isn't already on the latest, it just makes the manifest reflect what the integration actually depends on.

## meshcore_py 2.3.7 fixes that meshcore-ha relies on

- [meshcore-dev/meshcore_py#74](https://github.com/meshcore-dev/meshcore_py/pull/74) — umbrella crash protection and length guards in reader/parser dispatch. Malformed RF packets used to crash the SDK; the integration's coordinator now stays up across packet anomalies.
- [meshcore-dev/meshcore_py#75](https://github.com/meshcore-dev/meshcore_py/pull/75) — TCP reconnect-storm fix (TCP Future return, missing appstart, task-overwrite race). Directly affects the TCP transport path most users run on.
- [meshcore-dev/meshcore_py#76](https://github.com/meshcore-dev/meshcore_py/pull/76) — `EventType.ERROR` added to command `expected_events`, error payloads guarded. Error responses no longer crash command futures (`execute_command`, `set_*`, etc.).
- [meshcore-dev/meshcore_py#77](https://github.com/meshcore-dev/meshcore_py/pull/77) — symmetric disconnect signaling, serial read timeout, BLE disconnect callback, oversize-frame recovery. Affects serial and BLE transports.
- [meshcore-dev/meshcore_py#78](https://github.com/meshcore-dev/meshcore_py/pull/78) — asyncio lifecycle hardening: deferred `Queue`/`Lock` construction, `get_running_loop` usage, background-task tracking.
- [meshcore-dev/meshcore_py#79](https://github.com/meshcore-dev/meshcore_py/pull/79) — `DEFAULT_TIMEOUT` raised from 5s to 15s. Commands on slow or multi-hop mesh paths no longer time out prematurely. Pre-registered binary requests close a race window; broken deprecated `req_mma` removed.
- [meshcore-dev/meshcore_py#80](https://github.com/meshcore-dev/meshcore_py/pull/80) — adds missing protocol handlers (`CONTACT_DELETED`, `CONTACTS_FULL`, `TUNING_PARAMS`) and command wrappers.

## What changes

`custom_components/meshcore/manifest.json`: one line change in `requirements` — `meshcore>=2.2.24` → `meshcore>=2.3.7`. No code changes.

## Stability & compatibility

- No code paths change in this PR.
- Users on a normal `pip` resolve already get `meshcore_py` 2.3.7 or later.
- Users on a strict lockfile that pins `meshcore_py < 2.3.7` will need to bump their lockfile, but they were already running with the bugs above.
- Verified on a real HA host running `meshcore_py` 2.3.7 since 2026-04-25 with no regressions across contacts, channels, repeaters, telemetry, traces, and message delivery.