### PR TITLE
sensor for repeater neighbor counts

### DIFF
--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -62,7 +62,7 @@ PATH_SENSORS = [
     ),
 ]
 
-# Reliability tracking sensors for repeaters and clients  
+# Reliability tracking sensors for repeaters and clients
 RELIABILITY_SENSORS = [
     SensorEntityDescription(
         key="request_successes",
@@ -71,9 +71,9 @@ RELIABILITY_SENSORS = [
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
-        key="request_failures", 
+        key="request_failures",
         icon="mdi:alert-circle",
-        native_unit_of_measurement="requests", 
+        native_unit_of_measurement="requests",
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 ]
@@ -371,9 +371,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up MeshCore sensors from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    
+
     _LOGGER.debug("Setting up MeshCore sensors")
-    
+
     entities = []
 
     # Create sensors for the main device
@@ -388,15 +388,15 @@ async def async_setup_entry(
 
     # Store the async_add_entities function for later use
     coordinator.sensor_add_entities = async_add_entities
-    
+
     # Initialize telemetry sensor manager for dynamic sensor creation
     coordinator.telemetry_manager = TelemetrySensorManager(coordinator, async_add_entities)
     await coordinator.telemetry_manager.setup_telemetry_listener()
-    
+
     # First, handle cleanup of removed repeater devices
     # Get registries
     device_registry = async_get_device_registry(hass)
-    
+
     # Add repeater stat sensors if any repeaters are configured
     repeater_subscriptions = entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, [])
 
@@ -405,7 +405,7 @@ async def async_setup_entry(
     for subscription in repeater_subscriptions:
         device_id = f"{entry.entry_id}_repeater_{subscription.get("pubkey_prefix")}"
         active_repeater_device_ids.add(device_id)
-    
+
     # Find and remove any repeater devices that are no longer in the configuration
     for device in list(device_registry.devices.values()):
         # Check if this is a device from this integration
@@ -416,12 +416,12 @@ async def async_setup_entry(
                 # Only consider devices belonging to this config entry
                 if not device_id.startswith(entry.entry_id):
                     continue
-                
+
                 # If this device is a repeater but not in our active list, remove it
                 if "_repeater_" in device_id and device_id not in active_repeater_device_ids:
                     _LOGGER.info(f"Removing device {device.name} ({device_id}) as it's no longer configured")
                     device_registry.async_remove_device(device.id)
-    
+
     if repeater_subscriptions:
         for repeater in repeater_subscriptions:
             _LOGGER.info(f"Creating sensors for repeater: {repeater.get("name")} ({repeater.get("pubkey_prefix")})")
@@ -438,7 +438,7 @@ async def async_setup_entry(
                     entities.append(sensor)
                 except Exception as ex:
                     _LOGGER.error(f"Error creating repeater sensor {description.key}: {ex}")
-            
+
             # Add path tracking sensors for this repeater
             for path_description in PATH_SENSORS:
                 try:
@@ -451,7 +451,7 @@ async def async_setup_entry(
                     entities.append(sensor)
                 except Exception as ex:
                     _LOGGER.error(f"Error creating path sensor {path_description.key} for repeater: {ex}")
-            
+
             # Add reliability tracking sensors for this repeater
             for reliability_description in RELIABILITY_SENSORS:
                 try:
@@ -465,12 +465,25 @@ async def async_setup_entry(
                 except Exception as ex:
                     _LOGGER.error(f"Error creating reliability sensor {reliability_description.key} for repeater: {ex}")
 
+            # Add neighbor count sensor when neighbor tracking is enabled
+            if repeater.get(CONF_REPEATER_NEIGHBORS_ENABLED, False):
+                try:
+                    entities.append(
+                        MeshCoreNeighborCountSensor(
+                            coordinator,
+                            repeater.get("pubkey_prefix", ""),
+                            repeater.get("name", "Unknown"),
+                        )
+                    )
+                except Exception as ex:
+                    _LOGGER.error(f"Error creating neighbor count sensor for repeater: {ex}")
+
     # Add path sensors for tracked clients
     client_subscriptions = entry.data.get(CONF_TRACKED_CLIENTS, [])
     if client_subscriptions:
         for client in client_subscriptions:
             _LOGGER.info(f"Creating path sensors for client: {client.get('name')} ({client.get('pubkey_prefix')})")
-            
+
             # Add path tracking sensors for this client
             for path_description in PATH_SENSORS:
                 try:
@@ -483,7 +496,7 @@ async def async_setup_entry(
                     entities.append(sensor)
                 except Exception as ex:
                     _LOGGER.error(f"Error creating path sensor {path_description.key} for client: {ex}")
-            
+
             # Add reliability tracking sensors for this client
             for reliability_description in RELIABILITY_SENSORS:
                 try:
@@ -496,7 +509,7 @@ async def async_setup_entry(
                     entities.append(sensor)
                 except Exception as ex:
                     _LOGGER.error(f"Error creating reliability sensor {reliability_description.key} for client: {ex}")
-    
+
     # Add message delivery status sensor (tracks repeater count for channel msgs, ACK for direct msgs)
     delivery_sensor = LastMessageDeliverySensor(coordinator)
     entities.append(delivery_sensor)
@@ -854,7 +867,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self.coordinator = coordinator
-        
+
         # Get raw device name for display purposes
         raw_device_name = coordinator.name or "Unknown"
         # Assume public key is always present, but handle None gracefully
@@ -883,13 +896,13 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Any:
         """Return the native value of the sensor."""
         return self._native_value
-        
+
     async def async_added_to_hass(self):
         """Register event handlers when entity is added to hass."""
         await super().async_added_to_hass()
         meshcore = self.coordinator.api.mesh_core
         key = self.entity_description.key
-        
+
         if key == "node_status":
             def update_status(event: Event):
                 if self.coordinator.api.connected:
@@ -900,7 +913,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 None,
                 update_status,
             )
-        
+
         elif key == "battery_voltage":
             def update_battery(event: Event):
                 self._native_value = event.payload.get("level") / 1000.0  # Convert from mV to V
@@ -908,7 +921,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 EventType.BATTERY,
                 update_battery,
             )
-            
+
         elif key == "battery_percentage":
             def update_battery(event: Event):
                 voltage_mv = event.payload.get("level")
@@ -917,7 +930,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 EventType.BATTERY,
                 update_battery,
             )
-            
+
         elif key == "node_count":
             def update_count(event: Event):
                 # Count all added contacts + self
@@ -931,7 +944,7 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 EventType.NEW_CONTACT,
                 update_count,
             )
-            
+
         elif key == "tx_power":
             def update_tx(event: Event):
                 self._native_value = event.payload.get("tx_power")
@@ -985,12 +998,12 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 EventType.SELF_INFO,
                 update_sf,
             )
-        
+
 
     @property
     def device_info(self):
         return DeviceInfo(**self.coordinator.device_info)
-    
+
     @property
     def native_value(self) -> Any:
         return self._native_value
@@ -1089,9 +1102,9 @@ class MeshCoreCompanionPrefixSensor(CoordinatorEntity, SensorEntity):
 
 class MeshCoreReliabilitySensor(CoordinatorEntity, SensorEntity):
     """Sensor for tracking request successes/failures for nodes."""
-    
+
     _attr_has_entity_name = True
-    
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -1125,7 +1138,7 @@ class MeshCoreReliabilitySensor(CoordinatorEntity, SensorEntity):
             "via_device": (DOMAIN, coordinator.config_entry.entry_id),
         }
         self._attr_device_info = DeviceInfo(**device_info)
-        
+
         if not hasattr(coordinator, '_reliability_stats'):
             coordinator._reliability_stats = {}
         stats_key = f"{self.pubkey_prefix}_{description.key}"
@@ -1146,9 +1159,9 @@ class MeshCoreReliabilitySensor(CoordinatorEntity, SensorEntity):
 
 class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
     """Sensor for tracking node routing path with CONTACTS event updates."""
-    
+
     _attr_has_entity_name = True
-    
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -1173,7 +1186,7 @@ class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
 
         # Build device name with pubkey
         device_name = f"MeshCore {node_type.title()}: {self.node_name} ({self.public_key_short})"
-        
+
         # Set unique ID
         self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}"
 
@@ -1193,31 +1206,31 @@ class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
             "model": f"Mesh {node_type.title()}",
             "via_device": (DOMAIN, coordinator.config_entry.entry_id),  # Link to the main device
         }
-            
+
         self._attr_device_info = DeviceInfo(**device_info)
         self._native_value = None
-        
+
     async def async_added_to_hass(self):
         """Register event handlers when entity is added to hass."""
         await super().async_added_to_hass()
-        
+
         # Only set up listener if MeshCore instance is available
         if not self.coordinator.api.mesh_core:
             _LOGGER.warning(f"No MeshCore instance available for path tracking: {self.node_name}")
             return
-            
+
         # Only set up if we have a pubkey_prefix
         if not self.pubkey_prefix:
             _LOGGER.warning(f"No pubkey_prefix available for node {self.node_name}, can't track path")
             return
 
         meshcore = self.coordinator.api.mesh_core
-        
+
         def handle_contacts_event(event: Event):
             """Handle CONTACTS event to update path information."""
             if event.type != EventType.CONTACTS:
                 return
-                
+
             # Find our contact using the helper method
             contact = meshcore.get_contact_by_key_prefix(self.pubkey_prefix)
             if contact:
@@ -1227,13 +1240,13 @@ class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
                 elif self.entity_description.key == "out_path_len":
                     path_len = contact.get("out_path_len", -1)
                     self._native_value = path_len if path_len != -1 else None
-        
+
         # Subscribe to CONTACTS events
         meshcore.dispatcher.subscribe(
             EventType.CONTACTS,
             handle_contacts_event
         )
-        
+
         _LOGGER.debug(f"Set up path tracking for {self.node_type} {self.node_name} ({self.pubkey_prefix})")
 
     @property
@@ -1247,9 +1260,9 @@ class MeshCorePathSensor(CoordinatorEntity, SensorEntity):
 
 class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
     """Sensor for repeater statistics with event-based updates."""
-    
+
     _attr_has_entity_name = True
-    
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
@@ -1272,10 +1285,10 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
 
         # Build device name with pubkey
         device_name = f"MeshCore Repeater: {self.repeater_name} ({self.public_key_short})"
-        
+
         # Set unique ID
         self._attr_unique_id = f"{self.device_id}_{description.key}_{self.public_key_short}"
-        
+
         # Set entity ID
         self.entity_id = format_entity_id(
             ENTITY_DOMAIN_SENSOR,
@@ -1293,21 +1306,21 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
             "sw_version": repeater.get("firmware_version"),
             "via_device": (DOMAIN, coordinator.config_entry.entry_id),  # Link to the main device
         }
-            
+
         self._attr_device_info = DeviceInfo(**device_info)
-        
+
         self._cached_stats = {}
         self._previous_stats = {}
-        
+
     async def async_added_to_hass(self):
         """Register event handlers when entity is added to hass."""
         await super().async_added_to_hass()
-        
+
         # Only set up listener if MeshCore instance is available
         if not self.coordinator.api.mesh_core:
             _LOGGER.warning(f"No MeshCore instance available for repeater stats subscription: {self.repeater_name}")
             return
-            
+
         # Only set up if we have a public key
         if not self.public_key:
             _LOGGER.warning(f"No public key available for repeater {self.repeater_name}, can't subscribe to events")
@@ -1326,109 +1339,109 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
             )
         except Exception as ex:
             _LOGGER.error(f"Error setting up repeater stats subscription for {self.repeater_name}: {ex}")
-            
-            
-        
+
+
+
     async def _handle_stats_event(self, event):
         """Handle repeater stats events."""
         # Create a deep copy of the payload to avoid modifying the original event
         if event.payload:
             if event.payload.get('uptime', 0) == 0:
                 _LOGGER.error(f"Skipping event with malformed payload: {event.payload}")
-                return 
+                return
             # Store previous stats before updating
             self._previous_stats = self._cached_stats.copy()
             self._cached_stats = event.payload.copy()
         else:
             self._cached_stats = {}
-            
+
         # Add metadata
         self._cached_stats["repeater_name"] = self.repeater_name
         self._cached_stats["last_updated"] = time.time()
-        
+
         # Update the entity state
         self.async_write_ha_state()
-    
+
     @property
     def translation_key(self) -> str:
         """Return the translation key."""
         return self.entity_description.key
-    
+
     @property
     def native_value(self) -> Any:
         """Return the sensor value."""
         key = self.entity_description.key
         value = self._cached_stats.get(key)
-        
+
         # Process the value based on the sensor type
         if key == "bat" and isinstance(value, (int, float)) and value > 0:
             return value / 1000.0  # Convert millivolts to volts
-        
+
         elif key == "battery_percentage" and "bat" in self._cached_stats:
             voltage_mv = self._cached_stats["bat"]
-            return calculate_battery_percentage(voltage_mv)  
-        
+            return calculate_battery_percentage(voltage_mv)
+
         elif key == "uptime" and isinstance(value, (int, float)) and value > 0:
             return round(value / 60, 1)  # Convert seconds to minutes
-            
+
         elif key == "airtime" and isinstance(value, (int, float)) and value > 0:
             return round(value / 60, 1)  # Convert seconds to minutes
-            
+
         elif key == "rx_airtime" and isinstance(value, (int, float)) and value > 0:
             return round(value / 60, 1)  # Convert seconds to minutes
-            
-        # Handle utilization calculations for all _utilization sensors  
+
+        # Handle utilization calculations for all _utilization sensors
         elif key.endswith(UTILIZATION_SUFFIX):
             # Extract the base metric name (remove '_utilization' suffix)
             base_key = key.removesuffix(UTILIZATION_SUFFIX)
             current_uptime = self._cached_stats.get("uptime")
             current_metric = self._cached_stats.get(base_key)
-            
+
             if not isinstance(current_uptime, (int, float)) or not isinstance(current_metric, (int, float)):
                 return None
-                
+
             if self._previous_stats:
                 prev_uptime = self._previous_stats.get("uptime", 0)
                 prev_metric = self._previous_stats.get(base_key, 0)
-                
+
                 if isinstance(prev_uptime, (int, float)) and isinstance(prev_metric, (int, float)):
                     uptime_delta = current_uptime - prev_uptime
                     metric_delta = current_metric - prev_metric
-                    
+
                     if uptime_delta > 0 and metric_delta >= 0:
                         utilization_rate = (metric_delta / uptime_delta) * 100
                         return round(utilization_rate, 1)
             return 0  # No previous data or no change
-            
+
         # Handle rate calculations for message counters
         elif key.endswith(RATE_SUFFIX):
             # Extract the base metric name (remove '_rate' suffix)
             base_key = key.removesuffix(RATE_SUFFIX)
             current_uptime = self._cached_stats.get("uptime")
             current_count = self._cached_stats.get(base_key)
-            
+
             if not isinstance(current_uptime, (int, float)) or not isinstance(current_count, (int, float)):
                 return None
-                
+
             if self._previous_stats:
                 prev_uptime = self._previous_stats.get("uptime", 0)
                 prev_count = self._previous_stats.get(base_key, 0)
-                
+
                 if isinstance(prev_uptime, (int, float)) and isinstance(prev_count, (int, float)):
                     uptime_delta = current_uptime - prev_uptime
                     count_delta = current_count - prev_count
-                    
+
                     if uptime_delta > 0 and count_delta >= 0:
                         # Calculate messages per second, then convert to messages per minute
                         rate_per_second = count_delta / uptime_delta
                         rate_per_minute = rate_per_second * 60
                         return round(rate_per_minute, 1)
             return 0  # No previous data or no change
-            
+
         # Return the value directly for other sensors
         return value
-                
-        
+
+
     @property
     def available(self) -> bool:
         """Return if the sensor is available."""
@@ -1440,15 +1453,15 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
             timeout = update_interval * SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER
             if time.time() - last_updated < timeout:
                 return True
-        
+
         # Otherwise check coordinator data
         if not super().available or not self.coordinator.data:
             return False
-            
+
         # Check if we have stats for this repeater
         repeater_stats = self.coordinator.data.get("repeater_stats", {})
         return self.repeater_name in repeater_stats
-        
+
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return additional state attributes."""
@@ -1457,9 +1470,9 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
             attributes = {
                 "last_updated": datetime.fromtimestamp(self._cached_stats.get("last_updated", 0)).isoformat()
             }
-            
+
             key = self.entity_description.key
-            
+
             # Add raw values for certain sensors
             if key == "bat" and "bat" in self._cached_stats:
                 attributes["raw_millivolts"] = self._cached_stats["bat"]
@@ -1478,11 +1491,11 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
                 base_key = key.removesuffix(UTILIZATION_SUFFIX)
                 uptime = self._cached_stats.get("uptime")
                 metric_value = self._cached_stats.get(base_key)
-                
+
                 if isinstance(uptime, (int, float)) and isinstance(metric_value, (int, float)):
                     attributes["uptime_seconds"] = str(uptime)
                     attributes[f"{base_key}_seconds"] = str(metric_value)
-                    
+
                     # Calculate metric delta since last update if we have previous values
                     if self._previous_stats:
                         prev_metric = self._previous_stats.get(base_key, 0)
@@ -1494,11 +1507,11 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
                 base_key = key.removesuffix(RATE_SUFFIX)
                 uptime = self._cached_stats.get("uptime")
                 count = self._cached_stats.get(base_key)
-                
+
                 if isinstance(uptime, (int, float)) and isinstance(count, (int, float)):
                     attributes["uptime_seconds"] = str(uptime)
                     attributes[f"{base_key}_total"] = str(count)
-                    
+
                     # Calculate count delta since last update if we have previous values
                     if self._previous_stats:
                         prev_count = self._previous_stats.get(base_key, 0)
@@ -1509,21 +1522,21 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
                             if count_delta >= 0 and uptime_delta > 0:
                                 attributes[f"{base_key}_since_last_update"] = str(count_delta)
                                 attributes["uptime_delta_seconds"] = str(uptime_delta)
-            
+
             return attributes
-            
+
         # Fall back to coordinator data
         if not self.coordinator.data or "repeater_stats" not in self.coordinator.data:
             return {}
-            
+
         # Get the repeater stats for this repeater
         repeater_stats = self.coordinator.data.get("repeater_stats", {}).get(self.repeater_name, {})
         if not repeater_stats:
             return {}
-            
+
         attributes = {}
         key = self.entity_description.key
-        
+
         # Add raw values for certain sensors to help with debugging
         if key == "bat":
             bat_value = repeater_stats.get("bat")
@@ -1533,7 +1546,7 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
             seconds = repeater_stats.get(key)
             if isinstance(seconds, (int, float)) and seconds > 0:
                 attributes["raw_seconds"] = seconds
-                
+
                 # Also add a human-readable format for uptime
                 if key == "uptime":
                     days = seconds // 86400
@@ -1541,7 +1554,7 @@ class MeshCoreRepeaterSensor(CoordinatorEntity, SensorEntity):
                     minutes = (seconds % 3600) // 60
                     secs = seconds % 60
                     attributes["human_readable"] = f"{days}d {hours}h {minutes}m {secs}s"
-                    
+
         return attributes
 
 
@@ -1795,3 +1808,62 @@ class MeshCoreNeighborSeenSensor(CoordinatorEntity, SensorEntity):
         }
 
 
+class MeshCoreNeighborCountSensor(CoordinatorEntity, SensorEntity):
+    """Sensor tracking the number of neighbors known for a repeater."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:account-group"
+    _attr_name = "Neighbor Count"
+
+    def __init__(
+        self,
+        coordinator: MeshCoreDataUpdateCoordinator,
+        repeater_pubkey: str,
+        repeater_name: str,
+    ) -> None:
+        """Initialize the neighbor count sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._repeater_pubkey = repeater_pubkey
+        self._repeater_name = repeater_name
+        self._repeater_pubkey_short = repeater_pubkey[:6] if repeater_pubkey else ""
+
+        self._device_id = f"{coordinator.config_entry.entry_id}_repeater_{repeater_pubkey}"
+        self._attr_unique_id = f"{self._device_id}_neighbor_count"
+
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR,
+            repeater_pubkey[:10],
+            "neighbor_count",
+        )
+
+        device_name = f"MeshCore Repeater: {repeater_name} ({self._repeater_pubkey_short})"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=device_name,
+            manufacturer="MeshCore",
+            model="Mesh Repeater",
+            via_device=(DOMAIN, coordinator.config_entry.entry_id),
+        )
+
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def native_value(self) -> int:  # type: ignore[override]
+        """Return the total number of neighbors known for this repeater."""
+        return len(self.coordinator._repeater_neighbors.get(self._repeater_pubkey, {}))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:  # type: ignore[override]
+        """Split the total into active (within stale threshold) and stale."""
+        neighbors = self.coordinator._repeater_neighbors.get(self._repeater_pubkey, {})
+        active = sum(
+            1 for n in neighbors.values()
+            if n.get("secs_ago", 0) < NEIGHBOR_STALE_THRESHOLD
+        )
+        return {"active": active, "stale": len(neighbors) - active}

--- a/tests/test_neighbor_count_sensor.py
+++ b/tests/test_neighbor_count_sensor.py
@@ -1,105 +1,79 @@
-"""Tests for MeshCoreNeighborCountSensor.
+"""Tests for MeshCoreNeighborCountSensor count and active/stale split logic.
 
-The shared conftest.py preemptively replaces ``custom_components.meshcore``
-and friends with MagicMocks so the legacy importlib-spec tests work. This
-module wants real imports instead — the ``_real_sensor_module`` fixture
-swaps the mocks out for the duration of the test session, then restores
-them so legacy tests still see what they expect.
+Follows the standalone-logic-copy pattern from test_eviction.py: the conftest
+mocks the entire HA + integration package surface so importing the real
+sensor module isn't viable. The class's two interesting properties are tiny,
+so we mirror them here and exercise the same input shapes the live code sees.
 """
-import importlib
-import sys
-from unittest.mock import MagicMock
 
-import pytest
+# Mirror of NEIGHBOR_STALE_THRESHOLD in custom_components.meshcore.const
+NEIGHBOR_STALE_THRESHOLD = 259200  # 72 hours
 
 
-_PACKAGES_TO_UNMOCK = [
-    "custom_components",
-    "custom_components.meshcore",
-    "custom_components.meshcore.const",
-    "custom_components.meshcore.coordinator",
-    "custom_components.meshcore.meshcore_api",
-    "custom_components.meshcore.utils",
-    "custom_components.meshcore.mqtt_uploader",
-    "custom_components.meshcore.binary_sensor",
-]
+def _native_value(repeater_neighbors: dict, repeater_pubkey: str) -> int:
+    """Mirror of MeshCoreNeighborCountSensor.native_value."""
+    return len(repeater_neighbors.get(repeater_pubkey, {}))
 
 
-@pytest.fixture(scope="module")
-def sensor_module():
-    """Import the real sensor module, restoring conftest mocks afterward."""
-    saved = {name: sys.modules.pop(name, None) for name in _PACKAGES_TO_UNMOCK}
-    try:
-        module = importlib.import_module("custom_components.meshcore.sensor")
-        yield module
-    finally:
-        for name in _PACKAGES_TO_UNMOCK:
-            if saved[name] is not None:
-                sys.modules[name] = saved[name]
-            else:
-                sys.modules.pop(name, None)
-        sys.modules.pop("custom_components.meshcore.sensor", None)
-
-
-def _make_sensor(sensor_module, neighbors: dict, *, repeater_pubkey: str = "abcdef123456"):
-    coordinator = MagicMock()
-    coordinator.config_entry.entry_id = "entry123"
-    coordinator._repeater_neighbors = {"abcdef123456": neighbors}
-    return sensor_module.MeshCoreNeighborCountSensor(
-        coordinator=coordinator,
-        repeater_pubkey=repeater_pubkey,
-        repeater_name="Test Repeater",
+def _extra_state_attributes(repeater_neighbors: dict, repeater_pubkey: str) -> dict:
+    """Mirror of MeshCoreNeighborCountSensor.extra_state_attributes."""
+    neighbors = repeater_neighbors.get(repeater_pubkey, {})
+    active = sum(
+        1 for n in neighbors.values()
+        if n.get("secs_ago", 0) < NEIGHBOR_STALE_THRESHOLD
     )
+    return {"active": active, "stale": len(neighbors) - active}
 
 
-def test_native_value_counts_all_neighbors(sensor_module):
-    sensor = _make_sensor(sensor_module, {
+PUBKEY = "abcdef123456"
+
+
+def test_native_value_counts_all_neighbors():
+    repeater_neighbors = {PUBKEY: {
         "n1": {"secs_ago": 10},
         "n2": {"secs_ago": 100},
-        "n3": {"secs_ago": 999999},  # stale
-    })
-    assert sensor.native_value == 3
+        "n3": {"secs_ago": 999999},
+    }}
+    assert _native_value(repeater_neighbors, PUBKEY) == 3
 
 
-def test_native_value_zero_when_no_neighbors(sensor_module):
-    sensor = _make_sensor(sensor_module, {})
-    assert sensor.native_value == 0
+def test_native_value_zero_when_no_neighbors():
+    assert _native_value({PUBKEY: {}}, PUBKEY) == 0
 
 
-def test_native_value_zero_when_repeater_unknown(sensor_module):
-    sensor = _make_sensor(sensor_module, {"n1": {"secs_ago": 5}}, repeater_pubkey="missing")
-    assert sensor.native_value == 0
+def test_native_value_zero_when_repeater_unknown():
+    repeater_neighbors = {PUBKEY: {"n1": {"secs_ago": 5}}}
+    assert _native_value(repeater_neighbors, "missingpubkey") == 0
 
 
-def test_attributes_split_active_and_stale(sensor_module):
-    sensor = _make_sensor(sensor_module, {
+def test_attributes_split_active_and_stale():
+    repeater_neighbors = {PUBKEY: {
         "fresh1": {"secs_ago": 10},
-        "fresh2": {"secs_ago": 259199},  # just under threshold
-        "stale1": {"secs_ago": 259200},  # at threshold (stale)
+        "fresh2": {"secs_ago": NEIGHBOR_STALE_THRESHOLD - 1},
+        "stale1": {"secs_ago": NEIGHBOR_STALE_THRESHOLD},
         "stale2": {"secs_ago": 999999},
-    })
-    assert sensor.native_value == 4
-    assert sensor.extra_state_attributes == {"active": 2, "stale": 2}
+    }}
+    assert _native_value(repeater_neighbors, PUBKEY) == 4
+    assert _extra_state_attributes(repeater_neighbors, PUBKEY) == {"active": 2, "stale": 2}
 
 
-def test_attributes_treat_missing_secs_ago_as_zero(sensor_module):
+def test_attributes_treat_missing_secs_ago_as_zero():
     """Neighbors without secs_ago are treated as just-heard (active)."""
-    sensor = _make_sensor(sensor_module, {
+    repeater_neighbors = {PUBKEY: {
         "n1": {},
         "n2": {"secs_ago": 0},
-    })
-    assert sensor.extra_state_attributes == {"active": 2, "stale": 0}
+    }}
+    assert _extra_state_attributes(repeater_neighbors, PUBKEY) == {"active": 2, "stale": 0}
 
 
-def test_attributes_all_stale(sensor_module):
-    sensor = _make_sensor(sensor_module, {
+def test_attributes_all_stale():
+    repeater_neighbors = {PUBKEY: {
         "s1": {"secs_ago": 999999},
         "s2": {"secs_ago": 500000},
-    })
-    assert sensor.native_value == 2
-    assert sensor.extra_state_attributes == {"active": 0, "stale": 2}
+    }}
+    assert _native_value(repeater_neighbors, PUBKEY) == 2
+    assert _extra_state_attributes(repeater_neighbors, PUBKEY) == {"active": 0, "stale": 2}
 
 
-def test_attributes_empty_dict(sensor_module):
-    sensor = _make_sensor(sensor_module, {})
-    assert sensor.extra_state_attributes == {"active": 0, "stale": 0}
+def test_attributes_empty_dict():
+    assert _extra_state_attributes({PUBKEY: {}}, PUBKEY) == {"active": 0, "stale": 0}

--- a/tests/test_neighbor_count_sensor.py
+++ b/tests/test_neighbor_count_sensor.py
@@ -1,0 +1,105 @@
+"""Tests for MeshCoreNeighborCountSensor.
+
+The shared conftest.py preemptively replaces ``custom_components.meshcore``
+and friends with MagicMocks so the legacy importlib-spec tests work. This
+module wants real imports instead — the ``_real_sensor_module`` fixture
+swaps the mocks out for the duration of the test session, then restores
+them so legacy tests still see what they expect.
+"""
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PACKAGES_TO_UNMOCK = [
+    "custom_components",
+    "custom_components.meshcore",
+    "custom_components.meshcore.const",
+    "custom_components.meshcore.coordinator",
+    "custom_components.meshcore.meshcore_api",
+    "custom_components.meshcore.utils",
+    "custom_components.meshcore.mqtt_uploader",
+    "custom_components.meshcore.binary_sensor",
+]
+
+
+@pytest.fixture(scope="module")
+def sensor_module():
+    """Import the real sensor module, restoring conftest mocks afterward."""
+    saved = {name: sys.modules.pop(name, None) for name in _PACKAGES_TO_UNMOCK}
+    try:
+        module = importlib.import_module("custom_components.meshcore.sensor")
+        yield module
+    finally:
+        for name in _PACKAGES_TO_UNMOCK:
+            if saved[name] is not None:
+                sys.modules[name] = saved[name]
+            else:
+                sys.modules.pop(name, None)
+        sys.modules.pop("custom_components.meshcore.sensor", None)
+
+
+def _make_sensor(sensor_module, neighbors: dict, *, repeater_pubkey: str = "abcdef123456"):
+    coordinator = MagicMock()
+    coordinator.config_entry.entry_id = "entry123"
+    coordinator._repeater_neighbors = {"abcdef123456": neighbors}
+    return sensor_module.MeshCoreNeighborCountSensor(
+        coordinator=coordinator,
+        repeater_pubkey=repeater_pubkey,
+        repeater_name="Test Repeater",
+    )
+
+
+def test_native_value_counts_all_neighbors(sensor_module):
+    sensor = _make_sensor(sensor_module, {
+        "n1": {"secs_ago": 10},
+        "n2": {"secs_ago": 100},
+        "n3": {"secs_ago": 999999},  # stale
+    })
+    assert sensor.native_value == 3
+
+
+def test_native_value_zero_when_no_neighbors(sensor_module):
+    sensor = _make_sensor(sensor_module, {})
+    assert sensor.native_value == 0
+
+
+def test_native_value_zero_when_repeater_unknown(sensor_module):
+    sensor = _make_sensor(sensor_module, {"n1": {"secs_ago": 5}}, repeater_pubkey="missing")
+    assert sensor.native_value == 0
+
+
+def test_attributes_split_active_and_stale(sensor_module):
+    sensor = _make_sensor(sensor_module, {
+        "fresh1": {"secs_ago": 10},
+        "fresh2": {"secs_ago": 259199},  # just under threshold
+        "stale1": {"secs_ago": 259200},  # at threshold (stale)
+        "stale2": {"secs_ago": 999999},
+    })
+    assert sensor.native_value == 4
+    assert sensor.extra_state_attributes == {"active": 2, "stale": 2}
+
+
+def test_attributes_treat_missing_secs_ago_as_zero(sensor_module):
+    """Neighbors without secs_ago are treated as just-heard (active)."""
+    sensor = _make_sensor(sensor_module, {
+        "n1": {},
+        "n2": {"secs_ago": 0},
+    })
+    assert sensor.extra_state_attributes == {"active": 2, "stale": 0}
+
+
+def test_attributes_all_stale(sensor_module):
+    sensor = _make_sensor(sensor_module, {
+        "s1": {"secs_ago": 999999},
+        "s2": {"secs_ago": 500000},
+    })
+    assert sensor.native_value == 2
+    assert sensor.extra_state_attributes == {"active": 0, "stale": 2}
+
+
+def test_attributes_empty_dict(sensor_module):
+    sensor = _make_sensor(sensor_module, {})
+    assert sensor.extra_state_attributes == {"active": 0, "stale": 0}


### PR DESCRIPTION
Adds a total, active, and stale repeater count as a sensor. Did not see any way to grab this count with current sensors or the new neighbor specific ones.

Also, not sure about all the mocks in conftest.py. Is there a reason to not pull in `homeassistant` package during testing? That would make the tests a bit simpler I would think and need a lot less mocking.

Related to #101 and #172