### PR TITLE
fix: propagate path_hash_size in rx_log correlation entry

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -564,6 +564,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         "rssi": event.payload.get("rssi"),
                         "path_len": decrypted_data.get("path_len"),
                         "path": decrypted_data.get("path"),
+                        "path_hash_size": decrypted_data.get("path_hash_size"),
                         "channel_hash": decrypted_data.get("channel_hash"),
                     }
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -42,6 +42,7 @@ Fired when any message is received. Ideal for notifications and message logging.
   - `rssi` - Received signal strength indicator
   - `path_len` - Number of hops
   - `path` - Hex-encoded path (node pubkey prefixes)
+  - `path_hash_size` - Per-hop hash width in bytes (1–3). The `path` field concatenates each hop's hash at this width, so consumers must split `path` on this width rather than assuming one byte per hop.
   - `channel_hash` - Channel identifier hash
   - `decrypted` - Whether decryption succeeded
 


### PR DESCRIPTION
### Problem

The per-reception correlation entry that meshcore-ha fires on `EVENT_MESHCORE_MESSAGE` (built in `async_setup_entry`) produces an `rx_log_data` entry that omits `path_hash_size`, even though `decrypted_data` — the return of `parse_and_decrypt_rx_log` — carries it.

Without that per-hop width, any downstream consumer that splits the raw `path` into hops has to guess, and the only safe guess is one byte per hop. That mis-segments a path through a repeater running a two-byte path hash (`path_hash_mode 1`): a single two-byte hop such as `867d` splits into two one-byte hops (`86`, `7d`), and the hop count doubles (a real 3-hop path renders as 6 segments).

### Root cause

`path_hash_size` is a recent addition to the RX_LOG path-parsing framework. #226 ("Fix RX_LOG parsing for multi-byte path sizes") added it to the parser — `parse_and_decrypt_rx_log` sets `result["path_hash_size"]` in `utils.py`, before the non-GroupText early return, so it is always present on `decrypted_data` at the call site. But #226 touched only `utils.py` and `mqtt_uploader.py`; the per-reception correlation entry in `__init__.py` — which predates the field — was not updated to carry it forward. So the width is computed by the parser and then dropped before the event fires. This PR completes #226 by propagating it.

### Fix

Add the field to the correlation entry — one line, in the `decrypted_data.get("decrypted")` branch where the entry is built:

```python
  "path_len": decrypted_data.get("path_len"),
  "path": decrypted_data.get("path"),
  "path_hash_size": decrypted_data.get("path_hash_size"),
  "channel_hash": decrypted_data.get("channel_hash"),
```

This carries the protocol-truth width to every current and future consumer of `EVENT_MESHCORE_MESSAGE` rather than having each one re-derive or guess it.

### Docs

`docs/docs/events.md` enumerates the `rx_log_data` entry fields; that list predates #226 and never listed `path_hash_size`. This PR adds a one-line entry to that list so the field is documented alongside the change that exposes it. The `companion-integration-api.md` page is intentionally left unchanged: its `rx_log_data` row is an illustrative subset that points to `events.md` for the full field list, and its stability policy already treats new fields as additive.

### Why this is correct/safe

- The value is already computed and sitting on `decrypted_data`; this is pure propagation, no new computation.
- `path_hash_size` is assigned before the decrypt path's early returns, so it is always available wherever the correlation entry is built.
- Purely additive: one new key on an in-memory event dict. No wire format, stored schema, dedup, delivery-status, or storage behavior changes. Existing consumers that don't read the key are unaffected.

### Testing

- `python -m py_compile` of the edited module passes.
- No existing test covers the RX_LOG correlation entry, so the unit suite is unaffected (verified — none of the test modules reference the correlation path).
- Verified at runtime on a live host: after deploying this change, real received messages carry `path_hash_size` on their `rx_log` entries (e.g. a two-byte `867d`-path message stored with `path_hash_size=2`), whereas entries received before the change have the field absent — confirming the propagation is this code. The integration loaded cleanly with no new errors or warnings.