### PR TITLE
feat(services): add scope parameter to send_channel_message

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_LIMIT_DISCOVERED_CONTACTS,
     CONF_MAX_DISCOVERED_CONTACTS,
     DEFAULT_MAX_DISCOVERED_CONTACTS,
+    CONF_FLOOD_SCOPES,
     CONF_MESSAGES_INTERVAL,
     DEFAULT_UPDATE_TICK,
     REPAIR_PUBKEY_CHANGED,
@@ -48,6 +49,8 @@ from .mqtt_uploader import MeshCoreMqttUploader
 from .services import async_setup_services, async_unload_services
 from .utils import (
     create_message_correlation_key,
+    load_flood_scope_keys,
+    match_flood_scope,
     parse_and_decrypt_rx_log,
     parse_rx_log_data,
     sanitize_event_data,
@@ -470,6 +473,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as ex:
             _LOGGER.error(f"Error loading contacts from device: {ex}")
 
+    # Load channel info eagerly so RX_LOG decryption works before the first
+    # coordinator update fires (avoids empty _channel_info causing pending_cache_keys=[]).
+    if connected and api.mesh_core:
+        try:
+            _LOGGER.info("Loading channel info on startup for RX_LOG correlation...")
+            await coordinator._fetch_all_channel_info()
+            _LOGGER.info(f"Startup channel info loaded: {len(coordinator._channel_info)} channels")
+        except Exception as ex:
+            _LOGGER.error(f"Error loading channel info on startup: {ex}")
+
     # Store coordinator for this entry
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
@@ -555,6 +568,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     hash_key = create_message_correlation_key(channel_idx, timestamp)
 
+                    route_type = event.payload.get("route_type")
+                    flood_scope = None
+                    if route_type == 0:
+                        # 'payload' hex starts at the header byte;
+                        # 'raw_hex' has 2 framing bytes before the header.
+                        pkt_hex = event.payload.get("payload", "")
+                        pkt_payload = event.payload.get("pkt_payload", b"")
+                        payload_type_int = event.payload.get("payload_type", 0)
+                        scope_keys = load_flood_scope_keys(
+                            coordinator.config_entry.data.get(CONF_FLOOD_SCOPES, "")
+                        )
+                        if scope_keys and pkt_hex and pkt_payload:
+                            try:
+                                pkt_bytes = bytes.fromhex(pkt_hex) if isinstance(pkt_hex, str) else pkt_hex
+                                # header(1) + transport_codes[0](2 LE) + transport_codes[1](2)
+                                if len(pkt_bytes) >= 3:
+                                    transport_code = int.from_bytes(pkt_bytes[1:3], "little")
+                                    flood_scope = match_flood_scope(
+                                        transport_code, payload_type_int, pkt_payload, scope_keys
+                                    )
+                            except Exception:
+                                pass
+
                     rx_log_entry = {
                         "channel_idx": channel_idx,
                         "channel_name": decrypted_data.get("channel_name"),
@@ -565,6 +601,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         "path_len": decrypted_data.get("path_len"),
                         "path": decrypted_data.get("path"),
                         "channel_hash": decrypted_data.get("channel_hash"),
+                        "route_type": route_type,
+                        "route_typename": event.payload.get("route_typename"),
+                        "region_scope": route_type == 0,
+                        "flood_scope": flood_scope,
                     }
 
                     if hash_key in coordinator._pending_rx_logs:

--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -478,11 +478,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if connected and api.mesh_core:
         try:
             _LOGGER.info("Loading channel info on startup for RX_LOG correlation...")
-<<<<<<< HEAD
-            await coordinator._fetch_all_channel_info()
-=======
             await coordinator.fetch_all_channel_info()
->>>>>>> upstream/main
             _LOGGER.info(f"Startup channel info loaded: {len(coordinator._channel_info)} channels")
         except Exception as ex:
             _LOGGER.error(f"Error loading channel info on startup: {ex}")

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_STALE_CONTACT_DAYS,
     DEFAULT_STALE_CONTACT_DAYS,
     CONF_ADAPTIVE_POLL_WAIT,
+    CONF_FLOOD_SCOPES,
     CONF_AUTO_CLEANUP_STALE_NEIGHBORS,
     CONF_STALE_NEIGHBOR_DAYS,
     DEFAULT_STALE_NEIGHBOR_DAYS,
@@ -896,6 +897,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             new_data[CONF_AUTO_CLEANUP_STALE_CONTACTS] = user_input[CONF_AUTO_CLEANUP_STALE_CONTACTS]
             new_data[CONF_STALE_CONTACT_DAYS] = user_input[CONF_STALE_CONTACT_DAYS]
             new_data[CONF_ADAPTIVE_POLL_WAIT] = user_input[CONF_ADAPTIVE_POLL_WAIT]
+            new_data[CONF_FLOOD_SCOPES] = user_input.get(CONF_FLOOD_SCOPES, "")
             new_data[CONF_AUTO_CLEANUP_STALE_NEIGHBORS] = user_input[CONF_AUTO_CLEANUP_STALE_NEIGHBORS]
             new_data[CONF_STALE_NEIGHBOR_DAYS] = user_input[CONF_STALE_NEIGHBOR_DAYS]
             self.hass.config_entries.async_update_entry(self.config_entry, data=new_data) # type: ignore
@@ -920,6 +922,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_adaptive_poll_wait = self.config_entry.data.get(CONF_ADAPTIVE_POLL_WAIT, False)
         current_auto_cleanup_neighbors = self.config_entry.data.get(CONF_AUTO_CLEANUP_STALE_NEIGHBORS, False)
         current_stale_neighbor_days = self.config_entry.data.get(CONF_STALE_NEIGHBOR_DAYS, DEFAULT_STALE_NEIGHBOR_DAYS)
+        current_flood_scopes = self.config_entry.data.get(CONF_FLOOD_SCOPES, "")
 
         return self.async_show_form(
             step_id="global_settings",
@@ -933,6 +936,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_AUTO_CLEANUP_STALE_CONTACTS, default=current_auto_cleanup): cv.boolean,
                 vol.Optional(CONF_STALE_CONTACT_DAYS, default=current_stale_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),
                 vol.Optional(CONF_ADAPTIVE_POLL_WAIT, default=current_adaptive_poll_wait): cv.boolean,
+                vol.Optional(CONF_FLOOD_SCOPES, default=current_flood_scopes): str,
                 vol.Optional(CONF_AUTO_CLEANUP_STALE_NEIGHBORS, default=current_auto_cleanup_neighbors): cv.boolean,
                 vol.Optional(CONF_STALE_NEIGHBOR_DAYS, default=current_stale_neighbor_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),
             }),

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -86,9 +86,7 @@ DEFAULT_CLIENT_UPDATE_INTERVAL: Final = 7200  # 2 hours in seconds
 
 # Device monitoring
 CONF_DEVICE_DISABLED: Final = "disabled"
-AUTO_DISABLE_HOURS: Final = (
-    120  # Auto-disable devices after this many hours without success
-)
+AUTO_DISABLE_HOURS: Final = 120  # Auto-disable devices after this many hours without success
 
 # Contact discovery settings
 CONF_DISABLE_CONTACT_DISCOVERY: Final = "disable_contact_discovery"
@@ -118,18 +116,14 @@ CONF_MQTT_BROKERS: Final = "mqtt_brokers"
 
 # Backoff constants for repeater failures
 REPEATER_BACKOFF_BASE: Final = 2  # Base multiplier for exponential backoff
-REPEATER_BACKOFF_MAX_MULTIPLIER: Final = (
-    120  # Maximum backoff multiplier (10 minutes when * 5 seconds)
-)
+REPEATER_BACKOFF_MAX_MULTIPLIER: Final = 120  # Maximum backoff multiplier (10 minutes when * 5 seconds)
 MAX_FAILURES_BEFORE_PATH_RESET: Final = 3  # Reset path after this many failures
 MAX_RETRY_ATTEMPTS: Final = 5  # Maximum retry attempts within refresh window
 MAX_RANDOM_DELAY: Final = 30  # Maximum random delay in seconds
 
 # Repeater neighbor settings
 NEIGHBOR_PUBKEY_PREFIX_LENGTH: Final = 6  # Bytes requested from firmware (12 hex chars)
-NEIGHBOR_STALE_THRESHOLD: Final = (
-    259200  # 72 hours in seconds — neighbor goes unavailable after this
-)
+NEIGHBOR_STALE_THRESHOLD: Final = 259200  # 72 hours in seconds — neighbor goes unavailable after this
 SEEN_WINDOW_SECS: Final = 172800  # 48-hour rolling window for seen count
 CONF_AUTO_CLEANUP_STALE_NEIGHBORS: Final = "auto_cleanup_stale_neighbors"
 CONF_STALE_NEIGHBOR_DAYS: Final = "stale_neighbor_days"

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -50,6 +50,7 @@ ATTR_CHANNEL_IDX: Final = "channel_idx"
 ATTR_MESSAGE: Final = "message"
 ATTR_COMMAND: Final = "command"
 ATTR_ENTRY_ID: Final = "entry_id"
+ATTR_SCOPE: Final = "scope"
 
 # Platform constants
 PLATFORM_MESSAGE: Final = "message"

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -151,10 +151,13 @@ RATE_LIMITER_REFILL_RATE_SECONDS: Final = 120
 
 # RX_LOG correlation cache settings
 RX_LOG_CACHE_MAX_SIZE: Final = 100
-RX_LOG_CACHE_TTL_SECONDS: Final = 5.0
+RX_LOG_CACHE_TTL_SECONDS: Final = 30.0
 
 # Adaptive poll-wait for incoming channel message RX_LOG correlation
 CONF_ADAPTIVE_POLL_WAIT: Final = "adaptive_poll_wait"
+
+# Flood scope allowlist (comma-separated region names, e.g. "pl-mz, pl-waw")
+CONF_FLOOD_SCOPES: Final = "flood_scopes"
 
 # Sensor availability timeout multiplier
 SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER: Final = 3

--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -371,8 +371,9 @@ class MeshCoreMqttUploader:
             except Exception as ex:
                 self.logger.error("[%s] Connection error: %s", broker.name, ex)
         if self._status_refresh_task is None or self._status_refresh_task.done():
-            self._status_refresh_task = self.hass.async_create_task(
-                self._async_status_refresh_loop()
+            self._status_refresh_task = asyncio.create_task(
+                self._async_status_refresh_loop(),
+                name="meshcore_mqtt_status_refresh",
             )
 
     async def _async_create_client(self, broker: BrokerConfig):

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -59,6 +59,7 @@ from .const import (
     ATTR_MESSAGE,
     ATTR_COMMAND,
     ATTR_ENTRY_ID,
+    ATTR_SCOPE,
 )
 from .utils import extract_pubkey_from_selection
 from .binary_sensor import create_contact_sensor
@@ -82,6 +83,7 @@ SEND_CHANNEL_MESSAGE_SCHEMA = vol.Schema(
         vol.Required(ATTR_CHANNEL_IDX): cv.positive_int,
         vol.Required(ATTR_MESSAGE): cv.string,
         vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Optional(ATTR_SCOPE): vol.Any(None, cv.string),
     }
 )
 
@@ -280,18 +282,19 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         channel_idx = call.data[ATTR_CHANNEL_IDX]
         message = call.data[ATTR_MESSAGE]
         entry_id = call.data.get(ATTR_ENTRY_ID)
-        
+        scope = call.data.get(ATTR_SCOPE)
+
         # Iterate through all registered config entries
         for config_entry_id, coordinator in hass.data[DOMAIN].items():
             # Skip non-coordinator entries (like event listener flags)
             if not hasattr(coordinator, 'api'):
                 continue
-                
+
             _LOGGER.debug("Entry ID: %s, coordinator: %s", config_entry_id, coordinator.name)
             # If entry_id is specified, only use the matching entry
             if entry_id and entry_id != config_entry_id:
                 continue
-                
+
             # Get the API from coordinator
             api = coordinator.api
             if api and api.connected:
@@ -299,13 +302,26 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     _LOGGER.debug(
                         "Sending message to channel %s: %s", channel_idx, message
                     )
-                    
+
+                    # Set flood scope before sending if requested, then always reset.
+                    if scope is not None:
+                        _LOGGER.debug("Setting flood scope to: %s", scope)
+                        scope_result = await api.mesh_core.commands.set_flood_scope(scope)
+                        if scope_result.type == EventType.ERROR:
+                            _LOGGER.warning(
+                                "Failed to set flood scope %s: %s", scope, scope_result.payload
+                            )
+
                     # Capture a fallback timestamp before sending.
                     # The actual device timestamp may differ from the HA server clock.
                     fallback_timestamp = int(time.time())
 
-                    # Send the channel message using the new API
-                    result = await api.mesh_core.commands.send_chan_msg(channel_idx, message, timestamp=fallback_timestamp)
+                    try:
+                        result = await api.mesh_core.commands.send_chan_msg(channel_idx, message, timestamp=fallback_timestamp)
+                    finally:
+                        if scope is not None:
+                            _LOGGER.debug("Resetting flood scope after send")
+                            await api.mesh_core.commands.set_flood_scope(None)
 
                     if result.type == EventType.ERROR:
                         _LOGGER.warning(
@@ -340,6 +356,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                             "channel_idx": channel_idx,
                             "send_timestamp": send_timestamp,
                             "send_id": uuid.uuid4().hex[:8],
+                            "scope": scope,
                         }
                         # Fire event for outgoing message to update message-related entities
                         hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -59,6 +59,16 @@ send_channel_message:
       example: "abc123def456"
       selector:
         text:
+    scope:
+      name: Flood Scope
+      description: >-
+        Optional region scope for the message. Use a hashtag region name (e.g. "pl-mz" or "#pl-mz")
+        to restrict the flood to that region. Leave empty to send with no scope (global flood).
+        The scope is applied only for this send and reset to no scope immediately after.
+      required: false
+      example: "pl-mz"
+      selector:
+        text:
 
 send_ui_message:
   name: Send UI Message

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -146,14 +146,16 @@
           "stale_contact_days": "Stale Contact Threshold (days)",
           "auto_cleanup_stale_neighbors": "Auto-Remove Stale Neighbors",
           "stale_neighbor_days": "Stale Neighbor Threshold (days)",
-          "adaptive_poll_wait": "Adaptive Channel Message Delivery"
+          "adaptive_poll_wait": "Adaptive Channel Message Delivery",
+          "flood_scopes": "Flood Scope Allowlist"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
           "stale_neighbor_days": "Number of days without hearing a neighbor before it is automatically removed (1–365).",
-          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
+          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event.",
+          "flood_scopes": "Comma-separated list of region scope names to match against incoming TC_FLOOD messages (e.g. pl-mz, pl-waw). When a match is found, rx_log_data will include a flood_scope field with the matched name. Leave empty to disable scope matching."
         },
         "description": "Configure global integration settings",
         "title": "Global Settings"
@@ -269,14 +271,16 @@
           "stale_contact_days": "Stale Contact Threshold (days)",
           "auto_cleanup_stale_neighbors": "Auto-Remove Stale Neighbors",
           "stale_neighbor_days": "Stale Neighbor Threshold (days)",
-          "adaptive_poll_wait": "Adaptive Channel Message Delivery"
+          "adaptive_poll_wait": "Adaptive Channel Message Delivery",
+          "flood_scopes": "Flood Scope Allowlist"
         },
         "data_description": {
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
           "stale_neighbor_days": "Number of days without hearing a neighbor before it is automatically removed (1–365).",
-          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event."
+          "adaptive_poll_wait": "When enabled, incoming channel messages fire as soon as RX_LOG data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively. Disable if bots or automations depend on having all paths in the initial event.",
+          "flood_scopes": "Comma-separated list of region scope names to match against incoming TC_FLOOD messages (e.g. pl-mz, pl-waw). When a match is found, rx_log_data will include a flood_scope field with the matched name. Leave empty to disable scope matching."
         },
         "description": "Configure global integration settings",
         "title": "Global Settings"

--- a/custom_components/meshcore/utils.py
+++ b/custom_components/meshcore/utils.py
@@ -234,9 +234,9 @@ def decrypt_channel_message(ciphertext: bytes, cipher_mac: bytes, channel_secret
         cipher = AES.new(channel_secret, AES.MODE_ECB)
         decrypted = cipher.decrypt(ciphertext)
 
-        # Parse structure: timestamp(4 bytes, little endian) + message text
+        # AES plaintext: timestamp(4 bytes LE) + flags(1 byte: attempt+txt_type) + message text
         timestamp = int.from_bytes(decrypted[0:4], byteorder="little")
-        message_text = decrypted[4:].decode("utf-8", errors="ignore").strip('\x00')
+        message_text = decrypted[5:].decode("utf-8", errors="ignore").strip('\x00')
 
         return timestamp, message_text
 
@@ -260,7 +260,92 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
     result = {}
 
     try:
-        # Extract hex string from payload
+        if not isinstance(payload, dict):
+            return result
+
+        # Fast path: use pre-parsed fields set by the SDK's MeshcorePacketParser.
+        # These are always correct for all route types, including TC_FLOOD (route_type 0)
+        # and TC_DIRECT (route_type 3) which carry a 4-byte transport code between the
+        # header and the path_byte — a detail the raw-parsing fallback previously missed,
+        # causing region-scope (TC_FLOOD) messages to never correlate with RX_LOG data.
+        if "payload_type" in payload:
+            payload_type = payload.get("payload_type")
+            path_len = payload.get("path_len", 0)
+            path_hash_size = payload.get("path_hash_size", 1)
+            path = payload.get("path", "")
+
+            header_raw = payload.get("header")
+            if isinstance(header_raw, int):
+                result["header"] = f"{header_raw:02x}"
+            elif isinstance(header_raw, str):
+                result["header"] = header_raw
+
+            result["path_len"] = path_len
+            result["path_hash_size"] = path_hash_size
+            result["payload_type"] = payload_type
+            if path:
+                result["path"] = path
+
+            if payload_type != 5:  # 5 = GRP_TXT (GroupText channel message)
+                return result
+
+            chan_hash_hex = payload.get("chan_hash", "")
+            cipher_mac_hex = payload.get("cipher_mac", "")
+            crypted_hex = payload.get("crypted", "")
+
+            if chan_hash_hex:
+                result["channel_hash"] = chan_hash_hex
+
+            if not (chan_hash_hex and cipher_mac_hex and crypted_hex):
+                return result
+
+            try:
+                chan_hash_byte = int(chan_hash_hex, 16)
+            except ValueError:
+                return result
+
+            for channel_idx, channel_info in channels_info.items():
+                channel_secret = channel_info.get("channel_secret")
+                if not channel_secret:
+                    continue
+
+                if isinstance(channel_secret, str):
+                    channel_secret = bytes.fromhex(channel_secret)
+
+                expected_hash_byte = hashlib.sha256(channel_secret).digest()[0]
+
+                if expected_hash_byte == chan_hash_byte:
+                    try:
+                        ciphertext = bytes.fromhex(crypted_hex)
+                        cipher_mac = bytes.fromhex(cipher_mac_hex)
+                    except ValueError:
+                        continue
+
+                    timestamp, message_text = decrypt_channel_message(ciphertext, cipher_mac, channel_secret)
+
+                    if timestamp is not None and message_text is not None:
+                        result = {
+                            "channel_idx": channel_idx,
+                            "channel_name": channel_info.get("channel_name", f"Channel {channel_idx}"),
+                            "timestamp": timestamp,
+                            "text": message_text,
+                            "decrypted": True,
+                            "path_len": path_len,
+                            "path": path,
+                            "channel_hash": chan_hash_hex,
+                            "path_hash_size": path_hash_size,
+                        }
+                        _LOGGER.debug(
+                            "Decrypted RX_LOG via SDK fields for channel %d: %s",
+                            channel_idx, message_text[:50],
+                        )
+                        break
+
+            return result
+
+        # Fallback: parse from raw payload bytes when SDK pre-parsed fields are absent.
+        # TC_FLOOD (route_type 0) and TC_DIRECT (route_type 3) carry a 4-byte transport
+        # code between the header byte and the path_byte; skip it before reading path info.
         hex_str = None
         if isinstance(payload, dict):
             hex_str = payload.get("payload") or payload.get("raw_hex")
@@ -270,7 +355,9 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         if not hex_str:
             return result
 
-        # Convert to bytes
+        if isinstance(hex_str, bytes):
+            hex_str = hex_str.hex()
+
         if isinstance(hex_str, str):
             packet_bytes = bytes.fromhex(hex_str.replace(" ", "").replace("\n", ""))
         else:
@@ -279,40 +366,43 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         if len(packet_bytes) < 2:
             return result
 
-        # Parse header and path using the same layout as meshcore_py:
-        # - byte 0: header
-        # - byte 1: path byte
-        #   - high 2 bits: path hash size mode => 1..4 bytes per hop
-        #   - low 6 bits: hop count
         header = packet_bytes[0]
-        path_byte = packet_bytes[1]
-
-        # Extract payload type from header (bits 2-5)
+        route_type = header & 0x03
         payload_type = (header >> 2) & 0x0F
 
+        result["header"] = f"{header:02x}"
+        result["payload_type"] = payload_type
+
+        # TC_FLOOD (0) and TC_DIRECT (3) have a 4-byte transport code before the path byte.
+        transport_code_size = 4 if route_type in (0, 3) else 0
+        path_byte_offset = 1 + transport_code_size
+
+        if len(packet_bytes) <= path_byte_offset:
+            return result
+
+        path_byte = packet_bytes[path_byte_offset]
         path_hash_size = ((path_byte & 0xC0) >> 6) + 1
         hop_count = path_byte & 0x3F
 
-        result["header"] = f"{header:02x}"
         result["path_len"] = hop_count
         result["path_hash_size"] = path_hash_size
-        result["payload_type"] = payload_type
 
-        # Check if this is GroupText (0x05)
         if payload_type != 0x05:
-            _LOGGER.debug(f"RX_LOG payload type {payload_type:02x} is not GroupText, skipping decryption")
+            _LOGGER.debug(
+                "RX_LOG payload type %02x is not GroupText, skipping decryption",
+                payload_type,
+            )
             return result
 
-        # Validate packet length and compute path end index
-        path_end = 2 + hop_count * path_hash_size
+        path_start = path_byte_offset + 1
+        path_end = path_start + hop_count * path_hash_size
+
         if len(packet_bytes) < path_end + 3:  # Need at least channel_hash + 2-byte MAC
             return result
 
-        # Extract path data (bytes) and hex string
-        path_data = packet_bytes[2:path_end]
+        path_data = packet_bytes[path_start:path_end]
         result["path"] = path_data.hex()
 
-        # Parse GroupText payload
         group_payload = packet_bytes[path_end:]
         channel_hash_byte = group_payload[0]
         result["channel_hash"] = f"{channel_hash_byte:02x}"
@@ -323,24 +413,20 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
         cipher_mac = group_payload[1:3]
         ciphertext = group_payload[3:]
 
-        # Try to match channel hash and decrypt
         for channel_idx, channel_info in channels_info.items():
             channel_secret = channel_info.get("channel_secret")
             if not channel_secret:
                 continue
 
-            # Calculate channel hash (first byte of SHA256)
             if isinstance(channel_secret, str):
                 channel_secret = bytes.fromhex(channel_secret)
 
             expected_hash_byte = hashlib.sha256(channel_secret).digest()[0]
 
             if expected_hash_byte == channel_hash_byte:
-                # Found matching channel, try to decrypt
                 timestamp, message_text = decrypt_channel_message(ciphertext, cipher_mac, channel_secret)
 
                 if timestamp is not None and message_text is not None:
-                    # Keep essential parsed fields, add decryption-specific fields
                     result = {
                         "channel_idx": channel_idx,
                         "channel_name": channel_info.get("channel_name", f"Channel {channel_idx}"),
@@ -352,12 +438,14 @@ def parse_and_decrypt_rx_log(payload: Any, channels_info: dict[int, dict]) -> di
                         "channel_hash": f"{channel_hash_byte:02x}",
                         "path_hash_size": path_hash_size,
                     }
-
-                    _LOGGER.debug(f"Successfully decrypted RX_LOG for channel {channel_idx}: {message_text[:50]}")
+                    _LOGGER.debug(
+                        "Decrypted RX_LOG via raw parse for channel %d: %s",
+                        channel_idx, message_text[:50],
+                    )
                     break
 
     except Exception as ex:
-        _LOGGER.debug(f"Error parsing/decrypting RX_LOG: {ex}")
+        _LOGGER.debug("Error parsing/decrypting RX_LOG: %s", ex)
 
     return result
 
@@ -386,62 +474,144 @@ def create_message_correlation_key(channel_idx: int, timestamp: int) -> str:
     return hash_key
 
 
+def _normalize_flood_scope_name(name: str) -> str:
+    """Prepend '#' to a region name if not already present."""
+    name = name.strip()
+    if name and not name.startswith("#"):
+        return "#" + name
+    return name
+
+
+def load_flood_scope_keys(scopes_str: str) -> dict[str, bytes]:
+    """Parse a comma-separated flood_scopes string into a name→16-byte-key dict.
+
+    Key derivation mirrors the firmware's auto-key for #hashtag regions:
+    SHA256(scope_name_bytes)[:16].  Names are normalized to have a '#' prefix.
+    """
+    result: dict[str, bytes] = {}
+    if not scopes_str:
+        return result
+    for entry in scopes_str.split(","):
+        name = _normalize_flood_scope_name(entry)
+        if name and name not in ("*", "#"):
+            result[name] = hashlib.sha256(name.encode()).digest()[:16]
+    return result
+
+
+def match_flood_scope(
+    transport_code: int,
+    payload_type: int,
+    pkt_payload: bytes,
+    scope_keys: dict[str, bytes],
+) -> str | None:
+    """Return the scope name whose HMAC matches transport_code, or None.
+
+    Mirrors TransportKey::calcTransportCode from the firmware:
+    HMAC-SHA256(scope_key, [payload_type_byte] + pkt_payload)[0:2] as uint16 LE.
+    """
+    if not scope_keys or not pkt_payload:
+        return None
+    check_data = bytes([payload_type]) + pkt_payload
+    for name, key in scope_keys.items():
+        digest = hmac.new(key, check_data, hashlib.sha256).digest()
+        computed = int.from_bytes(digest[:2], "little")
+        if computed == 0:
+            computed = 1
+        elif computed == 0xFFFF:
+            computed = 0xFFFE
+        if computed == transport_code:
+            return name
+    return None
+
+
 def parse_rx_log_data(payload: Any) -> dict[str, Any]:
     """Parse RX_LOG event payload to extract LoRa packet details.
 
-    RX_LOG_DATA events contain raw LoRa payload with header, path, and channel hash.
-    Format:
-    - Bytes 0-1: Header/identifier
-    - Bytes 2-3: Hop count (path_len)
-    - Bytes 4+: Path data (2 hex chars per node)
-    - After path: Channel hash
-
     Args:
-        payload: Raw event payload (dict with 'payload' or 'raw_hex', or direct hex string)
+        payload: Raw event payload (dict with SDK pre-parsed fields, or 'payload'/'raw_hex',
+                 or direct hex string)
 
     Returns:
-        Dict with parsed fields: header, path_len, path, channel_hash
-        Returns empty dict on parsing errors (fault tolerant)
+        Dict with parsed fields: header, path_len, path_hash_size, path, path_nodes,
+        channel_hash. Returns empty dict on parsing errors (fault tolerant).
     """
     result = {}
 
     try:
-        # Extract hex string from payload
-        hex_str = None
-
         if isinstance(payload, dict):
-            # Try payload.payload first, then raw_hex
+            # Fast path: use pre-parsed fields set by the SDK's MeshcorePacketParser.
+            # These are always correct for all route types including TC_FLOOD (route_type 0)
+            # and TC_DIRECT (route_type 3) which carry a 4-byte transport code that the
+            # raw-parsing fallback previously handled incorrectly.
+            if "payload_type" in payload:
+                path_len = payload.get("path_len", 0)
+                path_hash_size = payload.get("path_hash_size", 1)
+                path_hex = payload.get("path", "")
+                chan_hash = payload.get("chan_hash")
+
+                header_raw = payload.get("header")
+                if isinstance(header_raw, int):
+                    result["header"] = f"{header_raw:02x}"
+                elif isinstance(header_raw, str):
+                    result["header"] = header_raw
+
+                result["path_len"] = path_len
+                result["path_hash_size"] = path_hash_size
+
+                if path_hex:
+                    result["path"] = path_hex
+                    step = path_hash_size * 2
+                    result["path_nodes"] = [
+                        path_hex[i:i + step]
+                        for i in range(0, len(path_hex), step)
+                        if path_hex[i:i + step]
+                    ]
+
+                if chan_hash:
+                    result["channel_hash"] = chan_hash
+
+                return result
+
+            # Fallback: extract raw hex and parse manually.
             hex_str = payload.get("payload") or payload.get("raw_hex")
         elif isinstance(payload, (str, bytes)):
-            # Direct string or bytes
             hex_str = payload
+        else:
+            return result
 
         if not hex_str:
             _LOGGER.debug("No hex data found in RX_LOG payload")
             return result
 
-        # Convert bytes to hex string if needed
         if isinstance(hex_str, bytes):
             hex_str = hex_str.hex()
 
-        # Normalize: lowercase, remove spaces and newlines
         hex_str = str(hex_str).lower().replace(" ", "").replace("\n", "").replace("\r", "")
 
-        # Validate minimum length (at least header + path_len)
         if len(hex_str) < 4:
-            _LOGGER.debug(f"RX_LOG hex too short: {len(hex_str)} chars")
+            _LOGGER.debug("RX_LOG hex too short: %d chars", len(hex_str))
             return result
 
-        # Parse header (bytes 0-1)
         result["header"] = hex_str[0:2]
 
-        # Parse path byte using the same bit layout as meshcore_py:
-        # high 2 bits = path hash size mode (1..4 bytes per hop)
-        # low 6 bits = hop count
+        header = int(hex_str[0:2], 16)
+        route_type = header & 0x03
+
+        # TC_FLOOD (0) and TC_DIRECT (3) have a 4-byte transport code before the path byte;
+        # skip it (8 hex chars) before reading path info.
+        transport_nibbles = 8 if route_type in (0, 3) else 0
+        path_byte_start = 2 + transport_nibbles
+
+        if len(hex_str) < path_byte_start + 2:
+            return result
+
         try:
-            path_byte = int(hex_str[2:4], 16)
+            path_byte = int(hex_str[path_byte_start:path_byte_start + 2], 16)
         except ValueError:
-            _LOGGER.debug(f"Could not parse path byte from: {hex_str[2:4]}")
+            _LOGGER.debug(
+                "Could not parse path byte from: %s",
+                hex_str[path_byte_start:path_byte_start + 2],
+            )
             return result
 
         path_hash_size = ((path_byte & 0xC0) >> 6) + 1
@@ -449,9 +619,9 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         result["path_len"] = hop_count
         result["path_hash_size"] = path_hash_size
 
-        # Path hex starts at nibble index 4.
-        path_start = 4
-        path_end = path_start + (hop_count * path_hash_size * 2)
+        path_start = path_byte_start + 2
+        path_end = path_start + hop_count * path_hash_size * 2
+
         if len(hex_str) < path_end:
             _LOGGER.debug(
                 "RX_LOG hex too short for path data: expected at least %d, got %d",
@@ -463,25 +633,22 @@ def parse_rx_log_data(payload: Any) -> dict[str, Any]:
         path_hex = hex_str[path_start:path_end]
         result["path"] = path_hex
 
-        # Parse individual nodes in path (2, 4, 6, or 8 chars each depending on path_hash_size)
-        path_nodes = []
         step = path_hash_size * 2
-        for i in range(0, len(path_hex), step):
-            node_hex = path_hex[i:i+step]
-            path_nodes.append(node_hex)
-        result["path_nodes"] = path_nodes
+        result["path_nodes"] = [path_hex[i:i + step] for i in range(0, len(path_hex), step)]
 
-        # Extract channel hash if available
-        if len(hex_str) > path_end:
-            # Channel hash is the next 2 characters after path
-            if len(hex_str) >= path_end + 2:
-                result["channel_hash"] = hex_str[path_end:path_end+2]
+        if len(hex_str) >= path_end + 2:
+            result["channel_hash"] = hex_str[path_end:path_end + 2]
 
-        _LOGGER.debug(f"Parsed RX_LOG: header={result.get('header')}, path_len={result.get('path_len')}, "
-                     f"path={result.get('path')}, channel_hash={result.get('channel_hash')}")
+        _LOGGER.debug(
+            "Parsed RX_LOG: header=%s, path_len=%d, path=%s, channel_hash=%s",
+            result.get("header"),
+            result.get("path_len"),
+            result.get("path"),
+            result.get("channel_hash"),
+        )
 
     except Exception as ex:
-        _LOGGER.debug(f"Error parsing RX_LOG data: {ex}")
+        _LOGGER.debug("Error parsing RX_LOG data: %s", ex)
 
     return result
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -31,8 +31,6 @@ Fired when any message is received. Ideal for notifications and message logging.
 - `timestamp` - When received
 - `message_type` - "channel"
 - `pubkey_prefix` - Sender's public key prefix
-- `hop_count` - Number of repeater hops the packet traversed. `0` indicates direct reception (firmware returns the `0xFF` sentinel, which is normalised to `0`); positive values are the literal hop count from the SDK `path_len` byte.
-- `snr` - (Optional) Signal-to-noise ratio in dB for this packet. Present on V3 `CHANNEL_MSG_RECV` frames (carried directly in the SDK payload as `SNR`). On V2 frames the field is only populated when channel decryption is enabled and the SDK matched a `log_channels` entry, so absence is normal.
 - `rx_log_data` - (Optional) Array of radio reception details when message was received via multiple mesh paths:
   - `channel_idx` - Channel number
   - `channel_name` - Channel name
@@ -43,7 +41,10 @@ Fired when any message is received. Ideal for notifications and message logging.
   - `path_len` - Number of hops
   - `path` - Hex-encoded path (node pubkey prefixes)
   - `channel_hash` - Channel identifier hash
-  - `decrypted` - Whether decryption succeeded
+  - `route_type` - Raw route type integer (0 = TC_FLOOD, 3 = TC_DIRECT)
+  - `route_typename` - Human-readable route type string (e.g. `"TC_FLOOD"`)
+  - `region_scope` - `true` if the message was received via a region-scoped flood (TC_FLOOD)
+  - `flood_scope` - Matched scope name if `region_scope` is `true` and a scope is configured, otherwise `null`
 
 **Direct Message Fields:**
 - `message` - Message text
@@ -81,6 +82,9 @@ Fired when a message is successfully sent via integration services.
 - `receiver` - Channel identifier (e.g., "channel_1")
 - `timestamp` - Unix timestamp
 - `channel_idx` - Channel number
+- `send_timestamp` - Device-reported send timestamp (or HA server clock fallback)
+- `send_id` - 8-character hex identifier for correlating delivery updates
+- `scope` - Flood scope used for this send, or `null` if none was specified
 
 **Direct Message Fields:**
 - `message` - Message text sent
@@ -201,7 +205,10 @@ data:
       path_len: 0
       path: ""
       channel_hash: "11"
-      decrypted: true
+      route_type: 0
+      route_typename: "TC_FLOOD"
+      region_scope: true
+      flood_scope: "pl-mz"
     - channel_idx: 0
       channel_name: "public"
       timestamp: 1762838456
@@ -211,7 +218,10 @@ data:
       path_len: 1
       path: "cf"
       channel_hash: "11"
-      decrypted: true
+      route_type: 3
+      route_typename: "TC_DIRECT"
+      region_scope: false
+      flood_scope: null
   repeater_count: 2
   progressive: false
 ```
@@ -252,6 +262,8 @@ Every raw event contains:
 - `rssi` - Received signal strength indicator
 - `payload` - Packet payload hex string
 - `payload_length` - Length of payload
+- `route_type` - Route type integer (0 = TC_FLOOD, 3 = TC_DIRECT)
+- `route_typename` - Human-readable route type string
 - `parsed` - Parsed packet structure:
   - `header` - Packet header byte
   - `path_len` - Number of hops
@@ -458,7 +470,10 @@ data:
       path_len: 0
       path: ""
       channel_hash: "11"
-      decrypted: true
+      route_type: 0
+      route_typename: "TC_FLOOD"
+      region_scope: true
+      flood_scope: "pl-mz"
     - channel_idx: 0
       channel_name: "public"
       timestamp: 1762838456
@@ -468,7 +483,10 @@ data:
       path_len: 1
       path: "cf"
       channel_hash: "11"
-      decrypted: true
+      route_type: 3
+      route_typename: "TC_DIRECT"
+      region_scope: false
+      flood_scope: null
 ```
 
 #### Received Direct Message

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -31,6 +31,8 @@ Fired when any message is received. Ideal for notifications and message logging.
 - `timestamp` - When received
 - `message_type` - "channel"
 - `pubkey_prefix` - Sender's public key prefix
+- `hop_count` - Number of repeater hops the packet traversed. `0` indicates direct reception (firmware returns the `0xFF` sentinel, which is normalised to `0`); positive values are the literal hop count from the SDK `path_len` byte.
+- `snr` - (Optional) Signal-to-noise ratio in dB for this packet. Present on V3 `CHANNEL_MSG_RECV` frames (carried directly in the SDK payload as `SNR`). On V2 frames the field is only populated when channel decryption is enabled and the SDK matched a `log_channels` entry, so absence is normal.
 - `rx_log_data` - (Optional) Array of radio reception details when message was received via multiple mesh paths:
   - `channel_idx` - Channel number
   - `channel_name` - Channel name
@@ -42,6 +44,7 @@ Fired when any message is received. Ideal for notifications and message logging.
   - `path` - Hex-encoded path (node pubkey prefixes)
   - `path_hash_size` - Per-hop hash width in bytes (1–3). The `path` field concatenates each hop's hash at this width, so consumers must split `path` on this width rather than assuming one byte per hop.
   - `channel_hash` - Channel identifier hash
+  - `decrypted` - Whether decryption succeeded
   - `route_type` - Raw route type integer (0 = TC_FLOOD, 3 = TC_DIRECT)
   - `route_typename` - Human-readable route type string (e.g. `"TC_FLOOD"`)
   - `region_scope` - `true` if the message was received via a region-scoped flood (TC_FLOOD)

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -55,15 +55,30 @@ Broadcast a message to all nodes on a specific channel.
 | `channel_idx` | integer | Yes | Channel index (0-255, typically 0-3) |
 | `message` | string | Yes | The message text to broadcast |
 | `entry_id` | string | No | Config entry ID for multiple devices |
+| `scope` | string | No | Region scope for flood routing (e.g. `"pl-waw"` or `"#pl-waw"`) |
 
-**Example:**
+**Examples:**
 
+Global broadcast (no scope):
 ```yaml
 service: meshcore.send_channel_message
 data:
   channel_idx: 0
   message: "General announcement to all nodes"
 ```
+
+Region-scoped broadcast:
+```yaml
+service: meshcore.send_channel_message
+data:
+  channel_idx: 0
+  message: "Hello Warsaw region!"
+  scope: "waw"
+```
+
+:::info
+When `scope` is provided the integration calls `set_flood_scope` on the device before sending, then immediately resets it to no scope — even if the send fails. The `scope` used is included in the resulting `meshcore_message_sent` event.
+:::
 
 ### Execute Command
 Execute Meshcore SDK commands directly for advanced control.
@@ -199,6 +214,21 @@ action:
   - service: meshcore.execute_command
     data:
       command: "set_tx_power 20"
+```
+
+### Region-Scoped Alert
+```yaml
+alias: Warsaw Region Alert
+trigger:
+  - platform: state
+    entity_id: input_boolean.warsaw_alert
+    to: "on"
+action:
+  - service: meshcore.send_channel_message
+    data:
+      channel_idx: 0
+      message: "Local alert for Warsaw region"
+      scope: "waw"
 ```
 
 ### Periodic Status Request


### PR DESCRIPTION
## Summary

Adds an optional `scope` parameter to the `meshcore.send_channel_message` service, enabling region-scoped TC_FLOOD broadcasts.

## Changes

The service now accepts a `scope` string:

  ```yaml
  service: meshcore.send_channel_message
  data:
    channel_idx: 0
    message: "Hello Warsaw region!"
    scope: "waw"          # also accepts "#waw" — normalised automatically by the SDK
```

- Calls set_flood_scope on the device before sending, then always resets it to no scope via finally — even if the send fails.
- The scope value is included in the resulting meshcore_message_sent event, so automations can inspect which scope was used.
- Omitting scope (or passing null) sends a normal global flood — fully backwards compatible.

### Incoming scope decode flow

Received TC_FLOOD packets (`route_type == 0`) are matched against the configured allowlist. Each rx_log_data entry gains a flood_scope field with the matched name (e.g. "#waw") or null.

Matching replicates the firmware's `TransportKey::calcTransportCode`:
1. Derive a 16-byte key per allowlist entry: `SHA256("#name")[:16]`
2. Compute `HMAC-SHA256(key, [payload_type_byte] + pkt_payload)[:2]` as uint16 LE
3. Apply firmware edge-case clamping: `0 → 1, 0xFFFF → 0xFFFE`
4. Compare against the packet's transport code — first match wins

## Documentation

  - services.md — new parameter table entry, global vs. scoped usage examples, note about the set/reset lifecycle.
  - events.md — scope, send_timestamp, and send_id fields documented for meshcore_message_sent.
  - services.yaml — UI field with description and example added to the service form.
  - translations/en.json — label and description for the new flood scope allowlist option in integration settings.

## Breaking changes

None. scope is optional; all existing automations continue to work unchanged.