### PR TITLE
feat: allow removing orphan repeater and client devices from HA UI

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceEntry
 
 
 from .const import (
@@ -722,7 +723,47 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # If no more entries, unload services
         if not hass.data[DOMAIN]:
             await async_unload_services(hass)
-    
+
     return unload_ok
 
-                
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Decide whether a device may be removed from the HA UI.
+
+    Refuses removal of the main hub device and of repeater/client devices
+    that are still present in the config entry. Allows removal of orphans
+    (devices whose pubkey_prefix is no longer in the configured lists).
+    """
+    entry_id = config_entry.entry_id
+    repeater_prefixes = {
+        r.get("pubkey_prefix")
+        for r in config_entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, [])
+        if r.get("pubkey_prefix")
+    }
+    client_prefixes = {
+        c.get("pubkey_prefix")
+        for c in config_entry.data.get(CONF_TRACKED_CLIENTS, [])
+        if c.get("pubkey_prefix")
+    }
+
+    for domain, identifier in device_entry.identifiers:
+        if domain != DOMAIN:
+            continue
+
+        if identifier == entry_id:
+            return False
+
+        prefix = f"{entry_id}_"
+        if not identifier.startswith(prefix):
+            continue
+        remainder = identifier[len(prefix):]
+        node_type, _, pubkey_prefix = remainder.partition("_")
+
+        if node_type == "repeater" and pubkey_prefix in repeater_prefixes:
+            return False
+        if node_type == "client" and pubkey_prefix in client_prefixes:
+            return False
+
+    return True

--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -748,6 +748,16 @@ async def async_remove_config_entry_device(
         if c.get("pubkey_prefix")
     }
 
+    # Build the set of live contact prefixes from the coordinator. Config
+    # prefixes are always 12 chars; normalize contact prefixes the same way.
+    coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+    live_contact_prefixes = set()
+    if coordinator is not None and getattr(coordinator, "data", None):
+        for contact in coordinator.data.get("contacts", []):
+            prefix = contact.get("pubkey_prefix") or (contact.get("public_key") or "")[:12]
+            if prefix:
+                live_contact_prefixes.add(prefix[:12])
+
     for domain, identifier in device_entry.identifiers:
         if domain != DOMAIN:
             continue
@@ -760,10 +770,16 @@ async def async_remove_config_entry_device(
             continue
         remainder = identifier[len(prefix):]
         node_type, _, pubkey_prefix = remainder.partition("_")
+        # Device identifiers may carry the full 64-char public_key (contact
+        # fallback in _get_node_info). Config prefixes are always 12 chars,
+        # so normalize before comparing.
+        pubkey_prefix = pubkey_prefix[:12]
 
         if node_type == "repeater" and pubkey_prefix in repeater_prefixes:
             return False
         if node_type == "client" and pubkey_prefix in client_prefixes:
+            return False
+        if node_type in ("contact", "unknown") and pubkey_prefix in live_contact_prefixes:
             return False
 
     return True

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -1,0 +1,182 @@
+"""Tests for async_remove_config_entry_device (PR #247 device-delete hook).
+
+The conftest mocks the entire HA + integration package surface, so the real
+custom_components.meshcore package can't be imported the normal way. Unlike the
+standalone-logic-copy pattern used elsewhere, this hook is small and security
+relevant, so we load the *real* function via importlib against the mocked
+package and exercise it directly. We reuse the module's own mocked sentinels
+(DOMAIN, CONF_REPEATER_SUBSCRIPTIONS, CONF_TRACKED_CLIENTS) as dict keys so the
+membership logic operates on the same objects the live code sees.
+"""
+import importlib.util
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mocks that conftest does not provide but __init__.py imports at module load.
+for _name in ("homeassistant.exceptions",
+              "custom_components.meshcore.coordinator",
+              "custom_components.meshcore.meshcore_api",
+              "custom_components.meshcore.map_uploader",
+              "custom_components.meshcore.mqtt_uploader",
+              "custom_components.meshcore.services"):
+    sys.modules.setdefault(_name, MagicMock())
+
+
+def _load_real_module():
+    """Load the real custom_components/meshcore/__init__.py under the mocked package."""
+    name = "custom_components.meshcore"
+    spec = importlib.util.spec_from_file_location(
+        name,
+        "custom_components/meshcore/__init__.py",
+        submodule_search_locations=["custom_components/meshcore"],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load_real_module()
+remove = MOD.async_remove_config_entry_device
+DOMAIN = MOD.DOMAIN
+CONF_REPEATER = MOD.CONF_REPEATER_SUBSCRIPTIONS
+CONF_CLIENTS = MOD.CONF_TRACKED_CLIENTS
+
+ENTRY_ID = "abc123entryid"
+# A repeater configured with a 12-char prefix.
+REPEATER_PREFIX = "aabbccddeeff"
+CLIENT_PREFIX = "112233445566"
+CONTACT_PREFIX = "778899aabbcc"
+# Full 64-char public key whose first 12 chars match a configured repeater.
+FULL_PUBKEY = REPEATER_PREFIX + "0" * 52
+
+
+def _make_config_entry(repeaters=None, clients=None):
+    entry = MagicMock()
+    entry.entry_id = ENTRY_ID
+    entry.data = {
+        CONF_REPEATER: [{"pubkey_prefix": p} for p in (repeaters or [])],
+        CONF_CLIENTS: [{"pubkey_prefix": p} for p in (clients or [])],
+    }
+    return entry
+
+
+def _make_device(identifier):
+    device = MagicMock()
+    device.identifiers = {(DOMAIN, identifier)}
+    return device
+
+
+def _make_hass(contacts=None):
+    """hass whose data[DOMAIN][entry_id] is a coordinator exposing .data['contacts']."""
+    hass = MagicMock()
+    if contacts is None:
+        hass.data = {}
+    else:
+        coordinator = MagicMock()
+        coordinator.data = {"contacts": contacts}
+        hass.data = {DOMAIN: {ENTRY_ID: coordinator}}
+    return hass
+
+
+def _id(node_type, pubkey):
+    return f"{ENTRY_ID}_{node_type}_{pubkey}"
+
+
+@pytest.mark.asyncio
+async def test_hub_device_refused():
+    hass = _make_hass()
+    entry = _make_config_entry()
+    device = _make_device(ENTRY_ID)  # identifier == entry_id
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_live_repeater_refused():
+    hass = _make_hass()
+    entry = _make_config_entry(repeaters=[REPEATER_PREFIX])
+    device = _make_device(_id("repeater", REPEATER_PREFIX))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_live_client_refused():
+    hass = _make_hass()
+    entry = _make_config_entry(clients=[CLIENT_PREFIX])
+    device = _make_device(_id("client", CLIENT_PREFIX))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_length_mismatch_repeater_still_refused():
+    """Bug #1: identifier carries the full 64-char pubkey; config has 12 chars."""
+    hass = _make_hass()
+    entry = _make_config_entry(repeaters=[REPEATER_PREFIX])
+    device = _make_device(_id("repeater", FULL_PUBKEY))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_live_contact_refused():
+    """Bug #2: a live auto-discovered contact must not be deletable."""
+    hass = _make_hass(contacts=[{"pubkey_prefix": CONTACT_PREFIX}])
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_live_contact_full_pubkey_refused():
+    """Bug #1 + #2: contact identifier with a full 64-char pubkey, live in coordinator."""
+    full = CONTACT_PREFIX + "f" * 52
+    hass = _make_hass(contacts=[{"public_key": full}])
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", full))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_live_unknown_refused():
+    hass = _make_hass(contacts=[{"pubkey_prefix": CONTACT_PREFIX}])
+    entry = _make_config_entry()
+    device = _make_device(_id("unknown", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_orphan_contact_allowed():
+    """Contact no longer present in the coordinator may be removed."""
+    hass = _make_hass(contacts=[{"pubkey_prefix": "ffffffffffff"}])
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is True
+
+
+@pytest.mark.asyncio
+async def test_orphan_repeater_allowed():
+    """Repeater dropped from config is an orphan and may be removed."""
+    hass = _make_hass()
+    entry = _make_config_entry(repeaters=["000000000000"])
+    device = _make_device(_id("repeater", REPEATER_PREFIX))
+    assert await remove(hass, entry, device) is True
+
+
+@pytest.mark.asyncio
+async def test_foreign_device_allowed():
+    """A device whose identifier belongs to another domain falls through to True."""
+    hass = _make_hass()
+    entry = _make_config_entry()
+    device = MagicMock()
+    device.identifiers = {("other_domain", "whatever")}
+    assert await remove(hass, entry, device) is True
+
+
+@pytest.mark.asyncio
+async def test_missing_coordinator_orphan_contact_allowed():
+    """Defensive: no coordinator in hass.data -> no live contacts -> orphan allowed."""
+    hass = _make_hass()  # hass.data == {}
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is True


### PR DESCRIPTION
Implements async_remove_config_entry_device so the Home Assistant UI's "Delete" button works on MeshCore repeater and tracked-client devices.

Previously, removing a tracked client (or repeater) from the integration options flow updated the config entry but left the corresponding device and its entities in the registries, with no way to remove them short of deleting the integration entirely.

The new hook:
- refuses removal of the main hub device (identifier equals the config entry id) -- the hub goes away only when the integration is removed
- refuses removal of repeater/client devices whose pubkey_prefix is still present in CONF_REPEATER_SUBSCRIPTIONS / CONF_TRACKED_CLIENTS
- allows removal of orphan devices (pubkey_prefix no longer in config) and of any unknown device carrying this domain

Home Assistant handles cascading removal of associated entities once the hook returns True.