### PR TITLE
fix: use utc timestamps for mqtt

### DIFF
--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -50,11 +50,6 @@ def _as_int(value: str | int | None, default: int) -> int:
         return default
 
 
-def _utc_timestamp() -> str:
-    """Return an offset-aware UTC ISO-8601 timestamp."""
-    return datetime.now(timezone.utc).isoformat()
-
-
 @dataclass
 class BrokerConfig:
     """Configuration for one MQTT broker."""
@@ -824,7 +819,7 @@ class MeshCoreMqttUploader:
         """Build status payload compatible with other uploaders."""
         payload: dict[str, Any] = {
             "status": state,
-            "timestamp": _utc_timestamp(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",
@@ -1021,7 +1016,7 @@ class MeshCoreMqttUploader:
     def _build_raw_event_payload(self, event_type: str, payload: Any) -> dict[str, Any]:
         """Build raw event payload for non-normalized broker mode."""
         return {
-            "timestamp": _utc_timestamp(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",

--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -12,7 +12,7 @@ import ssl
 import subprocess
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from typing import Any
 
@@ -48,6 +48,11 @@ def _as_int(value: str | int | None, default: int) -> int:
         return int(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return default
+
+
+def _utc_timestamp() -> str:
+    """Return an offset-aware UTC ISO-8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 @dataclass
@@ -819,7 +824,7 @@ class MeshCoreMqttUploader:
         """Build status payload compatible with other uploaders."""
         payload: dict[str, Any] = {
             "status": state,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_timestamp(),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",
@@ -1016,7 +1021,7 @@ class MeshCoreMqttUploader:
     def _build_raw_event_payload(self, event_type: str, payload: Any) -> dict[str, Any]:
         """Build raw event payload for non-normalized broker mode."""
         return {
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _utc_timestamp(),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",
@@ -1145,7 +1150,7 @@ class MeshCoreMqttUploader:
         if "RX_LOG" not in et and "RF_LOG" not in et and "PACKET" not in et:
             return None
 
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         payload_hex = str(payload.get("payload") or "").strip()
         raw_hex_fallback = str(payload.get("raw_hex") or "").strip()
         # Match packet-capture behavior: prefer payload, fallback to raw_hex without first 2 bytes.

--- a/docs/docs/mqtt.md
+++ b/docs/docs/mqtt.md
@@ -100,6 +100,8 @@ If the node cannot export its private key (firmware/export disabled), auth-token
 
 MQTT publishing behavior depends on broker `Payload Mode`.
 
+MQTT payload timestamps are UTC offset-aware ISO 8601 strings, for example `2026-06-04T21:42:31+00:00`.
+
 ### `packet` mode
 
 - Publishes packet-style payloads only (RX/RF/PACKET path)

--- a/tests/test_mqtt_timestamps.py
+++ b/tests/test_mqtt_timestamps.py
@@ -1,0 +1,60 @@
+"""Tests for MQTT timestamp formatting."""
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock
+
+
+class _EventType:
+    PRIVATE_KEY = "private_key"
+
+
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+sys.modules.setdefault("nacl", MagicMock())
+sys.modules.setdefault("nacl.bindings", MagicMock())
+
+_mc_events = sys.modules.get("meshcore.events")
+if _mc_events is not None:
+    _mc_events.EventType = _EventType
+
+_MQTT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "custom_components", "meshcore", "mqtt_uploader.py",
+)
+_spec = importlib.util.spec_from_file_location(
+    "custom_components.meshcore.mqtt_uploader", _MQTT_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+_module.__package__ = "custom_components.meshcore"
+_spec.loader.exec_module(_module)
+
+
+def _uploader():
+    entry = MagicMock()
+    entry.data = {}
+    return _module.MeshCoreMqttUploader(MagicMock(), MagicMock(), entry)
+
+
+def _assert_utc_aware(timestamp: str):
+    assert timestamp.endswith("+00:00") or timestamp.endswith("Z")
+
+
+def test_status_payload_uses_utc_aware_timestamp():
+    payload = _uploader()._build_status_payload("online")
+
+    _assert_utc_aware(payload["timestamp"])
+
+
+def test_raw_event_payload_uses_utc_aware_timestamp():
+    payload = _uploader()._build_raw_event_payload("RX_LOG_DATA", {})
+
+    _assert_utc_aware(payload["timestamp"])
+
+
+def test_packet_payload_uses_utc_aware_timestamp():
+    packet = _uploader()._normalize_packet_event("RX_LOG_DATA", {"payload": "00"})
+
+    assert packet is not None
+    _assert_utc_aware(packet["timestamp"])


### PR DESCRIPTION
## Summary

- Emit UTC-aware MQTT timestamps for status, raw event, and normalized packet payloads
- Add regression tests for MQTT timestamp formatting
- Update documentation

## Why

CoreScope reports and clamps MQTT observer timestamps when they are emitted as zone-less local-time values. Using UTC offset-aware ISO 8601 timestamps prevents consumers from interpreting local time as UTC and applying false clock-skew corrections.

## Testing

- `pytest tests/test_mqtt_timestamps.py -v`

Fixes #258 