### PR TITLE
fix: exclude discovered-contact select options from the recorder (#243)

### DIFF
--- a/custom_components/meshcore/select.py
+++ b/custom_components/meshcore/select.py
@@ -261,6 +261,12 @@ class MeshCoreRecipientTypeSelect(CoordinatorEntity, SelectEntity):
 class MeshCoreDiscoveredContactSelect(CoordinatorEntity, SelectEntity):
     """Select entity for discovered contacts not yet added to node."""
 
+    # The options list grows with the discovered-contact set and can exceed
+    # the recorder's 16 KiB per-state attribute cap on dense meshes, which
+    # makes the recorder drop the state's attributes and log warnings. A
+    # picker's options history has no value, so exclude it from recording.
+    _unrecorded_attributes = frozenset({"options"})
+
     def __init__(self, coordinator: DataUpdateCoordinator) -> None:
         """Initialize the discovered contact select entity."""
         super().__init__(coordinator)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,65 @@
+"""Tests for select.py entity definitions.
+
+select.py defines entity classes that subclass Home Assistant base classes,
+and this suite mocks Home Assistant (see tests/conftest.py) so helpers can be
+imported standalone. The select entities are therefore asserted at the AST
+level rather than instantiated, consistent with the standalone-helper approach
+used across this suite.
+"""
+import ast
+import os
+
+
+def _load_select_ast() -> ast.Module:
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "custom_components", "meshcore", "select.py",
+    )
+    with open(path, "r", encoding="utf-8") as fh:
+        return ast.parse(fh.read())
+
+
+def _class_def(tree: ast.Module, name: str) -> ast.ClassDef | None:
+    return next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.ClassDef) and n.name == name
+        ),
+        None,
+    )
+
+
+def test_discovered_contact_select_marks_options_unrecorded() -> None:
+    """MeshCoreDiscoveredContactSelect must exclude its ``options`` list from the
+    recorder via ``_unrecorded_attributes = frozenset({"options"})``.
+
+    The options list grows with the discovered-contact set and can exceed the
+    recorder's 16 KiB per-state attribute cap on dense meshes; excluding it
+    keeps the state recordable at any contact count. This guards the annotation
+    against accidental removal or a typo.
+    """
+    cls = _class_def(_load_select_ast(), "MeshCoreDiscoveredContactSelect")
+    assert cls is not None, "MeshCoreDiscoveredContactSelect class not found"
+
+    assignments = [
+        node.value
+        for node in cls.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(t, ast.Name) and t.id == "_unrecorded_attributes"
+            for t in node.targets
+        )
+    ]
+    assert assignments, "_unrecorded_attributes assignment not found in class body"
+
+    value = assignments[0]
+    assert (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id == "frozenset"
+        and value.args
+    ), f"expected frozenset(...), got {ast.dump(value)}"
+    assert ast.literal_eval(value.args[0]) == {"options"}, (
+        f"unexpected _unrecorded_attributes value: {ast.dump(value)}"
+    )


### PR DESCRIPTION
Fixes #243.

### Background

On instances with many discovered contacts, the recorder logs repeated `State attributes for select.meshcore_discovered_contact exceed maximum size of 16384 bytes` warnings and stores the entity's states **without** attributes. The mechanism is Home Assistant's recorder per-state attribute cap, `MAX_STATE_ATTRS_BYTES = 16384` (16 KiB). `MeshCoreDiscoveredContactSelect` carries every discovered contact in its `options` list; once that list pushes the serialized attributes past 16 KiB, the recorder drops the attributes for that state and warns. The live select keeps working — only its recorded history loses `options`, and the log fills with warnings. (See home-assistant/core#102964 for the recorder mechanism.)

Measured on a live instance: each option in the current `f"{name} ({pubkey_prefix})"` format costs ~31.7 bytes in the options list on top of ~112 bytes fixed overhead, so an instance crosses the 16 KiB ceiling at roughly ~500 options (~400 with longer names). This is a recorder-serialization limit, not a contact-count limit — the select itself functions at any count.

### The fix

Add `_unrecorded_attributes = frozenset({"options"})` to `MeshCoreDiscoveredContactSelect`. Home Assistant's recorder excludes an entity's `unrecorded_attributes` from the serialized attribute payload *before* the size check, so removing `options` prevents the overflow at any contact count.

Why this is sufficient (verified against the HA core recorder source): in `StateAttributes.shared_attrs_bytes_from_event` (`homeassistant/components/recorder/db_schema.py`), the recorder reads `state.state_info["unrecorded_attributes"]`, forms `exclude_attrs = {*ALL_DOMAIN_EXCLUDE_ATTRS, *unrecorded_attributes}`, serializes `{k: v for k, v in state.attributes.items() if k not in exclude_attrs}`, and only afterward evaluates `len(bytes_result) > MAX_STATE_ATTRS_BYTES` (`MAX_STATE_ATTRS_BYTES = 16384` at `db_schema.py:94`; the size check at `db_schema.py:581`). Because the exclusion happens before the size comparison, dropping `options` is enough. Note that `options` reaches the recorder as a `SelectEntity` *capability* attribute, but the recorder filters the already-merged `state.attributes` dict by key name regardless of an attribute's origin, so the `_unrecorded_attributes` exclusion applies to it.

A picker's `options` history has no analytical value (you don't chart or trigger on a dropdown's historical contents), so nothing useful is lost; the select still lists every discovered contact live. This is preferred over capping or paginating the dropdown, which would bound the contact count for the wrong reason (the recorder limit). Only `MeshCoreDiscoveredContactSelect` is changed — the other select entities' option lists are bounded by the added-contact / channel counts and don't approach the cap.

### Testing

**Verification split (stated plainly):** the change is confirmed **non-disruptive on a live instance**, but its **resolution of #243 is research-verified via the HA-core source read above, not observed live** — because no available instance has a >500-contact discovered set, and a synthetic >500-option harness was not stood up, so the before/after on the size-exceeded warning could not be observed.

- **Unit (`tests/test_select.py`):** asserts at the AST level that `MeshCoreDiscoveredContactSelect` declares `_unrecorded_attributes = frozenset({"options"})` — guarding the annotation against accidental removal or a typo. It is asserted via `ast` rather than by importing the entity class because this suite mocks Home Assistant (`tests/conftest.py`) so helpers can be checked standalone. This is by design close to a tautology: it does not exercise the recorder, so it does not by itself prove the overflow is fixed — efficacy against #243 rests on the source read above. Full suite **67 passed**.
- **Live (any density):** after deploy + reload on a live HA 2026.x install, `select.meshcore_discovered_contact` still lists every discovered contact and selecting one still drives the add-contact flow — confirming the "lost options history" change has no live functional impact.
- **Recorder before/after (the size-exceeded warning stopping):** **not run** — requires a >500-option instance, which was not available. Efficacy against #243 rests on the source read above; if a dense-enough instance becomes available the warning's disappearance can be confirmed directly.