### PR TITLE
fix(binary_sensor): filter message_sent_handler by entry_id to stop multi-entry fan-out

### DIFF
--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -279,7 +279,21 @@ async def async_setup_entry(
     # Subscribe to our internal message sent event for outgoing messages
     @callback
     async def message_sent_handler(event):
-        """Handle outgoing message events."""
+        """Handle outgoing message events.
+
+        Multi-entry safety: only the originating coordinator should
+        process its own send. The event is fired on the global bus
+        and all entries' listeners receive it; without this filter,
+        every registered listener fires on every send, causing
+        handle_outgoing_message to fan-fire meshcore_message events
+        with each coordinator's pubkey prefix - the message gets
+        stored as outgoing on entries that didn't actually send it.
+        The meshcore.send_* services tag the event with
+        ``device: <originating-entry-id>`` (services.py:259, :336),
+        so the filter has authoritative source data.
+        """
+        if event.data.get("device") != entry.entry_id:
+            return
         if event.data.get("message_type") == "direct":
             # Handle outgoing direct message
             _LOGGER.debug(f"Handling outgoing direct message: {event.data}")


### PR DESCRIPTION
> Continuation of the multi-entry-same-mesh hardening direction already established by [PR #131](https://github.com/meshcore-dev/meshcore-ha/pull/131) (@mannkind) and [PR #150](https://github.com/meshcore-dev/meshcore-ha/pull/150) (@awolden). Those fixed the entity-cleanup and config-flow paths; this closes the **event-dispatch path** that prior fixes did not reach.

### Summary

On a Home Assistant instance with **two `meshcore` config entries observing the same physical mesh** (e.g. a room radio and a portable radio both listening to the same neighborhood), every outgoing message is currently fired by *both* entries' `message_sent_handler` callbacks because the handler is registered per-entry but listens on the **global** bus key `f"{DOMAIN}_message_sent"`. This causes one logical send to produce N copies of `meshcore_message` (one per entry), each `outgoing=True`, each attributed to a different coordinator's pubkey-prefix entity_id.

This PR adds a single-line guard at the top of `message_sent_handler` that short-circuits the callback unless the event was originated by *this* entry. The fix uses authoritative source data already present in the event payload — no new fields, no event-naming changes, no producer-side modification.

### Problem (S2 — visibly wrong UI behavior)

When the user sends a channel message from any chat-companion panel under **entry B**, the `meshcore.send_*` services correctly route the radio transmit to entry B (per chat-companion fix `9fed85a`), but the event the service fires (`meshcore_message_sent`) is consumed on the global bus by **every** entry's `message_sent_handler`. Each handler unconditionally calls `handle_outgoing_message(event.data, coordinator)`, which fires `meshcore_message` events keyed by *that* coordinator's pubkey-derived entity_id.

Result: one logical send produces N copies of `meshcore_message` (one per entry), each `outgoing=True`, each attributed to a different entity_id. Any downstream consumer that stores per entity_id ends up with the same message in every entry's view — both as blue (outgoing) bubbles. Then entry A's radio independently receives the message over-air via the mesh and stores it as a separate inbound bubble — producing two render entries for the same logical message in entry A's view (one falsely blue, one correctly gray with sender name).

**Empirically observed on a multi-entry home install (2026-05-05).** Five distinct outgoing sends each appeared under **both** active entry prefixes (`1ed4c1` and `b63537`) in `/config/.storage/meshcore_chat.<entry>.msgs.binary_sensor_meshcore_<prefix>_ch_1_messages` with the same `id` field and microsecond-delta timestamps — proving these were two independent `meshcore_message` events processed in sequence, not a single write to two locations.

### Why this is the right HA pattern

The upstream `meshcore.send_*` services **already** include `device: <originating-entry-id>` in the event payload at `services.py:259, 336`:

```python
outgoing_msg = {
    ...
    "device": entry_id,           # already there!
    ...
}
hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
```

So the producer has always tagged the originating entry; the consumer just wasn't checking. Filtering at the consumer is the **HA-canonical pattern** for config-entry-scoped event handlers — `entry: ConfigEntry` is already captured in the closure of `async_setup_entry` (in active use one block below for the listener-key namespace), so the filter is just a `.get("device")` comparison against `entry.entry_id`. No new infrastructure.

### Why filter the consumer instead of changing the producer

The alternative — per-entry-keyed event names like `f"{DOMAIN}_message_sent_{entry_id}"` — would be a **breaking API change** for any third-party consumer subscribed to the current event name. Filtering at the consumer keeps the public event surface identical and is the smaller, more reversible diff.

### Direction (continuation of accepted multi-entry hardening work)

This bug class — multi-entry installs observing the same physical mesh — is already an acknowledged maintenance direction:

- **[Issue #75](https://github.com/meshcore-dev/meshcore-ha/issues/75)** (filed 2025-10-06 by @dotdavid) reported the multi-entry-same-mesh bug surface as real.
- **[PR #131](https://github.com/meshcore-dev/meshcore-ha/pull/131)** by @mannkind (merged 2026-02-12) established multi-entry-same-mesh hardening for the **entity-cleanup path** in `sensor.py`.
- **[PR #150](https://github.com/meshcore-dev/meshcore-ha/pull/150)** by @awolden (v2.4.0) extended the direction with a config-flow / duplicate-setup guard.

This PR covers the **event-dispatch path** that prior fixes did not reach. A companion PR (`fix/multi-entry-contact-uid-collision`) covers the **entity-registration path** for contact diagnostic binary_sensors — the two PRs are independent and can be reviewed/merged in either order.

### Changes

`custom_components/meshcore/binary_sensor.py` — `message_sent_handler` callback (~line 281):

```python
@callback
async def message_sent_handler(event):
    """Handle outgoing message events.

    Multi-entry safety: only the originating coordinator should
    process its own send. ...
    """
    if event.data.get("device") != entry.entry_id:
        return
    if event.data.get("message_type") == "direct":
        ...
```

**+15 / -1** in one file. The +14 of net additions is the explanatory docstring extension; the load-bearing change is one line.

### Compatibility

- **Single-entry installs** — `event.data["device"]` always equals `entry.entry_id`, so the guard is a no-op. Zero behavior change.
- **Multi-entry installs observing different physical meshes** — also no behavior change; sends from each entry only ever fire under that entry's `entry_id`.
- **Multi-entry installs observing the same physical mesh** — outgoing messages stop fanning out across entries; each entry sees its own outgoing send plus (separately) any over-air receive of the *other* entry's send, correctly marked `outgoing=False`.

### Testing

- **Pre-implementation grep audit (Risk: any non-service caller of `meshcore_message_sent`)** — exhaustive: only `services.py:267` (direct) and `services.py:345` (channel) fire this event, both inside `hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)` with `device: config_entry_id` set on the payload immediately above (lines 259, 336).
- **Unit suite** — 53/53 pass (`tests/test_eviction`, `test_query_services`, `test_services_parsing`). The suite mocks the `binary_sensor` module so it does not directly exercise this handler; the pass confirms no co-imports broke.
- **Live verification on multi-entry home HA host:** user sent two test messages to channel 1 — one from each entry. Pre-fix expectation: both send_ids appear under both prefixes. Post-fix observation:

  | Prefix | New outgoing send_id | Cross-prefix duplicates |
  |---|---|---|
  | `1ed4c1` (entry A) | `73285dc3` | none — does NOT contain B's `44b529dc` ✓ |
  | `b63537` (entry B) | `44b529dc` | none — does NOT contain A's `73285dc3` ✓ |

  Each entry also gained one inbound entry (the over-air mesh receive of the other entry's send), correctly marked `outgoing=False`.

### References

- Issue [#75](https://github.com/meshcore-dev/meshcore-ha/issues/75) — multi-entry-same-mesh bug surface (acknowledged)
- PR [#131](https://github.com/meshcore-dev/meshcore-ha/pull/131) — prior entity-cleanup fix in `sensor.py`
- PR [#150](https://github.com/meshcore-dev/meshcore-ha/pull/150) — prior config-flow / duplicate-setup guard
- Companion PR (will be opened separately): contact-diagnostic unique_id collision fix (`fix/multi-entry-contact-uid-collision`)