### PR TITLE
fix: replace removed hass.helpers accessor in three contact services

### DIFF
--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -853,7 +853,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         select_entity_id = None
         if entry_id:
             # Look for entity with matching unique_id
-            registry = hass.helpers.entity_registry.async_get()
+            registry = er.async_get(hass)
             for entity in registry.entities.values():
                 if entity.unique_id == f"{entry_id}_discovered_contact_select":
                     select_entity_id = entity.entity_id
@@ -902,7 +902,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         select_entity_id = None
         if entry_id:
             # Look for entity with matching unique_id
-            registry = hass.helpers.entity_registry.async_get()
+            registry = er.async_get(hass)
             for entity in registry.entities.values():
                 if entity.unique_id == f"{entry_id}_added_contact_select":
                     select_entity_id = entity.entity_id
@@ -951,7 +951,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if not pubkey_prefix:
             select_entity_id = None
             if entry_id:
-                registry = hass.helpers.entity_registry.async_get()
+                registry = er.async_get(hass)
                 for entity in registry.entities.values():
                     if entity.unique_id == f"{entry_id}_discovered_contact_select":
                         select_entity_id = entity.entity_id


### PR DESCRIPTION
### Background

Three contact services resolve a contact-select entity by `unique_id` on their `entry_id` code path, and each did so via `registry = hass.helpers.entity_registry.async_get()`. The `hass.helpers.*` accessor was removed in a recent Home Assistant core release, so on current HA that line raises `AttributeError: 'HomeAssistant' object has no attribute 'helpers'`.

Affected services (the `entry_id` branch only):

- `meshcore.add_selected_contact` (`async_add_selected_contact_service`)
- `meshcore.remove_selected_contact` (`async_remove_selected_contact_service`)
- `meshcore.remove_discovered_contact` (`async_remove_discovered_contact_service`)

### Impact

Calling any of these services **with** an `entry_id` raises the `AttributeError` (surfaced as a 500 to the caller) and the add/remove silently does not happen. The bare call (no `entry_id`) takes a different branch that uses `hass.states.async_all()` and is unaffected — which is why this stayed latent on single-config-entry installs that omit `entry_id`. Multi-entry installs, and any automation or UI that passes `entry_id` to disambiguate which radio to act on, hit the crash.

### The fix

Replace the three `hass.helpers.entity_registry.async_get()` calls with the supported module-level `er.async_get(hass)` (`homeassistant.helpers.entity_registry`, already imported as `er` in `services.py` and already used elsewhere in the file). This is a pure accessor swap — the surrounding select-entity lookup logic is unchanged, and there is no behavior change beyond the entity-registry handle now resolving instead of raising.

### Tests

- The integration's test suite passes — **66 passed** — including `tests/test_services_parsing.py` (functional-command parsing + contact-resolution coverage). `ast.parse` clean on `services.py`; a grep confirms no `hass.helpers.*` accessors remain anywhere in the integration.
- Verified on a live Home Assistant 2026.5.4 install: `meshcore.add_selected_contact` and `meshcore.remove_selected_contact` called **with** an `entry_id` now reach the handler (e.g. the "no contact selected" early-return) instead of raising `AttributeError`.