### PR TITLE
fix(binary_sensor): scope contact diagnostic unique_id by entry_id (with migration)

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -247,6 +247,51 @@ def _migrate_unique_ids_remove_name(
         _LOGGER.info("Stabilized %d entity unique_ids (removed name)", migrated)
 
 
+def _migrate_unique_ids_scope_contact_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> None:
+    """One-time: prefix contact-diagnostic unique_ids with entry_id.
+
+    Pre-fix unique_ids were the raw 12-char pubkey prefix, which
+    collides on multi-entry installs where the same mesh contact is
+    observed by both entries. This migration scopes them to
+    "{entry_id}_contact_{pubkey[:12]}" so each entry has its own
+    diagnostic entity per contact. Single-entry installs see no
+    behavior change beyond the unique_id format itself.
+
+    Idempotent: a second call finds no 12-char-only unique_ids
+    (they've all been migrated to the new format).
+    """
+    entity_registry = er.async_get(hass)
+    migrated = 0
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry.entry_id:
+            continue
+        if entity.platform != DOMAIN:
+            continue
+        # Old unique_ids are exactly 12 hex chars (pubkey[:12]).
+        old_uid = entity.unique_id
+        if not (len(old_uid) == 12 and all(c in "0123456789abcdef" for c in old_uid.lower())):
+            continue
+        new_uid = f"{entry.entry_id}_contact_{old_uid}"
+        try:
+            entity_registry.async_update_entity(
+                entity.entity_id, new_unique_id=new_uid,
+            )
+            migrated += 1
+        except Exception as ex:
+            _LOGGER.error(
+                "Failed to migrate contact unique_id %s: %s",
+                old_uid, ex,
+            )
+    if migrated:
+        _LOGGER.info(
+            "Migrated %d contact-diagnostic unique_ids for entry %s",
+            migrated, entry.entry_id,
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeshCore from a config entry."""
     # Home Assistant can trigger a duplicate setup during rapid reload/update cycles.
@@ -355,6 +400,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # One-time migration: remove device name from unique_ids
     _migrate_unique_ids_remove_name(hass, entry)
+    # One-time migration: scope contact-diagnostic unique_ids by
+    # entry_id so multi-entry installs don't collide on shared mesh
+    # contacts (F-U1). Idempotent.
+    _migrate_unique_ids_scope_contact_diagnostics(hass, entry)
 
     # TODO: remove this with contact refresh interval migration?
     # Get the messages interval for base update frequency

--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -56,7 +56,15 @@ def create_contact_sensor(coordinator, contact: dict):
             coordinator,
             contact_name,
             public_key,
-            public_key[:12]
+            # Multi-entry safety: scope unique_id by entry_id so two
+            # entries observing the same physical mesh contact don't
+            # collide at entity registration. Format mirrors other
+            # entities in this file (MeshCoreMessagesBinarySensor at
+            # line 363, MeshCoreMQTTBrokerConnectionBinarySensor at
+            # line 430). Continuation of PR #131's multi-entry-same-
+            # mesh hardening, which fixed the entity-cleanup path;
+            # this closes the entity-registration path.
+            f"{coordinator.config_entry.entry_id}_contact_{public_key[:12]}",
         )
     return None
 


### PR DESCRIPTION
> Closes the literal ERROR pattern reported in [Issue #75](https://github.com/meshcore-dev/meshcore-ha/issues/75) by @dotdavid. [PR #131](https://github.com/meshcore-dev/meshcore-ha/pull/131) closed Issue #75 by guarding the entity-**cleanup** path in `sensor.py`; the entity-**registration** path in `binary_sensor.py` was missed and still produces the same ERROR. This PR closes the registration path.

### Summary

`MeshCoreContactDiagnosticBinarySensor._attr_unique_id` is currently set to the raw 12-character pubkey prefix (`public_key[:12]`) with **no `entry_id` qualifier** — making it the only entity in `binary_sensor.py` that does not scope by `entry_id`. On multi-entry installs observing the same physical mesh, both coordinators try to register entities for the same shared mesh contact with the same 12-hex `unique_id`, and HA's `entity_platform.async_add_entities` rejects the second one with:

```
ERROR (helpers/entity_platform.py:885) [homeassistant.components.binary_sensor]
  Platform meshcore does not generate unique IDs.
  ID efae676de106 is already used by binary_sensor.meshcore_mesa_park_repeater_efae676de106_contact
```

This is the literal ERROR pattern that [Issue #75](https://github.com/meshcore-dev/meshcore-ha/issues/75) (@dotdavid) reported on 2025-10-06. [PR #131](https://github.com/meshcore-dev/meshcore-ha/pull/131) (@mannkind, merged 2026-02-12) closed Issue #75 by guarding the entity-**cleanup** path in `sensor.py` — but the entity-**registration** path in `binary_sensor.py` was not on PR #131's change axis and still produces the same ERROR today.

This PR closes the registration path: scope the contact diagnostic's `unique_id` by `entry_id` (matching what every other entity in the same file already does), plus a one-time idempotent registry migration so existing installs preserve their entity history.

### Why this is the right HA pattern

Every other entity in `binary_sensor.py` already scopes `_attr_unique_id` by `entry_id`. The contact diagnostic was the **outlier** in its own file:

| Entity class | File:line | unique_id format |
|---|---|---|
| `MeshCoreMessagesBinarySensor` | `binary_sensor.py:363` | `f"{entry_id}_messages_..."` ✓ |
| `MeshCoreMQTTBrokerConnectionBinarySensor` | `binary_sensor.py:430` | `f"{entry_id}_mqtt_..."` ✓ |
| (third entry-scoped class) | `binary_sensor.py:720` | `f"{entry_id}_..."` ✓ |
| `MeshCoreContactDiagnosticBinarySensor` | `binary_sensor.py:514` | `public_key[:12]` ✗ — **the bug** |

Across all of `binary_sensor.py`, `sensor.py`, and `__init__.py` (13 other `_attr_unique_id` sites), this is the **only** assignment that produces a bare 12-hex string. That's both the source of the bug and the load-bearing property of the migration's filter — the migration's `len == 12 and all-hex` check is the precise inverse of the new format and cannot false-positive on any other entity in the integration.

### Direction (continuation of accepted multi-entry hardening work)

Same bug class, same direction as [PR #131](https://github.com/meshcore-dev/meshcore-ha/pull/131) (@mannkind, multi-entry entity cleanup) and [PR #150](https://github.com/meshcore-dev/meshcore-ha/pull/150) (@awolden, multi-entry config-flow guard). The companion PR [#235](https://github.com/meshcore-dev/meshcore-ha/pull/235) covers the event-dispatch path. All three PRs are independent siblings off `upstream/main`.

### Empirical impact (S2)

Reproduced on a multi-entry home install (2026-05-05): an `ERROR`-level system-log query for the literal "Platform meshcore does not generate unique IDs" pattern returned **27 occurrences** across overlapping mesh contacts (repeaters and clients). After re-baselining 2026-05-06 the count had grown to 43 over five distinct colliding pubkeys.

User-visible consequence: the second entry has **no diagnostic binary_sensor for any shared mesh contact** — automations, dashboards, and templates keying on those entities work for one entry but silently fail for the other. Same root cause as @dotdavid's report against the (since-fixed) sensor side.

### Changes

**1. `binary_sensor.py` — entry-scope `_attr_unique_id` in `create_contact_sensor`** (the factory; line ~45-61):

```python
return MeshCoreContactDiagnosticBinarySensor(
    coordinator,
    contact_name,
    public_key,
    # Multi-entry safety: scope unique_id by entry_id so two
    # entries observing the same physical mesh contact don't
    # collide at entity registration. Format mirrors other
    # entities in this file.
    f"{coordinator.config_entry.entry_id}_contact_{public_key[:12]}",
)
```

The third positional argument becomes `_attr_unique_id` in `MeshCoreContactDiagnosticBinarySensor.__init__` (line 514). The class itself is unchanged. The `entity_id` (line 516) is unaffected — it goes through `format_entity_id(...)` which already produces unique entity_ids per `(domain, sanitized_name, prefix, suffix)`.

**2. `__init__.py` — new helper `_migrate_unique_ids_scope_contact_diagnostics`** adjacent to the existing `_migrate_unique_ids_remove_name`:

```python
def _migrate_unique_ids_scope_contact_diagnostics(
    hass: HomeAssistant,
    entry: ConfigEntry,
) -> None:
    """One-time: prefix contact-diagnostic unique_ids with entry_id."""
    entity_registry = er.async_get(hass)
    migrated = 0
    for entity in list(entity_registry.entities.values()):
        if entity.config_entry_id != entry.entry_id:
            continue
        if entity.platform != DOMAIN:
            continue
        old_uid = entity.unique_id
        if not (len(old_uid) == 12
                and all(c in "0123456789abcdef" for c in old_uid.lower())):
            continue
        new_uid = f"{entry.entry_id}_contact_{old_uid}"
        try:
            entity_registry.async_update_entity(
                entity.entity_id, new_unique_id=new_uid,
            )
            migrated += 1
        except Exception as ex:
            _LOGGER.error(
                "Failed to migrate contact unique_id %s: %s",
                old_uid, ex,
            )
    if migrated:
        _LOGGER.info(
            "Migrated %d contact-diagnostic unique_ids for entry %s",
            migrated, entry.entry_id,
        )
```

Mirrors the shape and idempotency strategy of the existing `_migrate_unique_ids_remove_name` (added by [PR #201](https://github.com/meshcore-dev/meshcore-ha/pull/201)). The 12-hex filter is the **precise inverse** of the new format (which contains underscores and is much longer) — second runs are silent no-ops.

`entity_registry.async_update_entity(..., new_unique_id=...)` is the documented HA path for unique_id migration; HA's recorder integration follows `previous_unique_id` references, so long-term-stats / state-change history is preserved across the migration.

**3. `__init__.py` — wire migration call into `async_setup_entry`** adjacent to the existing migration call:

```python
_migrate_unique_ids_remove_name(hass, entry)
_migrate_unique_ids_scope_contact_diagnostics(hass, entry)  # NEW
```

Per-entry, race-free across multi-entry first runs.

**Total: +58 / -1** across two files.

### Compatibility

- **Single-entry installs** see the unique_id format change once on first load after the upgrade (e.g. `7e1c20074d3a` → `01KQYFD04RKJXWBZXC92MAY06T_contact_7e1c20074d3a`), then no further activity. The `entity_id` is unchanged — every dashboard, automation, and template that references the entity by `entity_id` continues to work.
- **Recorder history is preserved bit-for-bit.** `entity_registry.async_update_entity(new_unique_id=...)` is the documented preservation path — recorder data is keyed by `entity_id`, which doesn't change. Verified live (see Testing).
- **Multi-entry installs** stop ERROR'ing on contact-diagnostic registration; every entry now registers its own diagnostic entity per shared mesh contact.

### Testing

- **Pre-implementation grep audit (Risk: false-positives in the migration filter)** — across `binary_sensor.py`, `sensor.py`, `__init__.py`, only `MeshCoreContactDiagnosticBinarySensor.__init__` produces a bare 12-hex unique_id. All 13 other `_attr_unique_id` sites use entry_id- or device_id-prefixed formats and cannot match the migration's strict 12-hex filter.
- **Unit suite** — 53/53 pass (`tests/test_eviction`, `test_query_services`, `test_services_parsing`). AST parse OK on both edited files.
- **Live verification on multi-entry home HA host (load-bearing):**

  | Metric | Pre-fix | Post-fix |
  |---|---|---|
  | "Platform meshcore does not generate unique IDs" ERROR count | 43 (over 5 distinct IDs) | **0** ✓ |
  | Total contact-diagnostic entities | 9 (3 entry A, 6 entry B) | 31 (3 entry A, 28 entry B) — both entries register; previously-rejected contacts now visible |
  | Pre-existing entity unique_id (sample) | `7e1c20074d3a` (raw 12-hex) | `01KQYFD04RKJXWBZXC92MAY06T_contact_7e1c20074d3a` ✓ migrated in place; entity_id unchanged |

- **Idempotency** — second `ha core stop/start` cycle confirmed: zero new migrations attempted on second startup; entity count stable; ERROR-search returned 0.
- **Recorder history continuity** — pre-migration snapshot captured for two contact entities (one per entry); post-migration re-query showed identical state-change timestamps preserved bit-for-bit (e.g. `psychohamster` entity retained 3 state changes with **exact pre-migration timestamps** — `unavailable` at `22:35:53.807942Z`, `discovered` at `22:35:53.823540Z`).

### Notes for reviewer

**Cosmetic side-effect of multi-entry registration** — when both entries register the same `(name, pubkey, suffix)` triple, their `unique_id`s differ (per the fix) but the `entity_id` slug collides at HA's `format_entity_id` layer; HA appends a normal `_2` disambiguation suffix (e.g. `volcano_bot_in_carlsbad_796c1994edfe_contact_2`). This is HA's documented behavior, not a unique_id-collision regression.

**The migration runs at INFO log level.** The "Migrated N contact-diagnostic unique_ids" line will be visible to anyone with the meshcore logger at default INFO; users who have `custom_components.meshcore: warning` in their `logger:` config (as we do on the home install) won't see the line — but the migration still runs. Direct evidence is the unique_id format change in the entity registry, not the log line.

### References

- Issue [#75](https://github.com/meshcore-dev/meshcore-ha/issues/75) — literal ERROR pattern reported by @dotdavid (closed by PR #131 on the cleanup-path side; this PR closes the registration-path side)
- PR [#131](https://github.com/meshcore-dev/meshcore-ha/pull/131) — multi-entry entity-cleanup fix (@mannkind)
- PR [#150](https://github.com/meshcore-dev/meshcore-ha/pull/150) — multi-entry config-flow guard (@awolden)
- PR [#201](https://github.com/meshcore-dev/meshcore-ha/pull/201) — established the `_migrate_unique_ids_*` pattern this PR mirrors
- Companion PR [#235](https://github.com/meshcore-dev/meshcore-ha/pull/235) — event-dispatch fan-out fix (`fix/multi-entry-message-fanout`)