### PR TITLE
fix(logbook): emit TZ-aware UTC timestamp in meshcore_message event

### DIFF
--- a/custom_components/meshcore/logbook.py
+++ b/custom_components/meshcore/logbook.py
@@ -2,9 +2,9 @@
 import asyncio
 import logging
 from typing import  Callable
-from datetime import datetime
 
 from homeassistant.core import HomeAssistant, callback, Event
+from homeassistant.util import dt as dt_util
 
 from .const import (
     DOMAIN,
@@ -114,7 +114,7 @@ async def handle_channel_message(event, coordinator) -> None:
             "channel_idx": channel_idx,
             "entity_id": entity_id,
             "domain": DOMAIN,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": dt_util.utcnow().isoformat(),
             "message_type": "channel"  # Explicit message type for filtering
         }
 
@@ -319,7 +319,7 @@ def handle_contact_message(event, coordinator) -> None:
             "receiver_name": DEFAULT_DEVICE_NAME,
             "entity_id": entity_id,
             "domain": DOMAIN,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": dt_util.utcnow().isoformat(),
             "message_type": "direct",  # Explicit message type for filtering
             "hop_count": hop_count,
         }
@@ -379,7 +379,7 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "pubkey_prefix": pubkey_prefix,
             "entity_id": entity_id,
             "domain": DOMAIN,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": dt_util.utcnow().isoformat(),
             "outgoing": True,
             "message_type": "direct",
             "send_id": event_data.get("send_id"),
@@ -422,7 +422,7 @@ async def handle_outgoing_message(event_data, coordinator) -> None:
             "channel_idx": channel_idx,
             "entity_id": entity_id,
             "domain": DOMAIN,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": dt_util.utcnow().isoformat(),
             "outgoing": True,
             "message_type": "channel",
             "send_id": event_data.get("send_id"),


### PR DESCRIPTION
### Summary

The `meshcore_message` event payload's `timestamp` field is currently set with `datetime.now().isoformat()` — a **naive** ISO string with no `Z` suffix and no `±HH:MM` offset (e.g. `2026-05-08T14:23:45.123456`). This PR replaces the four producer call sites in `logbook.py` with the canonical Home Assistant helper `dt_util.utcnow().isoformat()` so the field becomes `2026-05-08T19:23:45.123456+00:00` — unambiguously UTC, and parseable identically by every consumer regardless of their timezone.

### Why this is a Home Assistant best-practice violation

The current code violates HA's foundational time-zone convention in three ways:

1. **The 2015 founding policy.** From the canonical [UTC & Time zone awareness](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/) blog post — still authoritative, still cited by current docs:

   > "From now on **all internal communication will be done in UTC**: time changed events, datetime attributes of states, etc. To get the current time in UTC you can call `homeassistant.util.dt.utcnow()`. This is a timezone aware UTC datetime object… Local times should only be used for user facing information: logs, frontend and automation settings in configuration.yaml."

   A `meshcore_message` event fired with `hass.bus.async_fire(...)` is exactly the "internal communication / time changed events" this policy targets.

2. **`homeassistant.util.dt` is structurally aware-only.** The standard helper module is implemented so that producing a naive datetime via the HA helpers is impossible — [`utcnow = partial(dt.datetime.now, UTC)`](https://github.com/home-assistant/core/blob/dev/homeassistant/util/dt.py). There is no naive code path. Reaching for the stdlib `datetime.now()` is the explicit opt-out from the convention.

3. **`pyproject.toml` pins `dt_util` as the canonical alias and bans `datetime.utcnow()` outright.** The [HA core `pyproject.toml`](https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml) declares `homeassistant.util.dt = "dt_util"` under `[tool.ruff.lint.flake8-import-conventions.aliases]` and enables ruff `DTZ003`/`DTZ004` to forbid naive UTC helpers. The only ruff-clean way for any HA core integration to emit a UTC ISO string is `dt_util.utcnow().isoformat()`.

### Five HA core precedents for the fix

Verified line-for-line against the current `home-assistant/core` `dev` branch (2026-05-08):

| Integration | File | Pattern |
|---|---|---|
| `timer` | [`components/timer/__init__.py:395-444`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/timer/__init__.py#L395-L444) | `dt_util.utcnow()` value piped through `.isoformat()` into a bus event payload — **direct structural twin** of this PR's fix |
| `persistent_notification` | [`components/persistent_notification/__init__.py:99-113`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/persistent_notification/__init__.py#L99-L113) | `ATTR_CREATED_AT: dt_util.utcnow()` in a dispatched record |
| `helpers.storage` | [`helpers/storage.py:370-383`](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/storage.py#L370-L383) | `dt_util.utcnow().isoformat()` in a string-serialization context (the exact form used here) |
| `helpers.script` | [`helpers/script.py:1880-1888`](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/script.py#L1880-L1888) | `Script.last_triggered = utcnow()` — drives every automation/script `last_triggered` attribute in HA |
| `cast` | [`components/cast/media_player.py:425-491`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/cast/media_player.py#L425-L491) | `dt_util.utcnow()` stamping the moment an external event arrives — same data-flow shape as `logbook.py` stamping incoming meshcore packets |

### User-visible impact (S2)

Empirically reproducible the moment the user's browser/mobile-app TZ differs from the HA host TZ — a common configuration for travelers, VPN users, parents-instance owners, and anyone running HA in Docker with `TZ=UTC`:

- **Frontend relative-time labels** (chat panel, custom Lovelace cards subscribed to `meshcore_message`) interpret the naive ISO via JS `new Date(...)` as *browser-local* time. A "now" message renders as "2h" when the host is 2 hours east of the browser. Reproduced with HA host in PT and browser in MT.
- **Sensor attributes** — `sensor.<device>_message_status.last_send_time` carries the same naive string and breaks any `relative_time(...)` / `as_timestamp(...)` template that consumes it.
- **User automations** triggering on `meshcore_message` and reading `trigger.event.data.timestamp` get a naive host-local string that cannot be safely compared against any other HA-side TZ-aware timestamp.

Setting the timezone in **HA Profile → Localization** does **not** fix this — that preference does not rewrite event payload contents, and `datetime.now()` reads the HA host process's local time, not the per-account TZ preference.

### Reproduction (uses only this integration + stock HA Developer Tools)

1. Confirm HA host TZ differs from the browser's TZ (Docker `TZ=UTC` host accessed from a non-UTC browser is the easiest case).
2. Open **Developer Tools → Events**, listen for `meshcore_message`.
3. Send or receive any meshcore message.
4. Compare `event.time_fired` (set by HA core via `dt_util.utcnow()` — ends in `+00:00`) against `event.data.timestamp` (set by this integration — no offset, no `Z`). They represent the same moment but differ by exactly the host's TZ offset from UTC. That mismatch is the contract violation.

### Changes

`custom_components/meshcore/logbook.py`:

- **Add** `from homeassistant.util import dt as dt_util` to imports.
- **Drop** the now-unused `from datetime import datetime` import (no other call sites remain in the file).
- **Replace** `datetime.now().isoformat()` with `dt_util.utcnow().isoformat()` at the four `meshcore_message` producer sites — `handle_channel_message`, `handle_contact_message`, and both branches of `handle_outgoing_message`.

Total: **+5 / -5** in one file. No new dependencies, no API surface changes, no behavior changes beyond the timestamp-string format.

### Compatibility

- **Single-entry / UTC-host installs** see no observable behavior change beyond the `+00:00` suffix on the field (correct in all configurations).
- **Existing stored payloads** in any downstream message store continue to display naive timestamps until they age out via natural FIFO rotation. No retroactive migration needed; HA's Jinja built-ins (`relative_time`, `as_timestamp`, Python 3.11+ `datetime.fromisoformat`) handle both formats.
- **HA's standard Logbook card was always correct** — it reads `event.time_fired` (set by HA core), not `event.data.timestamp`. So no Logbook-rendered output changes; this fix only affects the consumers that trust `event.data.timestamp`.
- **`mqtt_uploader.py` is intentionally untouched.** Its naive format matches the de-facto MeshCore observer wire spec (Cisien, agessaman, Andrew-a-g). Changing it would create a mixed-format observer stream and needs ecosystem coordination — explicitly out of scope here.

### Backward-compatibility against the documented API surface (PR #217)

[PR #217](https://github.com/meshcore-dev/meshcore-ha/pull/217) (merged 2026-04-30) published the [Companion Integration API page](https://github.com/meshcore-dev/meshcore-ha/blob/main/docs/docs/companion-integration-api.md), which documents the `meshcore_message` and `meshcore_delivery_update` events as **stable** surfaces and pins `(entity_id, timestamp)` as the documented correlation key between them. This PR honors that contract:

- **The documented type stays `ISO 8601`.** The page declares `timestamp` as `ISO 8601 — always`. Both `2026-05-08T14:23:45.123456` (current naive) and `2026-05-08T19:23:45.123456+00:00` (post-fix TZ-aware UTC) satisfy ISO 8601 — the documented type contract is not changed. Strictly: the fix narrows the value space from "naive-or-aware ISO 8601" to "TZ-aware ISO 8601," which is a subset and therefore not a breaking change to the type.
- **The `(entity_id, timestamp)` correlation continues to work.** Verified in `logbook.py`: both `meshcore_delivery_update` firing sites copy the parent `meshcore_message`'s `timestamp` verbatim — line 247 does `"timestamp": base_event_data.get("timestamp")`, line ~471 does `update_event = dict(logbook_event)`. So the format changes in lockstep on both sides of the documented tuple; consumers that use the correlation pattern see matching keys before and after.
- **No new event field, no removed field, no rename.** This is purely a value-format tightening on an existing field, in service of the field's documented type.
- **Per the page's deprecation policy**, breaking changes to stable surfaces require a one-release-cycle deprecation. Because the type contract is preserved (still ISO 8601) and the correlation pattern is preserved (lockstep update across both events), this change is non-breaking under the page's own definition. The change-log entry should still call out the format tightening so any consumer doing string-equality or lexicographic-sort comparisons against stored historical naive values can prepare.

### Testing

- **Pre-edit grep** confirmed exactly 4 `datetime.now().isoformat()` matches on `upstream/main` at lines 117, 322, 382, 425; all replaced.
- **Import smoke** — `from homeassistant.util import dt as dt_util` imports cleanly inside the production HA core container; AST parse of the patched `logbook.py` OK; 0 residual `datetime.now().isoformat()` occurrences; 4 new `dt_util.utcnow().isoformat()` occurrences; 0 residual `datetime` references after dropping the unused import.
- **Unit suite** — 53/53 pass on the feature branch (`tests/test_eviction`, `test_query_services`, `test_services_parsing`).
- **Live verification on home HA host (PDT, multi-entry):**

  | Field | Pre-fix | Post-fix |
  |---|---|---|
  | `sensor.meshcore_<prefix>_last_message_delivery.last_send_time` | `2026-05-08T00:40:57.124514` (naive PT, ~7h skew from HA's UTC `last_updated`) | `2026-05-08T09:38:48.932296+00:00` (TZ-aware UTC) |
  | Logbook `when` for the same send event | matched `event.time_fired` | matches `last_send_time` to 321ms ✓ |

  No regressions in the standard Logbook panel.

### Notes for reviewer

**Why `dt_util.utcnow()` and not `datetime.now(timezone.utc)`** — both produce identical output, but `dt_util.utcnow()` is what the flake8-import-conventions alias and every cited core integration uses. Reviewing through the lens of "what would HA core look like" makes `dt_util.utcnow()` the conventional form.

### References

- [HA blog (2015-05-09) — UTC & Time zone awareness](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/)
- [HA core `homeassistant/util/dt.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/util/dt.py)
- [HA core `pyproject.toml`](https://github.com/home-assistant/core/blob/dev/pyproject.toml) (DTZ rules + `dt_util` import alias)
- [DateTime entity dev docs](https://developers.home-assistant.io/docs/core/entity/datetime/) — "must include timezone info"
- [Calendar entity dev docs](https://developers.home-assistant.io/docs/core/entity/calendar/) — "should call `homeassistant.util.dt.now`"
- Five core-integration precedents linked above.