### PR TITLE
feat: optional self-diagnostic sensors for the companion node

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ When enabled (off by default), the integration automatically uploads repeater an
 - Requires private key export on firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`)
 - Replay protection and signature verification built-in
 
+## Self Diagnostics
+
+When enabled (off by default), the integration polls the locally-attached companion node's own statistics and exposes them as sensor entities — giving the companion the same rich diagnostic tiles a managed repeater has. Enable it in the integration's **Global Settings** (or during initial setup).
+
+- **No mesh traffic.** The polls are local queries to the attached radio (`get_stats_core` / `get_stats_radio` / `get_stats_packets`) — they add no LoRa-mesh traffic and consume no airtime or duty-cycle.
+- **Off by default.** No new entities are created until you opt in, so existing installs are unaffected.
+- **Poll interval.** Configurable from 60 to 3600 seconds (default 300 s / 5 minutes).
+- **Entities created (~14 sensors).** Core: uptime, TX queue length. Radio: noise floor, last RSSI, last SNR, TX airtime, RX airtime. Packets: received, sent, flood/direct TX, flood/direct RX, receive errors. Battery is not duplicated — the companion already exposes battery voltage and percentage.
+- **Radio fault flags (3 `problem` binary sensors).** The radio's `errors` field is a bitmask of dispatcher fault events, not a count, so it is decoded into three diagnostic binary sensors with `device_class: problem`:
+  - **Packet Pool Exhausted** — the packet buffer pool ran out and a packet was dropped.
+  - **CAD Timeout** — Channel Activity Detection stayed busy too long (channel congested, or the radio may be wedged).
+  - **RX-Start Timeout** — the radio failed to (re)enter receive mode (possible radio hang).
+
+  Each flag **latches**: the firmware sets it on the first occurrence and clears it only when the radio reboots, so `on` means "this fault has happened at least once since the radio last booted," not "is happening now."
+
 ## Development
 
 ### Local Development Setup

--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -21,12 +21,16 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     CONF_DISABLE_CONTACT_DISCOVERY,
+    CONF_SELF_DIAGNOSTICS_ENABLED,
     DOMAIN,
     ENTITY_DOMAIN_BINARY_SENSOR,
     MESSAGES_SUFFIX,
     CHANNEL_PREFIX,
     CONTACT_SUFFIX,
     ONLINE_SUFFIX,
+    SELF_DIAG_ERR_CAD_TIMEOUT,
+    SELF_DIAG_ERR_POOL_FULL,
+    SELF_DIAG_ERR_RX_TIMEOUT,
     NodeType,
 )
 from .utils import (
@@ -283,6 +287,17 @@ async def async_setup_entry(
             )
     if online_entities:
         async_add_entities(online_entities)
+
+    # Self-diagnostic fault flags (companion main device) — created only when
+    # opted in (default off). The STATS_CORE `errors` field is a latching
+    # bitmask of radio dispatcher faults; each bit is decoded into its own
+    # `problem` binary sensor.
+    if entry.data.get(CONF_SELF_DIAGNOSTICS_ENABLED, False):
+        async_add_entities([
+            MeshCoreSelfDiagnosticBinarySensor(coordinator, "err_pool_full", SELF_DIAG_ERR_POOL_FULL),
+            MeshCoreSelfDiagnosticBinarySensor(coordinator, "err_cad_timeout", SELF_DIAG_ERR_CAD_TIMEOUT),
+            MeshCoreSelfDiagnosticBinarySensor(coordinator, "err_rx_timeout", SELF_DIAG_ERR_RX_TIMEOUT),
+        ])
 
     # Subscribe to our internal message sent event for outgoing messages
     @callback
@@ -780,3 +795,62 @@ class MeshCoreDeviceOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
         attrs["update_interval"] = update_interval
         attrs["staleness_window"] = max(update_interval, 300) * 2.5
         return attrs
+
+
+class MeshCoreSelfDiagnosticBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """A single decoded radio fault flag from the companion's STATS_CORE
+    ``errors`` bitmask.
+
+    The firmware OR-accumulates each fault bit and clears it only on a radio
+    reboot (or an internal stats reset the integration never triggers), so
+    ``on`` means "this fault has occurred at least once since the radio last
+    booted" rather than "is occurring right now". Created only when Self
+    Diagnostics is enabled (default off).
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        key: str,
+        bit_mask: int,
+    ) -> None:
+        """Initialize the fault-flag binary sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._bit_mask = bit_mask
+        self._attr_translation_key = key
+        self._attr_is_on = None  # unknown until the first STATS_CORE event
+
+        raw_device_name = coordinator.name or "Unknown"
+        public_key_short = coordinator.pubkey[:6] if coordinator.pubkey else ""
+
+        parts = [p for p in [coordinator.config_entry.entry_id, key, public_key_short] if p]
+        self._attr_unique_id = "_".join(parts)
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_BINARY_SENSOR,
+            public_key_short,
+            key,
+            sanitize_name(raw_device_name),
+        )
+
+    @property
+    def device_info(self):
+        """Attach to the companion main device."""
+        return DeviceInfo(**self.coordinator.device_info)
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to STATS_CORE and decode this sensor's fault bit."""
+        await super().async_added_to_hass()
+        meshcore = self.coordinator.api.mesh_core
+
+        def update_flag(event) -> None:
+            errors = event.payload.get("errors")
+            if isinstance(errors, int):
+                self._attr_is_on = bool(errors & self._bit_mask)
+                self.async_write_ha_state()
+
+        meshcore.dispatcher.subscribe(EventType.STATS_CORE, update_flag)

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -51,6 +51,9 @@ from .const import (
     CONF_SELF_TELEMETRY_ENABLED,
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
+    CONF_SELF_DIAGNOSTICS_ENABLED,
+    CONF_SELF_DIAGNOSTICS_INTERVAL,
+    DEFAULT_SELF_DIAGNOSTICS_INTERVAL,
     CONF_MAP_UPLOAD_ENABLED,
     CONF_AUTO_CLEANUP_STALE_CONTACTS,
     CONF_STALE_CONTACT_DAYS,
@@ -356,6 +359,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_BAUDRATE: user_input[CONF_BAUDRATE],
                     CONF_SELF_TELEMETRY_ENABLED: user_input.get(CONF_SELF_TELEMETRY_ENABLED, False),
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
+                    CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
+                    CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -377,6 +382,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): cv.positive_int,
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
+                vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
             }),
             errors=errors
         )
@@ -393,6 +400,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_BLE_ADDRESS: user_input[CONF_BLE_ADDRESS],
                     CONF_SELF_TELEMETRY_ENABLED: user_input.get(CONF_SELF_TELEMETRY_ENABLED, False),
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
+                    CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
+                    CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -423,6 +432,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     vol.Required(CONF_BLE_ADDRESS): vol.In(devices),
                     vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=False): cv.boolean,
                     vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                    vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
+                    vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 }
             )
         else:
@@ -431,6 +442,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Required(CONF_BLE_ADDRESS): str,
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
+                vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
             })
 
         return self.async_show_form(
@@ -450,6 +463,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_TCP_PORT: user_input[CONF_TCP_PORT],
                     CONF_SELF_TELEMETRY_ENABLED: user_input.get(CONF_SELF_TELEMETRY_ENABLED, False),
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
+                    CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
+                    CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -469,6 +484,8 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Optional(CONF_TCP_PORT, default=DEFAULT_TCP_PORT): cv.port,
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
+                vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
             }),
             errors=errors
         )
@@ -892,6 +909,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             new_data[CONF_MAX_DISCOVERED_CONTACTS] = user_input[CONF_MAX_DISCOVERED_CONTACTS]
             new_data[CONF_SELF_TELEMETRY_ENABLED] = user_input[CONF_SELF_TELEMETRY_ENABLED]
             new_data[CONF_SELF_TELEMETRY_INTERVAL] = user_input[CONF_SELF_TELEMETRY_INTERVAL]
+            new_data[CONF_SELF_DIAGNOSTICS_ENABLED] = user_input[CONF_SELF_DIAGNOSTICS_ENABLED]
+            new_data[CONF_SELF_DIAGNOSTICS_INTERVAL] = user_input[CONF_SELF_DIAGNOSTICS_INTERVAL]
             new_data[CONF_MAP_UPLOAD_ENABLED] = user_input[CONF_MAP_UPLOAD_ENABLED]
             new_data[CONF_AUTO_CLEANUP_STALE_CONTACTS] = user_input[CONF_AUTO_CLEANUP_STALE_CONTACTS]
             new_data[CONF_STALE_CONTACT_DAYS] = user_input[CONF_STALE_CONTACT_DAYS]
@@ -914,6 +933,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_max_contacts = self.config_entry.data.get(CONF_MAX_DISCOVERED_CONTACTS, DEFAULT_MAX_DISCOVERED_CONTACTS)
         current_telemetry_enabled = self.config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         current_telemetry_interval = self.config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
+        current_diagnostics_enabled = self.config_entry.data.get(CONF_SELF_DIAGNOSTICS_ENABLED, False)
+        current_diagnostics_interval = self.config_entry.data.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL)
         current_map_upload_enabled = self.config_entry.data.get(CONF_MAP_UPLOAD_ENABLED, False)
         current_auto_cleanup = self.config_entry.data.get(CONF_AUTO_CLEANUP_STALE_CONTACTS, False)
         current_stale_days = self.config_entry.data.get(CONF_STALE_CONTACT_DAYS, DEFAULT_STALE_CONTACT_DAYS)
@@ -929,6 +950,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_MAX_DISCOVERED_CONTACTS, default=current_max_contacts): vol.All(cv.positive_int, vol.Range(min=1, max=10000)),
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=current_telemetry_enabled): cv.boolean,
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=current_telemetry_interval): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=current_diagnostics_enabled): cv.boolean,
+                vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=current_diagnostics_interval): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_MAP_UPLOAD_ENABLED, default=current_map_upload_enabled): cv.boolean,
                 vol.Optional(CONF_AUTO_CLEANUP_STALE_CONTACTS, default=current_auto_cleanup): cv.boolean,
                 vol.Optional(CONF_STALE_CONTACT_DAYS, default=current_stale_days): vol.All(cv.positive_int, vol.Range(min=1, max=365)),

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -97,6 +97,19 @@ CONF_SELF_TELEMETRY_ENABLED: Final = "self_telemetry_enabled"
 CONF_SELF_TELEMETRY_INTERVAL: Final = "self_telemetry_interval"
 DEFAULT_SELF_TELEMETRY_INTERVAL: Final = 300  # 5 minutes in seconds
 
+# Self diagnostics settings (local get_stats_core/radio/packets polling — no mesh traffic)
+CONF_SELF_DIAGNOSTICS_ENABLED: Final = "self_diagnostics_enabled"
+CONF_SELF_DIAGNOSTICS_INTERVAL: Final = "self_diagnostics_interval"
+DEFAULT_SELF_DIAGNOSTICS_INTERVAL: Final = 300  # 5 minutes in seconds
+
+# STATS_CORE `errors` is a bitmask of radio dispatcher fault events, not a
+# count. Each bit latches on first occurrence and clears only on a radio
+# reboot. Bit values mirror the firmware (_err_flags in MeshCore Dispatcher.h);
+# they are decoded into individual diagnostic `problem` binary sensors.
+SELF_DIAG_ERR_POOL_FULL: Final = 1 << 0       # packet pool exhausted (allocation failed)
+SELF_DIAG_ERR_CAD_TIMEOUT: Final = 1 << 1     # channel-activity-detection stayed busy too long
+SELF_DIAG_ERR_RX_TIMEOUT: Final = 1 << 2      # radio failed to (re)enter receive mode
+
 # Map Auto Uploader settings
 CONF_MAP_UPLOAD_ENABLED: Final = "map_upload_enabled"
 

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -40,6 +40,9 @@ from .const import (
     CONF_SELF_TELEMETRY_ENABLED,
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
+    CONF_SELF_DIAGNOSTICS_ENABLED,
+    CONF_SELF_DIAGNOSTICS_INTERVAL,
+    DEFAULT_SELF_DIAGNOSTICS_INTERVAL,
     CONF_AUTO_CLEANUP_STALE_CONTACTS,
     CONF_STALE_CONTACT_DAYS,
     DEFAULT_STALE_CONTACT_DAYS,
@@ -156,6 +159,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_self_telemetry_update = 0
         self._self_telemetry_enabled = config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         self._self_telemetry_interval = config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
+
+        # Self diagnostics tracking (local get_stats_core/radio/packets — no mesh traffic)
+        self._last_self_diagnostics_update = 0
+        self._self_diagnostics_enabled = config_entry.data.get(CONF_SELF_DIAGNOSTICS_ENABLED, False)
+        self._self_diagnostics_interval = config_entry.data.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL)
 
         # Auto-cleanup of stale discovered contacts (daily)
         self._auto_cleanup_stale_contacts = config_entry.data.get(
@@ -556,6 +564,8 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         """Update telemetry settings from config entry."""
         self._self_telemetry_enabled = config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         self._self_telemetry_interval = config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
+        self._self_diagnostics_enabled = config_entry.data.get(CONF_SELF_DIAGNOSTICS_ENABLED, False)
+        self._self_diagnostics_interval = config_entry.data.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL)
         self._tracked_repeaters = config_entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, [])
         self._tracked_clients = config_entry.data.get(CONF_TRACKED_CLIENTS, [])
         self._auto_cleanup_stale_contacts = config_entry.data.get(
@@ -1334,7 +1344,26 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                     self.logger.error(f"Exception getting self telemetry: {ex}")
             else:
                 self.logger.debug(f"Skipping self telemetry (next in {self._self_telemetry_interval - (current_time - self._last_self_telemetry_update):.1f}s)")
-            
+
+        # Check for self diagnostics updates if enabled.
+        # These are LOCAL-transport queries to the attached radio (a 2-byte
+        # GET_STATS opcode frame, no destination contact) — they add no mesh
+        # traffic and consume no airtime/duty-cycle. The SDK dispatches
+        # STATS_CORE/RADIO/PACKETS events that the diagnostic sensor entities
+        # subscribe to, so no return-value handling is needed here.
+        if self._self_diagnostics_enabled:
+            if current_time - self._last_self_diagnostics_update >= self._self_diagnostics_interval:
+                self.logger.debug(f"Getting self diagnostics (interval: {self._self_diagnostics_interval}s)")
+                try:
+                    await self.api.mesh_core.commands.get_stats_core()
+                    await self.api.mesh_core.commands.get_stats_radio()
+                    await self.api.mesh_core.commands.get_stats_packets()
+                    self._last_self_diagnostics_update = current_time
+                except Exception as ex:
+                    self.logger.debug(f"Exception getting self diagnostics: {ex}")
+            else:
+                self.logger.debug(f"Skipping self diagnostics (next in {self._self_diagnostics_interval - (current_time - self._last_self_diagnostics_update):.1f}s)")
+
         # --- Message handling ---
         # On first cycle: drain any messages queued while disconnected.
         # After that: only poll if no message activity in MSG_SAFETY_NET_INTERVAL.

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_REPEATER_SUBSCRIPTIONS,
     CONF_REPEATER_NEIGHBORS_ENABLED,
     CONF_TRACKED_CLIENTS,
+    CONF_SELF_DIAGNOSTICS_ENABLED,
     SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER,
     NEIGHBOR_STALE_THRESHOLD,
     SEEN_WINDOW_SECS,
@@ -139,6 +140,106 @@ SENSORS = [
     SensorEntityDescription(
         key="spreading_factor",
         icon="mdi:radio"
+    ),
+]
+
+# Self-diagnostic sensors for the local companion node.
+# Created only when CONF_SELF_DIAGNOSTICS_ENABLED is set (default off). Sourced
+# from local get_stats_core/radio/packets polling (no mesh traffic). Definitions
+# mirror the matching REPEATER_SENSORS keys/device-classes/units/icons so units,
+# precision, and icons stay consistent across node types. Battery is intentionally
+# omitted (the companion already exposes battery_voltage/battery_percentage).
+# Unit conversions (seconds->minutes for uptime/airtime) are applied in the
+# async_added_to_hass handlers below.
+SELF_DIAGNOSTIC_SENSORS = [
+    # STATS_CORE
+    SensorEntityDescription(
+        key="uptime",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement="min",
+        suggested_unit_of_measurement="d",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:clock",
+    ),
+    SensorEntityDescription(
+        key="tx_queue_len",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:playlist-edit",
+    ),
+    # NOTE: STATS_CORE `errors` is intentionally NOT a sensor here — it is a
+    # latching bitmask of radio fault events, not a count, so it is decoded
+    # into individual `problem` binary sensors (see binary_sensor.py).
+    # STATS_RADIO
+    SensorEntityDescription(
+        key="noise_floor",
+        native_unit_of_measurement="dBm",
+        suggested_display_precision="0",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:waveform",
+    ),
+    SensorEntityDescription(
+        key="last_rssi",
+        native_unit_of_measurement="dBm",
+        suggested_display_precision="0",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:signal",
+    ),
+    SensorEntityDescription(
+        key="last_snr",
+        native_unit_of_measurement="dB",
+        suggested_display_precision="1",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:signal",
+    ),
+    SensorEntityDescription(
+        key="tx_airtime",
+        native_unit_of_measurement="min",
+        suggested_display_precision="1",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:radio",
+    ),
+    SensorEntityDescription(
+        key="rx_airtime",
+        native_unit_of_measurement="min",
+        suggested_display_precision="1",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:radio",
+    ),
+    # STATS_PACKETS
+    SensorEntityDescription(
+        key="nb_recv",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-left",
+    ),
+    SensorEntityDescription(
+        key="nb_sent",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-right",
+    ),
+    SensorEntityDescription(
+        key="sent_flood",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-right-outline",
+    ),
+    SensorEntityDescription(
+        key="sent_direct",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-right",
+    ),
+    SensorEntityDescription(
+        key="recv_flood",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-left-outline",
+    ),
+    SensorEntityDescription(
+        key="recv_direct",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-arrow-left",
+    ),
+    SensorEntityDescription(
+        key="recv_errors",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:message-alert",
     ),
 ]
 
@@ -391,6 +492,13 @@ async def async_setup_entry(
     # Create sensors for the main device
     for description in SENSORS:
         entities.append(MeshCoreSensor(coordinator, description))
+
+    # Create self-diagnostic sensors only when opted in (default off). These
+    # subscribe to the STATS_CORE/RADIO/PACKETS events emitted by the local
+    # get_stats_* polling added to the coordinator.
+    if entry.data.get(CONF_SELF_DIAGNOSTICS_ENABLED, False):
+        for description in SELF_DIAGNOSTIC_SENSORS:
+            entities.append(MeshCoreSensor(coordinator, description))
 
     # Add rate limiter monitoring sensor
     entities.append(RateLimiterSensor(coordinator))
@@ -1010,6 +1118,103 @@ class MeshCoreSensor(CoordinatorEntity, SensorEntity):
                 EventType.SELF_INFO,
                 update_sf,
             )
+
+        # --- Self-diagnostic sensors (local get_stats_* polling) ---
+        # STATS_CORE
+        elif key == "uptime":
+            def update_uptime(event: Event):
+                value = event.payload.get("uptime_secs")
+                self._native_value = round(value / 60, 1) if isinstance(value, (int, float)) else None
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_CORE, update_uptime)
+
+        elif key == "tx_queue_len":
+            def update_queue_len(event: Event):
+                self._native_value = event.payload.get("queue_len")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_CORE, update_queue_len)
+
+        # STATS_CORE `errors` is decoded into `problem` binary sensors
+        # (see binary_sensor.py MeshCoreSelfDiagnosticBinarySensor) rather
+        # than a numeric sensor — it is a latching fault-flag bitmask.
+
+        # STATS_RADIO
+        elif key == "noise_floor":
+            def update_noise_floor(event: Event):
+                self._native_value = event.payload.get("noise_floor")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_RADIO, update_noise_floor)
+
+        elif key == "last_rssi":
+            def update_last_rssi(event: Event):
+                self._native_value = event.payload.get("last_rssi")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_RADIO, update_last_rssi)
+
+        elif key == "last_snr":
+            def update_last_snr(event: Event):
+                # SDK already unscales SNR (raw value was multiplied by 4)
+                self._native_value = event.payload.get("last_snr")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_RADIO, update_last_snr)
+
+        elif key == "tx_airtime":
+            def update_tx_airtime(event: Event):
+                value = event.payload.get("tx_air_secs")
+                self._native_value = round(value / 60, 1) if isinstance(value, (int, float)) else None
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_RADIO, update_tx_airtime)
+
+        elif key == "rx_airtime":
+            def update_rx_airtime(event: Event):
+                value = event.payload.get("rx_air_secs")
+                self._native_value = round(value / 60, 1) if isinstance(value, (int, float)) else None
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_RADIO, update_rx_airtime)
+
+        # STATS_PACKETS
+        elif key == "nb_recv":
+            def update_nb_recv(event: Event):
+                self._native_value = event.payload.get("recv")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_nb_recv)
+
+        elif key == "nb_sent":
+            def update_nb_sent(event: Event):
+                self._native_value = event.payload.get("sent")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_nb_sent)
+
+        elif key == "sent_flood":
+            def update_sent_flood(event: Event):
+                self._native_value = event.payload.get("flood_tx")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_sent_flood)
+
+        elif key == "sent_direct":
+            def update_sent_direct(event: Event):
+                self._native_value = event.payload.get("direct_tx")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_sent_direct)
+
+        elif key == "recv_flood":
+            def update_recv_flood(event: Event):
+                self._native_value = event.payload.get("flood_rx")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_recv_flood)
+
+        elif key == "recv_direct":
+            def update_recv_direct(event: Event):
+                self._native_value = event.payload.get("direct_rx")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_recv_direct)
+
+        elif key == "recv_errors":
+            def update_recv_errors(event: Event):
+                # May be None on a legacy 26-byte STATS_PACKETS frame
+                self._native_value = event.payload.get("recv_errors")
+                self.async_write_ha_state()
+            meshcore.dispatcher.subscribe(EventType.STATS_PACKETS, update_recv_errors)
 
 
     @property

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -27,14 +27,24 @@
       "usb": {
         "data": {
           "usb_path": "USB Device Path",
-          "baudrate": "Connection Speed"
+          "baudrate": "Connection Speed",
+          "self_diagnostics_enabled": "Enable Self Diagnostics",
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+        },
+        "data_description": {
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
         },
         "description": "Connect to your MeshCore node via USB",
         "title": "Configure USB Connection"
       },
       "ble": {
         "data": {
-          "ble_address": "Bluetooth Device"
+          "ble_address": "Bluetooth Device",
+          "self_diagnostics_enabled": "Enable Self Diagnostics",
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+        },
+        "data_description": {
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
         },
         "description": "Connect to your MeshCore node via Bluetooth",
         "title": "Configure Bluetooth Connection"
@@ -42,7 +52,12 @@
       "tcp": {
         "data": {
           "tcp_host": "Host Address",
-          "tcp_port": "Port"
+          "tcp_port": "Port",
+          "self_diagnostics_enabled": "Enable Self Diagnostics",
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+        },
+        "data_description": {
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
         },
         "description": "Connect to your MeshCore node over the network",
         "title": "Configure Network Connection"
@@ -141,6 +156,8 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
+          "self_diagnostics_enabled": "Enable Self Diagnostics",
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)",
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
           "stale_contact_days": "Stale Contact Threshold (days)",
@@ -149,6 +166,7 @@
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
@@ -264,6 +282,8 @@
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
           "self_telemetry_interval": "Self Telemetry Interval (seconds)",
+          "self_diagnostics_enabled": "Enable Self Diagnostics",
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)",
           "map_upload_enabled": "Enable Map Auto Uploader (map.meshcore.io)",
           "auto_cleanup_stale_contacts": "Auto-Cleanup Stale Discovered Contacts (runs daily)",
           "stale_contact_days": "Stale Contact Threshold (days)",
@@ -272,6 +292,7 @@
           "adaptive_poll_wait": "Adaptive Channel Message Delivery"
         },
         "data_description": {
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
@@ -452,6 +473,17 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "err_pool_full": {
+        "name": "Radio Fault: Packet Pool Exhausted"
+      },
+      "err_cad_timeout": {
+        "name": "Radio Fault: CAD Timeout"
+      },
+      "err_rx_timeout": {
+        "name": "Radio Fault: RX-Start Timeout"
+      }
+    },
     "sensor": {
       "node_status": {
         "name": "Node Status",
@@ -558,6 +590,9 @@
       },
       "airtime_utilization": {
         "name": "Airtime Utilization"
+      },
+      "tx_airtime": {
+        "name": "TX Airtime"
       },
       "rx_airtime": {
         "name": "RX Airtime"

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -76,6 +76,8 @@ During setup, you can configure:
 
 - **Self Telemetry Enabled**: Whether to collect telemetry from this node
 - **Self Telemetry Interval** (60-3600 seconds): How often to collect telemetry data from this node
+- **Self Diagnostics Enabled**: Whether to create local diagnostic sensors (uptime, radio, and packet statistics) for the companion node. Off by default; adds no mesh traffic (local radio queries only).
+- **Self Diagnostics Interval** (60-3600 seconds): How often to refresh the self-diagnostic sensors
 
 ## Post-Installation Configuration
 
@@ -106,6 +108,8 @@ Configure integration-wide settings:
 - **Disable Contact Discovery**: Stop automatically creating contact sensors (useful for large networks)
 - **Enable Self Telemetry**: Collect telemetry from this node
 - **Self Telemetry Interval** (60-3600 seconds): How often to collect self telemetry data
+- **Enable Self Diagnostics**: Create ~15 local diagnostic sensors (uptime, TX queue, noise floor, RSSI/SNR, TX/RX airtime, packet counters) for the companion node, giving it the same diagnostic tiles a managed repeater has. Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests.
+- **Self Diagnostics Interval** (60-3600 seconds): How often to refresh the self-diagnostic sensors
 - **Enable Map Upload (map.meshcore.io)**: When enabled, adverts from repeaters and room servers you receive are uploaded to [map.meshcore.io](https://map.meshcore.io). Those nodes appear on the official MeshCore map for the community. See [Map Auto Uploader](./map-upload) for details.
 - **Adaptive Channel Message Delivery**: When enabled, incoming channel messages fire as soon as RX_LOG radio reception data arrives (typically ~50ms) instead of always waiting the full 500ms. Late-arriving repeater data is delivered progressively via `meshcore_delivery_update` events. Disabled by default. See [Messaging — RX_LOG Correlation](./messaging#rx_log-correlation) for details.
 

--- a/docs/docs/sensors.md
+++ b/docs/docs/sensors.md
@@ -222,6 +222,18 @@ Binary sensors showing node freshness:
   - On = Fresh (recent activity within 12 hours)
   - Off = Stale (no recent activity)
 
+#### Radio Fault Flags (Diagnostic)
+
+Three binary sensors decode the companion radio's `errors` bitmask. They are created only when **Self Diagnostics** is enabled. The firmware latches each flag on first occurrence and clears it only on a radio reboot, so **On** means "this fault has occurred at least once since the radio last booted," not "is occurring now."
+
+- **Entities**: `binary_sensor.meshcore_<pubkey>_err_pool_full_<name>`, `..._err_cad_timeout_...`, `..._err_rx_timeout_...`
+- **Device Class**: Problem
+- **Category**: Diagnostic
+- **Flags**:
+  - **Packet Pool Exhausted** — the packet buffer pool ran out and a packet was dropped.
+  - **CAD Timeout** — Channel Activity Detection stayed busy too long (channel congested, or the radio may be wedged).
+  - **RX-Start Timeout** — the radio failed to (re)enter receive mode (possible radio hang).
+
 #### Device Online Status
 
 A per-device connectivity sensor for each managed repeater and client. Unlike the integration-level connection sensor (which reports whether the companion device itself is reachable via USB/TCP/BLE), this sensor reflects whether a specific managed node is being successfully polled.


### PR DESCRIPTION
### Summary

Adds a default-off **Self Diagnostics** option that polls the locally-attached companion node's own statistics (`get_stats_core` / `get_stats_radio` / `get_stats_packets`) on a configurable interval and exposes them as main-device sensor entities — giving the companion the same kind of diagnostic detail a managed repeater already has.

Crucially, these are **local-transport queries** to the attached radio (a 2-byte `GET_STATS` frame with no destination contact), so the poll adds **no mesh traffic** and consumes no airtime or duty-cycle — unlike the repeater status polling it mirrors.

### What it adds

- A `Self Diagnostics Enabled` toggle + `Self Diagnostics Interval` (60–3600 s, default 300 s) in the USB/BLE/TCP setup steps and in Options → Global Settings, with labels and descriptions in `translations/en.json`.
- A gated self-stats poll in the coordinator, mirroring the existing self-telemetry poll. Wrapped in try/except with debug logging; no return-value handling needed (the SDK dispatches `STATS_CORE/RADIO/PACKETS` events).
- ~14 main-device sensor entities, created **only when the option is enabled**, that subscribe to those events: uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters (received, sent, flood/direct TX, flood/direct RX, receive errors). Definitions reuse the existing repeater sensor classes/units/icons for consistency.
- Three diagnostic `problem` binary sensors decoding the radio `errors` bitmask (Packet Pool Exhausted / CAD Timeout / RX-Start Timeout). `STATS_CORE.errors` is a latching fault-flag bitmask, not a count, so it is surfaced as boolean problem flags rather than a numeric sensor (`on` = the fault has occurred since the radio last booted).
- README + docs entry describing the option, the sensors, and the fault flags.

### Design notes

- **Off by default** — existing installs gain no new entities until a user opts in (no surprise entity proliferation / recorder load).
- **Battery is not duplicated** — the companion already exposes battery voltage/percentage from the `BATTERY`/`SELF_INFO` events; `STATS_CORE.battery_mv` is ignored.
- Unit conversions match the repeater sensors (seconds → minutes for uptime/airtime). `recv_errors` is guarded for the legacy 26-byte `STATS_PACKETS` frame (reported as unknown rather than failing).
- All sensor keys carry an `entity.sensor.<key>.name` translation. Most reuse existing repeater keys; the genuinely new `tx_airtime` key got its own `name` entry (`TX Airtime`) so it renders with a friendly name rather than the bare device name. The three fault binary sensors carry `entity.binary_sensor.<key>.name` entries.

### Testing

- Deployed to a live HA instance (HA 2026.5.4, `meshcore` SDK 2.3.7) on a USB-attached companion.
- With the option off: no new entities; integration loads cleanly.
- With the option on: all ~15 sensors created and populated. Verified one `STATS_CORE/RADIO/PACKETS` event of each type carried the expected fields, and that converted uptime/airtime values matched the raw `get_stats_*` readings.
- Confirmed the poll issues only local radio queries — no mesh-packet transmission, no path/rate-limiter activity.
- Toggling the option off removes the entities from active updates on reload; toggling back on restores them.

### Notes for reviewers

- The change is self-contained and mirrors the established repeater-sensor and self-telemetry patterns.
- A follow-up could tag the new counters `EntityCategory.DIAGNOSTIC` (the repeater sensors currently don't); left as-is here for parity, open to reviewer preference.