### PR TITLE
fix: repair discovered-contact entity cleanup broken by the #236 unique_id migration

### DIFF
--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -309,14 +309,18 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         for public_key in keys_to_evict:
             pubkey_prefix = public_key[:12]
             del self._discovered_contacts[public_key]
-            self.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
+            self.tracked_diagnostic_binary_contacts.discard(public_key)
 
-            for entity in list(entity_registry.entities.values()):
-                if entity.platform == DOMAIN and entity.domain == "binary_sensor":
-                    if entity.unique_id == pubkey_prefix:
-                        _LOGGER.info(f"Evicting binary sensor entity: {entity.entity_id}")
-                        entity_registry.async_remove(entity.entity_id)
-                        break
+            # Post-PR-#236 contact unique_ids are scoped by entry_id; the
+            # migration at __init__.py:_migrate_unique_ids_scope_contact_diagnostics
+            # guarantees every existing entity uses this format.
+            unique_id = f"{self.config_entry.entry_id}_contact_{pubkey_prefix}"
+            entity_id = entity_registry.async_get_entity_id(
+                "binary_sensor", DOMAIN, unique_id
+            )
+            if entity_id:
+                _LOGGER.info(f"Evicting binary sensor entity: {entity_id}")
+                entity_registry.async_remove(entity_id)
 
         _LOGGER.info(f"Evicted {evict_count} oldest discovered contacts (limit: {max_contacts})")
 
@@ -344,16 +348,19 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         events, which can overwhelm WebSocket clients and block the main thread.
 
         Returns the number of contacts removed.
-        """
-        if not self._discovered_contacts:
-            return 0
 
+        Note: this function ALWAYS runs the Phase 4 orphan sweep, even when
+        the dict is empty or no stale contacts are found. Orphans live in the
+        entity registry, not the dict — early-returning on empty-stale would
+        skip the sweep on every typical call once the dict is stable.
+        """
         now = time.time()
         threshold_seconds = days_threshold * 86400
         entity_registry = er.async_get(self.hass)
         skipped_node_contacts = 0
+        batch_size = 10
 
-        # Phase 1: Collect stale contacts (no side effects)
+        # Phase 1: Collect stale contacts (no side effects).
         stale_keys: list[str] = []
         for public_key, contact in self._discovered_contacts.items():
             if contact.get("added_to_node", False):
@@ -363,17 +370,9 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             if not lastmod or (now - lastmod) > threshold_seconds:
                 stale_keys.append(public_key)
 
-        if not stale_keys:
-            _LOGGER.info(
-                "Stale contact cleanup: 0 contacts older than %d days "
-                "(%d node contacts skipped)",
-                days_threshold, skipped_node_contacts,
-            )
-            return 0
-
         # Phase 2: Remove in batches, yielding the event loop between each
-        # batch so WebSocket clients can drain their message queues.
-        batch_size = 10
+        # batch so WebSocket clients can drain their message queues. No-op
+        # when stale_keys is empty; Phase 4 still runs.
         removed_count = 0
 
         for i, public_key in enumerate(stale_keys):
@@ -386,11 +385,14 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             lastmod = contact.get("lastmod", 0)
 
             del self._discovered_contacts[public_key]
-            self.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
+            self.tracked_diagnostic_binary_contacts.discard(public_key)
 
-            # O(1) entity registry lookup instead of scanning all entities
+            # Post-PR-#236 contact unique_ids are scoped by entry_id; the
+            # migration at __init__.py:_migrate_unique_ids_scope_contact_diagnostics
+            # guarantees every existing entity uses this format.
+            unique_id = f"{self.config_entry.entry_id}_contact_{pubkey_prefix}"
             entity_id = entity_registry.async_get_entity_id(
-                "binary_sensor", DOMAIN, pubkey_prefix
+                "binary_sensor", DOMAIN, unique_id
             )
             if entity_id:
                 entity_registry.async_remove(entity_id)
@@ -416,10 +418,49 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
             updated_data["contacts"] = self.get_all_contacts()
             self.async_set_updated_data(updated_data)
 
+        # Phase 4: Sweep pre-existing orphaned contact entities.
+        #
+        # Catches entities that were "removed" by buggy cleanup calls between
+        # PR #236's migration (2026-05-10) and the lookup-format fix in this
+        # change set — the dict deletion ran but the entity-lookup format was
+        # wrong, so the entity stayed in the registry. Walks entities tied to
+        # this config entry whose unique_id matches
+        # "<entry_id>_contact_<hex12>" and removes any whose pubkey is not in
+        # the current contact set (added + discovered).
+        #
+        # The 12-hex suffix check is load-bearing: the contact-selector entity
+        # has unique_id "<entry_id>_contact_select" which would otherwise match
+        # the entry_prefix. Do not loosen this check.
+        entry_prefix = f"{self.config_entry.entry_id}_contact_"
+        live_pubkey_prefixes = {
+            c.get("public_key", "")[:12]
+            for c in self.get_all_contacts()
+            if c.get("public_key")
+        }
+        orphan_count = 0
+        for entity in list(entity_registry.entities.values()):
+            if entity.config_entry_id != self.config_entry.entry_id:
+                continue
+            if entity.platform != DOMAIN or entity.domain != "binary_sensor":
+                continue
+            if not entity.unique_id.startswith(entry_prefix):
+                continue
+            suffix = entity.unique_id[len(entry_prefix):]
+            if len(suffix) != 12 or any(c not in "0123456789abcdef" for c in suffix.lower()):
+                continue
+            if suffix in live_pubkey_prefixes:
+                continue
+            entity_registry.async_remove(entity.entity_id)
+            orphan_count += 1
+            # Yield the event loop every batch_size removals (consistent with Phase 2).
+            if orphan_count % batch_size == 0:
+                await asyncio.sleep(0)
+
         _LOGGER.info(
-            "Stale contact cleanup: removed %d contacts older than %d days "
-            "(%d node contacts skipped)",
-            removed_count, days_threshold, skipped_node_contacts,
+            "Stale contact cleanup: removed %d stale dict contacts (%d node "
+            "contacts skipped) and swept %d orphaned registry entities older "
+            "than %d days",
+            removed_count, skipped_node_contacts, orphan_count, days_threshold,
         )
         return removed_count
 

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -1025,14 +1025,18 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         updated_data["contacts"] = coordinator.get_all_contacts()
         coordinator.async_set_updated_data(updated_data)
 
-        # Remove the binary sensor entity for this contact
+        # Remove the binary sensor entity for this contact.
+        # Post-PR-#236 contact unique_ids are scoped by entry_id; the migration
+        # at __init__.py:_migrate_unique_ids_scope_contact_diagnostics guarantees
+        # every existing entity uses this format.
         entity_registry = er.async_get(hass)
-        for entity in list(entity_registry.entities.values()):
-            if entity.platform == DOMAIN and entity.domain == "binary_sensor":
-                if entity.unique_id == pubkey_prefix:
-                    _LOGGER.info(f"Removing binary sensor entity: {entity.entity_id}")
-                    entity_registry.async_remove(entity.entity_id)
-                    break
+        unique_id = f"{coordinator.config_entry.entry_id}_contact_{pubkey_prefix}"
+        entity_id = entity_registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, unique_id
+        )
+        if entity_id:
+            _LOGGER.info(f"Removing binary sensor entity: {entity_id}")
+            entity_registry.async_remove(entity_id)
 
     # Register the contact management services
     hass.services.async_register(
@@ -1126,13 +1130,17 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
             for public_key in list(coordinator._discovered_contacts.keys()):
                 pubkey_prefix = public_key[:12]
-                coordinator.tracked_diagnostic_binary_contacts.discard(pubkey_prefix)
+                coordinator.tracked_diagnostic_binary_contacts.discard(public_key)
 
-                for entity in list(entity_registry.entities.values()):
-                    if entity.platform == DOMAIN and entity.domain == "binary_sensor":
-                        if entity.unique_id == pubkey_prefix:
-                            entity_registry.async_remove(entity.entity_id)
-                            break
+                # Post-PR-#236 contact unique_ids are scoped by entry_id; the
+                # migration at __init__.py:_migrate_unique_ids_scope_contact_diagnostics
+                # guarantees every existing entity uses this format.
+                unique_id = f"{coordinator.config_entry.entry_id}_contact_{pubkey_prefix}"
+                entity_id = entity_registry.async_get_entity_id(
+                    "binary_sensor", DOMAIN, unique_id
+                )
+                if entity_id:
+                    entity_registry.async_remove(entity_id)
 
             coordinator._discovered_contacts.clear()
 


### PR DESCRIPTION
### Background

PR #236 scoped contact-diagnostic `binary_sensor` unique_ids by `entry_id` (from a bare `pubkey_prefix` to `"<entry_id>_contact_<pubkey_prefix>"`) and migrated existing entities to the new format. That migration runs unconditionally, so every install on #236 or later is affected — single-entry and multi-entry alike.

The migration updated the entities but not the four code paths that *delete* discovered-contact entities. Those paths still looked entities up by the old bare-`pubkey_prefix` format, which post-migration never matches. The result: each cleanup removed the contact from the in-memory discovered dict and from `.storage`, but left the `binary_sensor` orphaned in the entity registry. On the next reload HA flags every one of them "no longer being provided by the meshcore integration."

### Summary

Two fixes that must ship together — the entity-lookup repair, and a companion `discard()` fix that would otherwise turn the first fix into a regression.

### The fix

**1. Align the entity lookup with the post-#236 unique_id (coordinator + services).** The four deletion paths — stale-cleanup, FIFO eviction, the single-contact `remove_discovered_contact` service, and the `clear_discovered_contacts` clear-all branch — now compute the post-#236 unique_id and resolve it with `async_get_entity_id` for an O(1) lookup. In the eviction path this also replaces an O(N) full-registry scan that compared against the old bare-prefix format.

A new orphan-sweep step walks the registry for this entry's `"<entry_id>_contact_<hex12>"` entities and removes any whose pubkey is no longer in `get_all_contacts()`, self-healing orphans that accumulated between #236 and this fix. The 12-hex suffix match is load-bearing: without it the sweep would also match the contact-selector entity (`"<entry_id>_contact_select"`). The early-returns on an empty discovered dict / empty stale set were removed so the sweep runs on every invocation — orphans live in the registry, not the dict, so those early-returns made the sweep unreachable once the dict had already been pruned by a prior daily cleanup. The end-of-run INFO log now distinguishes dict removals from registry sweeps (previously it reported the dict-removal count as if it were the entity count).

**2. Discard tracked contacts by full pubkey, not prefix.** `binary_sensor.py` keys `coordinator.tracked_diagnostic_binary_contacts` by the full 64-char `public_key`, but the eviction, stale-cleanup, and clear-all paths called `.discard()` with the 12-char prefix — a silent no-op since the eviction/clear paths landed in #150 and the stale-cleanup path inherited the pattern in #183. It was masked the whole time because entity removal at those same sites was also failing, so a re-discovered contact still had its entity present and the membership gate never mattered. With entity removal now fixed (fix 1), the membership gate in `create_contact_sensor` would block a re-discovered contact from getting a fresh `binary_sensor`. So without fix 2, fix 1 is a strict regression for users with `auto_cleanup_stale_contacts` or `limit_discovered_contacts` enabled.

Both changes are idempotent and safe: discarding a key not in the set is a no-op, and on the next HA restart the set re-initializes empty and the "create sensors for existing contacts" loop recreates an entity for every contact in the discovered dict, healing any that were missing.

### Tests

`ast.parse` clean on both modified modules; a grep confirms all three discard sites now pass the full `public_key`. Verified on a live install: a registry carrying ~790 orphaned contact entities — accumulated over ~20 days against a discovered set held near ~35 by the configured stale-cleanup and limit settings — cleared to 0 orphans in a single `clear_discovered_contacts` call. Curated/added contacts were preserved, and there were no event-loop-blocking warnings or integration errors across the restart-and-verify window.

### Notes for the maintainer

The two commits are presented squashed here; happy to split them back into the lookup fix and the discard fix as two commits if you'd prefer to review them separately. The orphan-sweep step is the one piece that does registry I/O on every cleanup invocation rather than only when the dict changed — called out in case you'd rather gate it behind a one-time migration flag instead of running it each pass.