### PR TITLE
fix: MQTT status refresh loop blocks HA startup (#225)

### DIFF
--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -371,8 +371,9 @@ class MeshCoreMqttUploader:
             except Exception as ex:
                 self.logger.error("[%s] Connection error: %s", broker.name, ex)
         if self._status_refresh_task is None or self._status_refresh_task.done():
-            self._status_refresh_task = self.hass.async_create_task(
-                self._async_status_refresh_loop()
+            self._status_refresh_task = asyncio.create_task(
+                self._async_status_refresh_loop(),
+                name="meshcore_mqtt_status_refresh",
             )
 
     async def _async_create_client(self, broker: BrokerConfig):


### PR DESCRIPTION
In current implementation Home Assistant startup takes a lot of time to finalize.

 `_async_status_refresh_loop` was started with `hass.async_create_task()`, which registers the task in HA's startup tracker. Since the loop never exits (300 s sleep, runs while clients are connected), HA startup hung waiting for it on every restart.

Changed to `asyncio.create_task()` so the task is not tracked by HA's startup phase. `async_stop()` already explicitly cancels and awaits `_status_refresh_task` on unload, so shutdown cleanup is unchanged.