### PR TITLE
add recv errors as count and measurement

### DIFF
--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -287,7 +287,7 @@ REPEATER_SENSORS = [
     SensorEntityDescription(
         key="recv_errors",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        icon="mdi:email-alert",
+        icon="mdi:message-alert",
     ),
     SensorEntityDescription(
         key="airtime_utilization",
@@ -373,7 +373,7 @@ REPEATER_SENSORS = [
         native_unit_of_measurement="msg/min",
         suggested_display_precision="1",
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:email-alert",
+        icon="mdi:message-alert",
     ),
 ]
 

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -285,6 +285,11 @@ REPEATER_SENSORS = [
         icon="mdi:content-duplicate",
     ),
     SensorEntityDescription(
+        key="recv_errors",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:email-alert",
+    ),
+    SensorEntityDescription(
         key="airtime_utilization",
         device_class=SensorDeviceClass.POWER_FACTOR,
         native_unit_of_measurement="%",
@@ -362,6 +367,13 @@ REPEATER_SENSORS = [
         suggested_display_precision="1",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:message-arrow-right-outline",
+    ),
+    SensorEntityDescription(
+        key="recv_errors_rate",
+        native_unit_of_measurement="msg/min",
+        suggested_display_precision="1",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:email-alert",
     ),
 ]
 

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -553,6 +553,9 @@
       "flood_dups": {
         "name": "Flood Duplicates"
       },
+      "recv_errors": {
+        "name": "Receive Errors"
+      },
       "airtime_utilization": {
         "name": "Airtime Utilization"
       },
@@ -585,6 +588,9 @@
       },
       "sent_flood_rate": {
         "name": "Sent Flood Messages Rate"
+      },
+      "recv_errors_rate": {
+        "name": "Receive Errors Rate"
       }
     }
   }


### PR DESCRIPTION
Closes #140. I didn't see a tag for 2.3.7 but the code already relies on it. I guess those are not getting tags pushed to GitHub?