### PR TITLE
Fix RX_LOG parsing for multi-byte path sizes

### DIFF
--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -1183,14 +1183,26 @@ class MeshCoreMqttUploader:
                 if not hash_value:
                     has_transport = route_type in (0x00, 0x03)
                     offset = 1 + (4 if has_transport else 0)
-                    path_len_value = packet_bytes[offset] if len(packet_bytes) > offset else 0
-                    payload_start = offset + 1 + path_len_value
+                    # Path byte is bit-packed: low 4 bits = hop count
+                    raw_path_byte = packet_bytes[offset] if len(packet_bytes) > offset else 0
+                    hop_count = raw_path_byte & 0x0F
+
+                    # Determine per-node address size (1..4 bytes) by testing which fits
+                    addr_size = 1
+                    for candidate in (4, 3, 2, 1):
+                        path_bytes_len = hop_count * candidate
+                        # need at least channel_hash (1) + MAC (2) after path
+                        if len(packet_bytes) >= offset + 1 + path_bytes_len + 3:
+                            addr_size = candidate
+                            break
+
+                    payload_start = offset + 1 + hop_count * addr_size
                     payload_data = packet_bytes[payload_start:] if len(packet_bytes) > payload_start else b""
 
                     hash_obj = hashlib.sha256()
                     hash_obj.update(bytes([payload_type_value]))
                     if payload_type_value == 9:  # TRACE
-                        hash_obj.update(path_len_value.to_bytes(2, byteorder="little"))
+                        hash_obj.update(hop_count.to_bytes(2, byteorder="little"))
                     hash_obj.update(payload_data)
                     hash_value = hash_obj.hexdigest()[:16].upper()
             except Exception:

--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -1183,20 +1183,11 @@ class MeshCoreMqttUploader:
                 if not hash_value:
                     has_transport = route_type in (0x00, 0x03)
                     offset = 1 + (4 if has_transport else 0)
-                    # Path byte is bit-packed: low 4 bits = hop count
                     raw_path_byte = packet_bytes[offset] if len(packet_bytes) > offset else 0
-                    hop_count = raw_path_byte & 0x0F
+                    path_hash_size = ((raw_path_byte & 0xC0) >> 6) + 1
+                    hop_count = raw_path_byte & 0x3F
 
-                    # Determine per-node address size (1..4 bytes) by testing which fits
-                    addr_size = 1
-                    for candidate in (4, 3, 2, 1):
-                        path_bytes_len = hop_count * candidate
-                        # need at least channel_hash (1) + MAC (2) after path
-                        if len(packet_bytes) >= offset + 1 + path_bytes_len + 3:
-                            addr_size = candidate
-                            break
-
-                    payload_start = offset + 1 + hop_count * addr_size
+                    payload_start = offset + 1 + (hop_count * path_hash_size)
                     payload_data = packet_bytes[payload_start:] if len(packet_bytes) > payload_start else b""
 
                     hash_obj = hashlib.sha256()

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -279,29 +279,23 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         if len(packet_bytes) < 2:
             return result
 
-        # Parse header and path
+        # Parse header and path using the same layout as meshcore_py:
+        # - byte 0: header
+        # - byte 1: path byte
+        #   - high 2 bits: path hash size mode => 1..4 bytes per hop
+        #   - low 6 bits: hop count
         header = packet_bytes[0]
         path_byte = packet_bytes[1]
 
         # Extract payload type from header (bits 2-5)
         payload_type = (header >> 2) & 0x0F
 
-        # New protocol: path_byte is bit-packed. Low 4 bits contain hop count
-        # (number of nodes). High bits are flags (address/hash sizing).
-        hop_count = path_byte & 0x0F
-
-        # Determine per-node address size (bytes). Try larger sizes first
-        # (support 1..4 bytes per node) and pick the first that fits the packet.
-        addr_size = 1
-        for candidate in (4, 3, 2, 1):
-            path_end_candidate = 2 + hop_count * candidate
-            # need at least channel_hash (1) + MAC (2)
-            if len(packet_bytes) >= path_end_candidate + 3:
-                addr_size = candidate
-                break
+        path_hash_size = ((path_byte & 0xC0) >> 6) + 1
+        hop_count = path_byte & 0x3F
 
         result["header"] = f"{header:02x}"
         result["path_len"] = hop_count
+        result["path_hash_size"] = path_hash_size
         result["payload_type"] = payload_type
 
         # Check if this is GroupText (0x05)
@@ -310,7 +304,7 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
             return result
 
         # Validate packet length and compute path end index
-        path_end = 2 + hop_count * addr_size
+        path_end = 2 + hop_count * path_hash_size
         if len(packet_bytes) < path_end + 3:  # Need at least channel_hash + 2-byte MAC
             return result
 
@@ -356,7 +350,7 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
                         "path_len": hop_count,
                         "path": path_data.hex(),
                         "channel_hash": f"{channel_hash_byte:02x}",
-                        "addr_size": addr_size,
+                        "path_hash_size": path_hash_size,
                     }
 
                     _LOGGER.debug(f"Successfully decrypted RX_LOG for channel {channel_idx}: {message_text[:50]}")
@@ -441,38 +435,37 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         # Parse header (bytes 0-1)
         result["header"] = hex_str[0:2]
 
-        # Parse path byte (bit-packed): low 4 bits = hop count
+        # Parse path byte using the same bit layout as meshcore_py:
+        # high 2 bits = path hash size mode (1..4 bytes per hop)
+        # low 6 bits = hop count
         try:
             path_byte = int(hex_str[2:4], 16)
         except ValueError:
             _LOGGER.debug(f"Could not parse path byte from: {hex_str[2:4]}")
             return result
 
-        hop_count = path_byte & 0x0F
+        path_hash_size = ((path_byte & 0xC0) >> 6) + 1
+        hop_count = path_byte & 0x3F
         result["path_len"] = hop_count
+        result["path_hash_size"] = path_hash_size
 
-        # Determine address size (1..4 bytes) by checking which candidate
-        # fits the hex packet length. Path hex starts at nibble index 4.
+        # Path hex starts at nibble index 4.
         path_start = 4
-        path_hex = ""
-        addr_size = None
-        for candidate in (4, 3, 2, 1):
-            path_end_candidate = path_start + (hop_count * candidate * 2)
-            if len(hex_str) >= path_end_candidate:
-                addr_size = candidate
-                path_hex = hex_str[path_start:path_end_candidate]
-                path_end = path_end_candidate
-                break
-
-        if addr_size is None:
-            _LOGGER.debug(f"RX_LOG hex too short for path data: expected at least {path_start + hop_count * 2}, got {len(hex_str)}")
+        path_end = path_start + (hop_count * path_hash_size * 2)
+        if len(hex_str) < path_end:
+            _LOGGER.debug(
+                "RX_LOG hex too short for path data: expected at least %d, got %d",
+                path_end,
+                len(hex_str),
+            )
             return result
 
+        path_hex = hex_str[path_start:path_end]
         result["path"] = path_hex
 
-        # Parse individual nodes in path (2 or 4 chars each depending on addr_size)
+        # Parse individual nodes in path (2, 4, 6, or 8 chars each depending on path_hash_size)
         path_nodes = []
-        step = addr_size * 2
+        step = path_hash_size * 2
         for i in range(0, len(path_hex), step):
             node_hex = path_hex[i:i+step]
             path_nodes.append(node_hex)

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -281,13 +281,27 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
 
         # Parse header and path
         header = packet_bytes[0]
-        path_len = packet_bytes[1]
+        path_byte = packet_bytes[1]
 
         # Extract payload type from header (bits 2-5)
         payload_type = (header >> 2) & 0x0F
 
+        # New protocol: path_byte is bit-packed. Low 4 bits contain hop count
+        # (number of nodes). High bits are flags (address/hash sizing).
+        hop_count = path_byte & 0x0F
+
+        # Determine per-node address size (bytes). Try larger sizes first
+        # (support 1..4 bytes per node) and pick the first that fits the packet.
+        addr_size = 1
+        for candidate in (4, 3, 2, 1):
+            path_end_candidate = 2 + hop_count * candidate
+            # need at least channel_hash (1) + MAC (2)
+            if len(packet_bytes) >= path_end_candidate + 3:
+                addr_size = candidate
+                break
+
         result["header"] = f"{header:02x}"
-        result["path_len"] = path_len
+        result["path_len"] = hop_count
         result["payload_type"] = payload_type
 
         # Check if this is GroupText (0x05)
@@ -295,12 +309,12 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
             _LOGGER.debug(f"RX_LOG payload type {payload_type:02x} is not GroupText, skipping decryption")
             return result
 
-        # Validate packet length
-        path_end = 2 + path_len
+        # Validate packet length and compute path end index
+        path_end = 2 + hop_count * addr_size
         if len(packet_bytes) < path_end + 3:  # Need at least channel_hash + 2-byte MAC
             return result
 
-        # Extract path data
+        # Extract path data (bytes) and hex string
         path_data = packet_bytes[2:path_end]
         result["path"] = path_data.hex()
 
@@ -339,9 +353,10 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
                         "timestamp": timestamp,
                         "text": message_text,
                         "decrypted": True,
-                        "path_len": path_len,
+                        "path_len": hop_count,
                         "path": path_data.hex(),
-                        "channel_hash": f"{channel_hash_byte:02x}"
+                        "channel_hash": f"{channel_hash_byte:02x}",
+                        "addr_size": addr_size,
                     }
 
                     _LOGGER.debug(f"Successfully decrypted RX_LOG for channel {channel_idx}: {message_text[:50]}")
@@ -426,31 +441,40 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         # Parse header (bytes 0-1)
         result["header"] = hex_str[0:2]
 
-        # Parse path_len (bytes 2-3)
+        # Parse path byte (bit-packed): low 4 bits = hop count
         try:
-            path_len = int(hex_str[2:4], 16)
-            result["path_len"] = path_len
+            path_byte = int(hex_str[2:4], 16)
         except ValueError:
-            _LOGGER.debug(f"Could not parse path_len from: {hex_str[2:4]}")
+            _LOGGER.debug(f"Could not parse path byte from: {hex_str[2:4]}")
             return result
 
-        # Calculate expected positions
+        hop_count = path_byte & 0x0F
+        result["path_len"] = hop_count
+
+        # Determine address size (1..4 bytes) by checking which candidate
+        # fits the hex packet length. Path hex starts at nibble index 4.
         path_start = 4
-        path_end = path_start + (path_len * 2)  # Each node is 2 hex chars
+        path_hex = ""
+        addr_size = None
+        for candidate in (4, 3, 2, 1):
+            path_end_candidate = path_start + (hop_count * candidate * 2)
+            if len(hex_str) >= path_end_candidate:
+                addr_size = candidate
+                path_hex = hex_str[path_start:path_end_candidate]
+                path_end = path_end_candidate
+                break
 
-        # Validate length for path data
-        if len(hex_str) < path_end:
-            _LOGGER.debug(f"RX_LOG hex too short for path data: expected {path_end}, got {len(hex_str)}")
+        if addr_size is None:
+            _LOGGER.debug(f"RX_LOG hex too short for path data: expected at least {path_start + hop_count * 2}, got {len(hex_str)}")
             return result
 
-        # Extract path data
-        path_hex = hex_str[path_start:path_end]
         result["path"] = path_hex
 
-        # Parse individual nodes in path (2 chars each)
+        # Parse individual nodes in path (2 or 4 chars each depending on addr_size)
         path_nodes = []
-        for i in range(0, len(path_hex), 2):
-            node_hex = path_hex[i:i+2]
+        step = addr_size * 2
+        for i in range(0, len(path_hex), step):
+            node_hex = path_hex[i:i+step]
             path_nodes.append(node_hex)
         result["path_nodes"] = path_nodes
 


### PR DESCRIPTION
This PR fixes RX_LOG parsing for MeshCore packets using the new packed path byte format. It correctly reads the hop count, supports 1/2/3/4-byte node addresses, and restores rx_log_data population for GroupText packets.

It also keeps the parsing logic aligned with meshcore_py so raw RX log events are decoded consistently across protocol modes.