### PR TITLE
feat: collapse contact-discovery flags into one tri-state mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ A companion Lovelace card is available at [meshcore-card](https://github.com/jpe
 
 For detailed configuration instructions, see the [documentation](https://meshcore-dev.github.io/meshcore-ha/).
 
+## Contact Discovery Mode
+
+A single **Contact Discovery Mode** setting controls how much per-discovered-contact machinery the integration creates, with three choices:
+
+- **Entity per contact** (default) — every discovered contact gets its own diagnostic binary sensor, as before.
+- **Data only** — discovered (un-added) contacts are tracked as data only, with no per-contact entity, while contacts you add to your node keep their entities as usual. On dense meshes this avoids hundreds of low-utility entities and the entity-registry churn they drive.
+- **Disabled** — no discovered-contact processing at all (no contact sensors, no persistence, empty selectors) — for when you only track specific repeaters or clients.
+
+Set it at install time or later in **Configure → Global Settings**. In **Data only** mode the discovered-contact dropdown, messaging, services, and the chat panel all keep working, and the data-only contacts stay inspectable via an aggregate summary sensor and the `meshcore.get_discovered_contact` service; the only trade-off is no individual connectivity sensor / charting / automation for un-added contacts. See [Contact Management → Contact Discovery Mode](https://meshcore-dev.github.io/meshcore-ha/contacts#contact-discovery-mode).
+
 ## MQTT Upload (Addon/Container Env)
 
 Configuration can be done in the Home Assistant Web UI:

--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -42,6 +42,11 @@ from .const import (
     CONF_MESSAGES_INTERVAL,
     DEFAULT_UPDATE_TICK,
     REPAIR_PUBKEY_CHANGED,
+    CONF_CONTACT_DISCOVERY_MODE,
+    MODE_FULL,
+    MODE_DATA_ONLY,
+    MODE_OFF,
+    get_contact_discovery_mode,
 )
 from .coordinator import MeshCoreDataUpdateCoordinator
 from .meshcore_api import MeshCoreAPI
@@ -79,7 +84,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     _LOGGER.debug("Migrating configuration from version %s", config_entry.version)
     
     # Don't allow downgrading from future versions
-    if config_entry.version > 2:
+    if config_entry.version > 3:
         _LOGGER.error("Cannot downgrade from version %s", config_entry.version)
         return False
     
@@ -108,6 +113,26 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         
         _LOGGER.info("Migrated configuration from version %s to version 2", config_entry.version)
     
+    # Migrate from version 2 to version 3: collapse the two overlapping
+    # discovery booleans into the single contact_discovery_mode tri-state.
+    # Standalone `if` (not `elif`): a v1 entry's v1->v2 block above sets
+    # version=2, so it falls into this block and chains v1->v3 in one pass.
+    if config_entry.version == 2:
+        new_data = dict(config_entry.data)
+        # Read the legacy keys as string literals so the migration is
+        # independent of the const definitions.
+        disable = new_data.pop("disable_contact_discovery", False)
+        large_mesh = new_data.pop("large_mesh_mode", False)
+        if disable:
+            mode = MODE_OFF  # "off" wins the tie-break: no discovery, nothing to be data-only
+        elif large_mesh:
+            mode = MODE_DATA_ONLY
+        else:
+            mode = MODE_FULL
+        new_data[CONF_CONTACT_DISCOVERY_MODE] = mode
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
+        _LOGGER.info("Migrated contact-discovery settings to %s (version 3)", mode)
+
     _LOGGER.debug("Migration to configuration version %s successful", config_entry.version)
     return True
 
@@ -518,7 +543,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Set up all platforms for this device
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
+
+    # Bring the EXISTING discovered-contact population into line with the
+    # configured contact discovery mode now that platforms are up (entities,
+    # the binary_sensor add-callback, and the tracking sets all exist). Runs
+    # once per setup with the correct post-reload coordinator, so it covers
+    # start, reload, and the reload a mode switch triggers -- without the
+    # pre-reload race. full is a near no-op (the setup create-pass already
+    # built entities); data_only/off remove the discovered per-contact
+    # entities, and off also clears the discovered set.
+    try:
+        await coordinator.async_reconcile_discovered_for_mode()
+    except Exception as ex:
+        _LOGGER.error("Error reconciling discovered contacts to mode: %s", ex)
+
     # Register static paths for icons
     should_cache = False
     icons_path = Path(__file__).parent / "www" / "icons"
@@ -663,6 +701,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async def handle_new_contact(event):
             """Handle NEW_CONTACT events for discovered but not-yet-added contacts."""
             if not event or not event.payload:
+                return
+
+            # Discovery disabled (mode off): drop incoming adverts so they do
+            # not repopulate the discovered set (mirrors the off early-return in
+            # binary_sensor.handle_contacts_update). HA-side only -- the radio
+            # still hears and forwards the advert; HA just stops keeping it.
+            if get_contact_discovery_mode(entry) == MODE_OFF:
                 return
 
             contact = event.payload

--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
-    CONF_DISABLE_CONTACT_DISCOVERY,
     CONF_SELF_DIAGNOSTICS_ENABLED,
     DOMAIN,
     ENTITY_DOMAIN_BINARY_SENSOR,
@@ -31,6 +30,9 @@ from .const import (
     SELF_DIAG_ERR_CAD_TIMEOUT,
     SELF_DIAG_ERR_POOL_FULL,
     SELF_DIAG_ERR_RX_TIMEOUT,
+    MODE_DATA_ONLY,
+    MODE_OFF,
+    get_contact_discovery_mode,
     NodeType,
 )
 from .utils import (
@@ -53,8 +55,37 @@ def create_contact_sensor(coordinator, contact: dict):
 
     contact_name = contact.get("adv_name", "Unknown")
     public_key = contact.get("public_key", "")
+    if not public_key:
+        return None
 
-    if public_key and public_key not in coordinator.tracked_diagnostic_binary_contacts:
+    # Suppress the per-contact entity for discovered (un-added) contacts in
+    # both data_only and off: data_only tracks them as data only, and off
+    # disables discovery entirely -- neither should materialize a per-
+    # discovered-contact entity. Added/curated contacts still get one in every
+    # mode; only full creates an entity for discovered contacts. The off case
+    # matters because the setup path (async_setup_entry) has no off early-return
+    # of its own -- gating only on data_only here let a reload in off mode
+    # create a per-contact entity for every contact (the opposite of disabled).
+    # NOTE: do NOT gate on contact.get("added_to_node") here -- that field is
+    # computed only in coordinator.get_all_contacts(); raw event-payload
+    # contacts reaching this function via handle_contacts_update do not carry
+    # it, so it would falsely block added contacts too. Test membership in the
+    # added-contact set (coordinator._contacts), the same source
+    # get_all_contacts() derives added_pubkeys from. This governs both callers:
+    # the event path (no added_to_node) and the setup path (has it).
+    if get_contact_discovery_mode(coordinator.config_entry) in (
+        MODE_DATA_ONLY,
+        MODE_OFF,
+    ):
+        added_pubkeys = {
+            c.get("public_key")
+            for c in coordinator._contacts.values()
+            if c.get("public_key")
+        }
+        if public_key not in added_pubkeys:
+            return None  # discovered-only: suppressed in data_only and off
+
+    if public_key not in coordinator.tracked_diagnostic_binary_contacts:
         coordinator.tracked_diagnostic_binary_contacts.add(public_key)
         return MeshCoreContactDiagnosticBinarySensor(
             coordinator,
@@ -78,8 +109,8 @@ def handle_contacts_update(event, coordinator, async_add_entities):
     if not event or not hasattr(event, "payload") or not event.payload:
         return
 
-    # Skip contact discovery if disabled in settings
-    if coordinator.config_entry.data.get(CONF_DISABLE_CONTACT_DISCOVERY, False):
+    # Skip contact discovery entirely when discovery is disabled (mode off).
+    if get_contact_discovery_mode(coordinator.config_entry) == MODE_OFF:
         return
 
     # Initialize tracking sets if needed

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -10,6 +10,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 from bleak import BleakScanner
 from meshcore.events import EventType
 
@@ -44,10 +49,13 @@ from .const import (
     CONF_CLIENT_DISABLE_PATH_RESET,
     DEFAULT_CLIENT_UPDATE_INTERVAL,
     CONF_DEVICE_DISABLED,
-    CONF_DISABLE_CONTACT_DISCOVERY,
     CONF_LIMIT_DISCOVERED_CONTACTS,
     CONF_MAX_DISCOVERED_CONTACTS,
     DEFAULT_MAX_DISCOVERED_CONTACTS,
+    CONF_CONTACT_DISCOVERY_MODE,
+    DEFAULT_CONTACT_DISCOVERY_MODE,
+    CONTACT_DISCOVERY_MODES,
+    get_contact_discovery_mode,
     CONF_SELF_TELEMETRY_ENABLED,
     CONF_SELF_TELEMETRY_INTERVAL,
     DEFAULT_SELF_TELEMETRY_INTERVAL,
@@ -113,6 +121,23 @@ TCP_SCHEMA = vol.Schema(
         vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600))
     }
 )
+
+def _contact_discovery_mode_selector() -> SelectSelector:
+    """Build the translation-keyed select for the contact-discovery mode.
+
+    The option labels (Entity per contact / Data only / Disabled) come from the
+    selector translation key (translations/en.json -> selector.
+    contact_discovery_mode.options); the stored value is the machine string
+    ("full" / "data_only" / "off").
+    """
+    return SelectSelector(
+        SelectSelectorConfig(
+            options=list(CONTACT_DISCOVERY_MODES),
+            mode=SelectSelectorMode.DROPDOWN,
+            translation_key="contact_discovery_mode",
+        )
+    )
+
 
 async def validate_common(api: MeshCoreAPI) -> Dict[str, Any]:
     """Validate the user input allows us to connect to the USB device."""
@@ -186,7 +211,7 @@ async def validate_tcp_input(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[
 class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: ignore
     """Handle a config flow for MeshCore."""
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         """Initialize flow."""
@@ -362,6 +387,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
                     CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
                     CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
+                    CONF_CONTACT_DISCOVERY_MODE: user_input.get(CONF_CONTACT_DISCOVERY_MODE, DEFAULT_CONTACT_DISCOVERY_MODE),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -385,6 +411,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_CONTACT_DISCOVERY_MODE, default=DEFAULT_CONTACT_DISCOVERY_MODE): _contact_discovery_mode_selector(),
             }),
             errors=errors
         )
@@ -403,6 +430,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
                     CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
                     CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
+                    CONF_CONTACT_DISCOVERY_MODE: user_input.get(CONF_CONTACT_DISCOVERY_MODE, DEFAULT_CONTACT_DISCOVERY_MODE),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -435,6 +463,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                     vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
                     vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                    vol.Optional(CONF_CONTACT_DISCOVERY_MODE, default=DEFAULT_CONTACT_DISCOVERY_MODE): _contact_discovery_mode_selector(),
                 }
             )
         else:
@@ -445,6 +474,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_CONTACT_DISCOVERY_MODE, default=DEFAULT_CONTACT_DISCOVERY_MODE): _contact_discovery_mode_selector(),
             })
 
         return self.async_show_form(
@@ -466,6 +496,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                     CONF_SELF_TELEMETRY_INTERVAL: user_input.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL),
                     CONF_SELF_DIAGNOSTICS_ENABLED: user_input.get(CONF_SELF_DIAGNOSTICS_ENABLED, False),
                     CONF_SELF_DIAGNOSTICS_INTERVAL: user_input.get(CONF_SELF_DIAGNOSTICS_INTERVAL, DEFAULT_SELF_DIAGNOSTICS_INTERVAL),
+                    CONF_CONTACT_DISCOVERY_MODE: user_input.get(CONF_CONTACT_DISCOVERY_MODE, DEFAULT_CONTACT_DISCOVERY_MODE),
                     CONF_NAME: info.get("name"),
                     CONF_PUBKEY: info.get("pubkey"),
                     CONF_REPEATER_SUBSCRIPTIONS: [],
@@ -487,6 +518,7 @@ class MeshCoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN): # type: igno
                 vol.Optional(CONF_SELF_TELEMETRY_INTERVAL, default=DEFAULT_SELF_TELEMETRY_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
                 vol.Optional(CONF_SELF_DIAGNOSTICS_ENABLED, default=False): cv.boolean,
                 vol.Optional(CONF_SELF_DIAGNOSTICS_INTERVAL, default=DEFAULT_SELF_DIAGNOSTICS_INTERVAL): vol.All(cv.positive_int, vol.Range(min=60, max=3600)),
+                vol.Optional(CONF_CONTACT_DISCOVERY_MODE, default=DEFAULT_CONTACT_DISCOVERY_MODE): _contact_discovery_mode_selector(),
             }),
             errors=errors
         )
@@ -905,7 +937,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Handle global settings."""
         if user_input is not None:
             new_data = copy.deepcopy(dict(self.config_entry.data))
-            new_data[CONF_DISABLE_CONTACT_DISCOVERY] = user_input[CONF_DISABLE_CONTACT_DISCOVERY]
+            new_data[CONF_CONTACT_DISCOVERY_MODE] = user_input[CONF_CONTACT_DISCOVERY_MODE]
             new_data[CONF_LIMIT_DISCOVERED_CONTACTS] = user_input[CONF_LIMIT_DISCOVERED_CONTACTS]
             new_data[CONF_MAX_DISCOVERED_CONTACTS] = user_input[CONF_MAX_DISCOVERED_CONTACTS]
             new_data[CONF_SELF_TELEMETRY_ENABLED] = user_input[CONF_SELF_TELEMETRY_ENABLED]
@@ -930,7 +962,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
             return await self.async_step_init()
 
-        current_disable_discovery = self.config_entry.data.get(CONF_DISABLE_CONTACT_DISCOVERY, False)
+        current_contact_discovery_mode = get_contact_discovery_mode(self.config_entry)
         current_limit_enabled = self.config_entry.data.get(CONF_LIMIT_DISCOVERED_CONTACTS, False)
         current_max_contacts = self.config_entry.data.get(CONF_MAX_DISCOVERED_CONTACTS, DEFAULT_MAX_DISCOVERED_CONTACTS)
         current_telemetry_enabled = self.config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
@@ -948,7 +980,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="global_settings",
             data_schema=vol.Schema({
-                vol.Optional(CONF_DISABLE_CONTACT_DISCOVERY, default=current_disable_discovery): cv.boolean,
+                vol.Optional(CONF_CONTACT_DISCOVERY_MODE, default=current_contact_discovery_mode): _contact_discovery_mode_selector(),
                 vol.Optional(CONF_LIMIT_DISCOVERED_CONTACTS, default=current_limit_enabled): cv.boolean,
                 vol.Optional(CONF_MAX_DISCOVERED_CONTACTS, default=current_max_contacts): vol.All(cv.positive_int, vol.Range(min=1, max=10000)),
                 vol.Optional(CONF_SELF_TELEMETRY_ENABLED, default=current_telemetry_enabled): cv.boolean,

--- a/custom_components/meshcore/const.py
+++ b/custom_components/meshcore/const.py
@@ -38,6 +38,7 @@ SERVICE_REMOVE_DISCOVERED_CONTACT: Final = "remove_discovered_contact"
 SERVICE_CLEANUP_UNAVAILABLE_CONTACTS: Final = "cleanup_unavailable_contacts"
 SERVICE_CLEAR_DISCOVERED_CONTACTS: Final = "clear_discovered_contacts"
 SERVICE_GET_CONTACTS: Final = "get_contacts"
+SERVICE_GET_DISCOVERED_CONTACT: Final = "get_discovered_contact"
 SERVICE_GET_CHANNELS: Final = "get_channels"
 SERVICE_TRACE: Final = "trace"
 
@@ -89,10 +90,32 @@ CONF_DEVICE_DISABLED: Final = "disabled"
 AUTO_DISABLE_HOURS: Final = 120  # Auto-disable devices after this many hours without success
 
 # Contact discovery settings
-CONF_DISABLE_CONTACT_DISCOVERY: Final = "disable_contact_discovery"
 CONF_LIMIT_DISCOVERED_CONTACTS: Final = "limit_discovered_contacts"
 CONF_MAX_DISCOVERED_CONTACTS: Final = "max_discovered_contacts"
 DEFAULT_MAX_DISCOVERED_CONTACTS: Final = 100
+
+# Contact discovery mode: a single tri-state setting controlling how much
+# discovered-contact machinery runs. Supersedes the legacy per-flag discovery
+# settings, mapped on entry migration from the old "disable_contact_discovery"
+# and "large_mesh_mode" keys (see async_migrate_entry). Machine values are
+# stored in config_entry.data; the user-facing labels come from the translations.
+#   full      - every discovered contact gets a per-contact binary_sensor (default)
+#   data_only - discovered contacts are tracked as data only, no per-contact entity
+#   off       - discovered contacts are not processed at all
+CONF_CONTACT_DISCOVERY_MODE: Final = "contact_discovery_mode"
+MODE_FULL: Final = "full"
+MODE_DATA_ONLY: Final = "data_only"
+MODE_OFF: Final = "off"
+DEFAULT_CONTACT_DISCOVERY_MODE: Final = MODE_FULL
+CONTACT_DISCOVERY_MODES: Final = (MODE_FULL, MODE_DATA_ONLY, MODE_OFF)
+
+
+def get_contact_discovery_mode(config_entry) -> str:
+    """Return the contact-discovery mode from entry data (default full)."""
+    return config_entry.data.get(
+        CONF_CONTACT_DISCOVERY_MODE, DEFAULT_CONTACT_DISCOVERY_MODE
+    )
+
 
 # Self telemetry settings
 CONF_SELF_TELEMETRY_ENABLED: Final = "self_telemetry_enabled"

--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -59,6 +59,10 @@ from .const import (
     CONF_AUTO_CLEANUP_STALE_NEIGHBORS,
     CONF_STALE_NEIGHBOR_DAYS,
     DEFAULT_STALE_NEIGHBOR_DAYS,
+    MODE_FULL,
+    MODE_DATA_ONLY,
+    MODE_OFF,
+    get_contact_discovery_mode,
 )
 from .meshcore_api import MeshCoreAPI
 
@@ -299,6 +303,189 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
         return list(contacts_dict.values())
 
+    def _remove_discovered_contact_entities(self, public_key: str) -> bool:
+        """Remove the per-contact entities for one discovered (un-added) contact.
+
+        Removes the contact-diagnostic ``binary_sensor`` and, unless the node
+        has a repeater/client tracking subscription (whose telemetry/GPS
+        entities recreate dynamically), its telemetry and GPS-tracker entities.
+        Allowlists by unique_id SHAPE (``<entry_id>_<prefix>_*`` ending in
+        ``_telemetry`` / ``_gps_tracker``) so a bare substring match cannot hit
+        a repeater-neighbor sensor (which embeds another node's pubkey) or a
+        subscription-backed entity. Returns True if a contact binary_sensor was
+        removed.
+
+        This mirrors the data-only demote teardown in
+        ``services.async_execute_command_service`` (keep the two in sync); the
+        mode reconciler reuses it to bring the existing discovered population
+        into the configured mode.
+        """
+        # Imported in-function to avoid a module-level import cycle
+        # (services -> binary_sensor -> ... ; coordinator stays a leaf).
+        from .services import _node_has_tracked_subscription
+
+        prefix = public_key[:12]
+        entity_registry = er.async_get(self.hass)
+
+        tracked = getattr(self, "tracked_diagnostic_binary_contacts", None)
+        if tracked is not None:
+            tracked.discard(public_key)
+
+        removed = False
+        unique_id = f"{self.config_entry.entry_id}_contact_{prefix}"
+        entity_id = entity_registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, unique_id
+        )
+        if entity_id:
+            entity_registry.async_remove(entity_id)
+            removed = True
+
+        if not _node_has_tracked_subscription(self, prefix):
+            uid_prefix = f"{self.config_entry.entry_id}_{prefix}_"
+            to_remove = [
+                e.entity_id
+                for e in er.async_entries_for_config_entry(
+                    entity_registry, self.config_entry.entry_id
+                )
+                if (e.unique_id or "").startswith(uid_prefix)
+                and (
+                    e.unique_id.endswith("_telemetry")
+                    or e.unique_id.endswith("_gps_tracker")
+                )
+            ]
+            for stale_entity_id in to_remove:
+                entity_registry.async_remove(stale_entity_id)
+
+            # In-memory dedup maps: without these discards the managers keep
+            # updating deregistered entities and a same-session re-add will not
+            # recreate the sensors.
+            tm = getattr(self, "telemetry_manager", None)
+            if tm is not None:
+                for key in [k for k in tm.discovered_sensors if k.startswith(prefix)]:
+                    del tm.discovered_sensors[key]
+            dtm = getattr(self, "device_tracker_manager", None)
+            if dtm is not None:
+                for key in [
+                    k for k in dtm.discovered_trackers if k.startswith(prefix)
+                ]:
+                    del dtm.discovered_trackers[key]
+
+        return removed
+
+    async def async_reconcile_discovered_for_mode(self) -> None:
+        """Enforce the configured contact discovery mode on EXISTING contacts.
+
+        ``contact_discovery_mode`` is otherwise a creation-time gate: switching
+        modes governs new contacts but leaves the existing discovered
+        population as-is. This pass reconciles what already exists so each mode
+        is the source of truth on every setup (start / reload — and because a
+        mode change reloads the entry, on every mode switch too):
+
+        - ``full``      -- ensure every discovered contact has a per-contact
+                           entity (idempotent safety net; the platform setup
+                           create-pass and the NEW_CONTACT event path already
+                           cover the common cases).
+        - ``data_only`` -- remove the per-contact entities for discovered
+                           contacts; keep the discovered data (summary sensor /
+                           dropdown / get_discovered_contact).
+        - ``off``       -- remove the per-contact entities AND clear + persist
+                           the discovered set so it does not repopulate on the
+                           next store-load. The advert handler is gated
+                           separately (NEW_CONTACT off early-return).
+
+        Added/curated contacts are never touched: membership is tested against
+        the added set (the same source create_contact_sensor uses), unioned
+        with the SDK's authoritative contact list as a safety net so a
+        transient-empty ``_contacts`` cannot misclassify an added contact as
+        discovered. Entirely HA-side -- the companion is in manual mode and
+        never stored discovered contacts. Runs in the coordinator at
+        post-reload setup with the correct (new) coordinator reference, so it
+        does not reintroduce the pre-reload race.
+        """
+        # Reconciliation needs a trustworthy contact picture; skip when the
+        # device is not connected and reconcile on the next connected setup.
+        mesh_core = getattr(self.api, "mesh_core", None)
+        if not getattr(self.api, "connected", False) or mesh_core is None:
+            _LOGGER.debug(
+                "Contact-mode reconcile skipped: device not connected"
+            )
+            return
+
+        mode = get_contact_discovery_mode(self.config_entry)
+
+        sdk_contacts = getattr(mesh_core, "contacts", None) or {}
+        added_pubkeys = {
+            c.get("public_key")
+            for c in list(self._contacts.values()) + list(sdk_contacts.values())
+            if isinstance(c, dict) and c.get("public_key")
+        }
+
+        if mode == MODE_FULL:
+            # Create an entity for any discovered contact still lacking one.
+            # create_contact_sensor dedups via tracked_diagnostic_binary_contacts
+            # so already-created contacts are skipped (no double-create).
+            add_entities = getattr(self, "binary_sensor_async_add_entities", None)
+            if add_entities is None:
+                return
+            from .binary_sensor import create_contact_sensor
+
+            new_entities = []
+            for contact in list(self._discovered_contacts.values()):
+                if not isinstance(contact, dict):
+                    continue
+                pubkey = contact.get("public_key")
+                if pubkey and pubkey in added_pubkeys:
+                    continue  # added contacts use the normal create path
+                try:
+                    sensor = create_contact_sensor(self, contact)
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.error(
+                        "Contact-mode reconcile (full): error creating sensor: %s",
+                        ex,
+                    )
+                    continue
+                if sensor:
+                    new_entities.append(sensor)
+            if new_entities:
+                add_entities(new_entities)
+                _LOGGER.info(
+                    "Contact-mode reconcile (full): created %d missing "
+                    "discovered contact entities",
+                    len(new_entities),
+                )
+            return
+
+        # data_only / off: remove per-contact entities for discovered contacts.
+        removed = 0
+        for public_key in list(self._discovered_contacts.keys()):
+            if public_key in added_pubkeys:
+                continue  # never touch added contacts
+            if self._remove_discovered_contact_entities(public_key):
+                removed += 1
+
+        if mode == MODE_OFF:
+            # Disabled: do not keep/track discovered contacts. Clear and persist
+            # the empty set so the next store-load does not repopulate it.
+            self._discovered_contacts.clear()
+            try:
+                await self._store.async_save(self._discovered_contacts)
+            except Exception as ex:  # noqa: BLE001
+                _LOGGER.error(
+                    "Contact-mode reconcile (off): error saving cleared set: %s",
+                    ex,
+                )
+
+        if removed or mode == MODE_OFF:
+            updated_data = dict(self.data) if self.data else {}
+            updated_data["contacts"] = self.get_all_contacts()
+            self.async_set_updated_data(updated_data)
+            _LOGGER.info(
+                "Contact-mode reconcile (%s): removed %d discovered contact "
+                "entities",
+                mode,
+                removed,
+            )
+
     async def async_evict_discovered_contacts(self, max_contacts: int) -> bool:
         """Evict oldest discovered contacts using FIFO ordering when over the limit.
 
@@ -314,6 +501,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
 
         entity_registry = er.async_get(self.hass)
 
+        # Removal runs unconditionally. In data-only/off modes discovered
+        # contacts have no per-contact entity, so async_get_entity_id below
+        # returns None and the removal is a harmless no-op; the dict trim still
+        # bounds the discovered set by max_contacts. Running it in every mode
+        # also clears any entity orphaned by a prior mode switch.
         for public_key in keys_to_evict:
             pubkey_prefix = public_key[:12]
             del self._discovered_contacts[public_key]
@@ -383,6 +575,11 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         # when stale_keys is empty; Phase 4 still runs.
         removed_count = 0
 
+        # Removal runs unconditionally. In data-only/off modes discovered
+        # contacts have no per-contact entity, so the registry lookup returns
+        # None and removal is a no-op; the dict trim still removes stale
+        # contacts. Running it in every mode also clears any entity orphaned by
+        # a prior mode switch.
         for i, public_key in enumerate(stale_keys):
             contact = self._discovered_contacts.get(public_key)
             if contact is None:

--- a/custom_components/meshcore/sensor.py
+++ b/custom_components/meshcore/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 from homeassistant.helpers.update_coordinator import (
@@ -31,9 +31,13 @@ from .const import (
     CONF_REPEATER_NEIGHBORS_ENABLED,
     CONF_TRACKED_CLIENTS,
     CONF_SELF_DIAGNOSTICS_ENABLED,
+    CONF_LIMIT_DISCOVERED_CONTACTS,
+    CONF_MAX_DISCOVERED_CONTACTS,
+    DEFAULT_MAX_DISCOVERED_CONTACTS,
     SENSOR_AVAILABILITY_TIMEOUT_MULTIPLIER,
     NEIGHBOR_STALE_THRESHOLD,
     SEEN_WINDOW_SECS,
+    NodeType,
 )
 from .utils import (
     format_entity_id,
@@ -47,6 +51,12 @@ _LOGGER = logging.getLogger(__name__)
 # Sensor key suffixes
 UTILIZATION_SUFFIX = "_utilization"
 RATE_SUFFIX = "_rate"
+
+# A discovered contact is "fresh" if its last advert was heard within this
+# window. Mirrors the per-contact binary_sensor freshness threshold
+# (binary_sensor.py: 12 hours) so the summary's fresh/stale split matches what
+# users already see on the individual contact entities.
+DISCOVERED_FRESH_WINDOW_SECS = 3600 * 12
 
 # Path tracking sensors for repeaters and clients
 PATH_SENSORS = [
@@ -633,6 +643,12 @@ async def async_setup_entry(
     # Add message delivery status sensor (tracks repeater count for channel msgs, ACK for direct msgs)
     delivery_sensor = LastMessageDeliverySensor(coordinator)
     entities.append(delivery_sensor)
+
+    # Add the aggregate discovered-contact summary sensor. Created in both
+    # modes (useful to default-mode users deciding whether to enable large
+    # mesh mode), but registered disabled-by-default so it imposes no recorder
+    # cost until a user opts to chart it. See MeshCoreDiscoveredSummarySensor.
+    entities.append(MeshCoreDiscoveredSummarySensor(coordinator))
 
     async_add_entities(entities)
 
@@ -2084,3 +2100,141 @@ class MeshCoreNeighborCountSensor(CoordinatorEntity, SensorEntity):
             if n.get("secs_ago", 0) < NEIGHBOR_STALE_THRESHOLD
         )
         return {"active": active, "stale": len(neighbors) - active}
+
+
+class MeshCoreDiscoveredSummarySensor(CoordinatorEntity, SensorEntity):
+    """Aggregate summary of discovered (un-added) contacts on the main device.
+
+    State is the total discovered-contact count. Attributes carry a small,
+    bounded rollup (fresh/stale split, per-type counts, the single most-recent
+    advert, and capacity headroom) so the discovered contacts in data-only mode
+    remain inspectable at a glance without one entity per contact.
+
+    Registered disabled-by-default and under the diagnostic category. The state
+    is a count that changes on every advert, so leaving it enabled would write
+    a recorder time-series on every install -- including dense-mesh users who
+    never opted in -- which is the exact recorder churn data-only mode exists
+    to reduce. Disabled-by-default keeps it free until a user chooses to chart
+    it. The attribute payload is counts + one sample, so its size is constant
+    regardless of how many contacts are discovered.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:account-search"
+    _attr_name = "Discovered Contacts"
+
+    def __init__(self, coordinator: MeshCoreDataUpdateCoordinator) -> None:
+        """Initialize the discovered-contact summary sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+        public_key_short = coordinator.pubkey[:6] if coordinator.pubkey else ""
+
+        self._attr_unique_id = "_".join([
+            coordinator.config_entry.entry_id,
+            "discovered_summary",
+        ])
+
+        self.entity_id = format_entity_id(
+            ENTITY_DOMAIN_SENSOR,
+            public_key_short,
+            "discovered_summary",
+            sanitize_name(coordinator.name or "Unknown"),
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (attach to the main companion device)."""
+        return self.coordinator.device_info
+
+    @property
+    def translation_key(self) -> str:
+        """Return the translation key."""
+        return "discovered_summary"
+
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def native_value(self) -> int:  # type: ignore[override]
+        """Return the total number of discovered (un-added) contacts."""
+        return len(self.coordinator._discovered_contacts)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:  # type: ignore[override]
+        """Return a bounded rollup of the discovered-contact set.
+
+        Shape is constant regardless of contact count: scalar counts, a
+        fixed-key per-type breakdown, one newest-advert sample, and capacity
+        headroom. No per-contact detail is emitted.
+        """
+        discovered = self.coordinator._discovered_contacts
+        now = time.time()
+
+        # Fixed-key per-type breakdown so the attribute shape never changes.
+        by_type: Dict[str, int] = {
+            "chat": 0,           # NodeType.CLIENT
+            "repeater": 0,       # NodeType.REPEATER
+            "room_server": 0,    # NodeType.ROOM_SERVER
+            "sensor": 0,         # NodeType.SENSOR
+            "unknown": 0,        # missing / unrecognized type
+        }
+        type_key = {
+            NodeType.CLIENT: "chat",
+            NodeType.REPEATER: "repeater",
+            NodeType.ROOM_SERVER: "room_server",
+            NodeType.SENSOR: "sensor",
+        }
+
+        fresh_count = 0
+        newest_contact = None
+        newest_advert = -1.0
+        for contact in discovered.values():
+            last_advert = contact.get("last_advert", 0) or 0
+            if last_advert and (now - last_advert) < DISCOVERED_FRESH_WINDOW_SECS:
+                fresh_count += 1
+            by_type[type_key.get(contact.get("type"), "unknown")] += 1
+            if last_advert > newest_advert:
+                newest_advert = last_advert
+                newest_contact = contact
+
+        total = len(discovered)
+
+        if newest_contact is not None:
+            newest_pubkey = newest_contact.get("public_key", "") or ""
+            newest = {
+                "adv_name": newest_contact.get("adv_name", "Unknown"),
+                "pubkey_short": newest_pubkey[:12],
+                "last_advert": newest_contact.get("last_advert", 0) or 0,
+            }
+        else:
+            newest = None
+
+        # Capacity headroom: only meaningful when the discovered-contact limit
+        # is enabled; otherwise the set is unbounded by count.
+        if self.coordinator.config_entry.data.get(CONF_LIMIT_DISCOVERED_CONTACTS, False):
+            max_contacts = self.coordinator.config_entry.data.get(
+                CONF_MAX_DISCOVERED_CONTACTS, DEFAULT_MAX_DISCOVERED_CONTACTS
+            )
+            capacity: Any = max_contacts
+            capacity_used_pct: Any = (
+                round(100.0 * total / max_contacts, 1) if max_contacts else None
+            )
+        else:
+            capacity = "unlimited"
+            capacity_used_pct = None
+
+        return {
+            "fresh_count": fresh_count,
+            "stale_count": total - fresh_count,
+            "by_type": by_type,
+            "newest": newest,
+            "capacity": capacity,
+            "capacity_used_pct": capacity_used_pct,
+        }

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -37,6 +37,8 @@ _SELF_INFO_COMMANDS = frozenset({
 
 from .const import (
     ATTR_PUBKEY_PREFIX,
+    MODE_DATA_ONLY,
+    get_contact_discovery_mode,
     DOMAIN,
     SERVICE_SEND_MESSAGE,
     SERVICE_SEND_CHANNEL_MESSAGE,
@@ -49,6 +51,7 @@ from .const import (
     SERVICE_CLEANUP_UNAVAILABLE_CONTACTS,
     SERVICE_CLEAR_DISCOVERED_CONTACTS,
     SERVICE_GET_CONTACTS,
+    SERVICE_GET_DISCOVERED_CONTACT,
     SERVICE_GET_CHANNELS,
     SERVICE_TRACE,
     SELECT_NO_CONTACTS,
@@ -156,6 +159,21 @@ def _resolve_contact(arg: str, command_name: str, api: Any, coordinator: Any) ->
     if contact:
         return _ensure_contact_compat(contact)
     return contact
+
+
+def _node_has_tracked_subscription(coordinator, pubkey_prefix: str) -> bool:
+    """True when the node has a repeater/client tracking subscription.
+
+    Subscription-backed telemetry/GPS entities recreate dynamically, so
+    demote-cleanup must not sweep them; their lifecycle follows the
+    subscription. Bidirectional startswith matches the convention used
+    for subscription lookups elsewhere (varying prefix lengths).
+    """
+    for cfg in list(coordinator._tracked_repeaters or []) + list(coordinator._tracked_clients or []):
+        cp = cfg.get("pubkey_prefix", "")
+        if cp and (pubkey_prefix.startswith(cp) or cp.startswith(pubkey_prefix)):
+            return True
+    return False
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -743,6 +761,87 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                                 # Mark contact as dirty so binary sensors update
                                 coordinator.mark_contact_dirty(prefix)
 
+                                # Data-only mode: a demoted contact (added ->
+                                # discovered) becomes data-only, so its per-contact
+                                # binary_sensor must be removed. In data-only mode
+                                # nothing else deletes it -- the discovered-cleanup
+                                # paths only find an entity when one exists, and a
+                                # demoted contact's entity must go immediately rather
+                                # than wait for eviction/stale-cleanup. In full mode
+                                # the contact stays a valid discovered entity, so this
+                                # block is gated off and the entity is left untouched.
+                                # NOTE: this gate is the INVERSE of the discovered-
+                                # cleanup paths; data-only mode is exactly when the
+                                # entity must go. Discard the FULL public_key (the key
+                                # create_contact_sensor added), not the 12-hex prefix.
+                                if (
+                                    get_contact_discovery_mode(coordinator.config_entry)
+                                    == MODE_DATA_ONLY
+                                ):
+                                    coordinator.tracked_diagnostic_binary_contacts.discard(pubkey)
+                                    entity_registry = er.async_get(hass)
+                                    unique_id = f"{coordinator.config_entry.entry_id}_contact_{prefix}"
+                                    entity_id = entity_registry.async_get_entity_id(
+                                        "binary_sensor", DOMAIN, unique_id
+                                    )
+                                    if entity_id:
+                                        _LOGGER.info(
+                                            "Data-only mode: removing entity for demoted contact %s",
+                                            entity_id,
+                                        )
+                                        entity_registry.async_remove(entity_id)
+
+                                    # Telemetry sensors and the GPS tracker are created
+                                    # dynamically while a contact is added and have no
+                                    # other demote teardown. Sweep them too -- except
+                                    # for nodes with a tracked-device subscription,
+                                    # whose entities are subscription-backed and would
+                                    # recreate on the next response.
+                                    # Allowlist by unique_id SHAPE (prefix + suffix):
+                                    # a bare "contains pubkey" match would wrongly hit
+                                    # repeater-neighbor sensors (they embed OTHER
+                                    # nodes' pubkeys) and tracked-client entities.
+                                    if not _node_has_tracked_subscription(coordinator, prefix):
+                                        uid_prefix = (
+                                            f"{coordinator.config_entry.entry_id}_{prefix}_"
+                                        )
+                                        to_remove = [
+                                            e.entity_id
+                                            for e in er.async_entries_for_config_entry(
+                                                entity_registry,
+                                                coordinator.config_entry.entry_id,
+                                            )
+                                            if (e.unique_id or "").startswith(uid_prefix)
+                                            and (
+                                                e.unique_id.endswith("_telemetry")
+                                                or e.unique_id.endswith("_gps_tracker")
+                                            )
+                                        ]
+                                        for stale_entity_id in to_remove:
+                                            _LOGGER.info(
+                                                "Data-only mode: removing telemetry/GPS entity for demoted contact %s",
+                                                stale_entity_id,
+                                            )
+                                            entity_registry.async_remove(stale_entity_id)
+
+                                        # In-memory dedup maps: without these discards
+                                        # the managers keep updating deregistered
+                                        # entities and a same-session re-add will not
+                                        # recreate the sensors (same desync class as
+                                        # the tracked-set discard above).
+                                        tm = getattr(coordinator, "telemetry_manager", None)
+                                        if tm is not None:
+                                            for key in [
+                                                k for k in tm.discovered_sensors if k.startswith(prefix)
+                                            ]:
+                                                del tm.discovered_sensors[key]
+                                        dtm = getattr(coordinator, "device_tracker_manager", None)
+                                        if dtm is not None:
+                                            for key in [
+                                                k for k in dtm.discovered_trackers if k.startswith(prefix)
+                                            ]:
+                                                del dtm.discovered_trackers[key]
+
                                 updated_data = dict(coordinator.data) if coordinator.data else {}
                                 updated_data["contacts"] = coordinator.get_all_contacts()
                                 coordinator.async_set_updated_data(updated_data)
@@ -1057,7 +1156,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         updated_data["contacts"] = coordinator.get_all_contacts()
         coordinator.async_set_updated_data(updated_data)
 
-        # Remove the binary sensor entity for this contact.
+        # Remove the binary sensor entity for this contact. Removal runs
+        # unconditionally: in data-only/off modes discovered contacts have no
+        # entity, so async_get_entity_id returns None and this is a no-op (and
+        # also clears any entity orphaned by a prior mode switch).
         # Post-PR-#236 contact unique_ids are scoped by entry_id; the migration
         # at __init__.py:_migrate_unique_ids_scope_contact_diagnostics guarantees
         # every existing entity uses this format.
@@ -1160,6 +1262,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             entity_registry = er.async_get(hass)
             removed_count = len(coordinator._discovered_contacts)
 
+            # Removal runs unconditionally. In data-only/off modes discovered
+            # contacts have no per-contact entity, so async_get_entity_id
+            # returns None and the removal is a no-op; the dict clear below is
+            # the whole operation. Running it in every mode also clears any
+            # entity orphaned by a prior mode switch.
             for public_key in list(coordinator._discovered_contacts.keys()):
                 pubkey_prefix = public_key[:12]
                 coordinator.tracked_diagnostic_binary_contacts.discard(public_key)
@@ -1256,6 +1363,62 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_GET_CONTACTS,
         async_get_contacts_service,
         schema=vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string}),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def async_get_discovered_contact_service(call: ServiceCall) -> dict:
+        """Return the full data dict for a single discovered contact.
+
+        In data-only mode discovered contacts have no per-contact entity, so
+        this is the supported way to inspect one. ``pubkey_prefix`` matches any
+        discovered contact whose full public key starts with the given value
+        (the 12-char prefix shown in the discovered-contact dropdown works, as
+        does a full key). The returned dict carries only data already exposed
+        via ``get_contacts`` and the dropdown -- pubkeys are mesh-advertised,
+        not secret -- so this opens no new data-exposure surface.
+        """
+        entry_id = call.data.get(ATTR_ENTRY_ID)
+        pubkey_prefix = call.data.get(ATTR_PUBKEY_PREFIX)
+        # Defense-in-depth for direct / non-schema callers: an empty or 1-char
+        # prefix would match an arbitrary contact (str.startswith("") is always
+        # True). The vol.Schema min-length below is the primary boundary check;
+        # this inline guard protects callers that bypass schema validation.
+        if not pubkey_prefix or len(pubkey_prefix) < 2:
+            return {"contact": None, "error": "invalid_prefix"}
+        coordinator = _resolve_coordinator(entry_id)
+        if coordinator is None:
+            return {"contact": None, "error": "no_coordinator"}
+
+        match = None
+        try:
+            for pubkey, contact in coordinator._discovered_contacts.items():
+                if pubkey.startswith(pubkey_prefix):
+                    match = contact
+                    break
+        except Exception as ex:
+            _LOGGER.error("get_discovered_contact: coordinator access failed: %s", ex)
+            return {"contact": None, "error": "coordinator_error"}
+
+        if match is None:
+            return {"contact": None, "error": "not_found", "pubkey_prefix": pubkey_prefix}
+
+        c = _ensure_contact_compat(dict(match))
+        pk = c.get("public_key") or ""
+        if pk and "pubkey_prefix" not in c:
+            c["pubkey_prefix"] = pk[:12]
+        return {"contact": c}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_DISCOVERED_CONTACT,
+        async_get_discovered_contact_service,
+        schema=vol.Schema({
+            # Min length 2 is the canonical input-validation boundary (security
+            # rubric S-04): rejects the empty/1-char prefix that would match an
+            # arbitrary discovered contact via str.startswith.
+            vol.Required(ATTR_PUBKEY_PREFIX): vol.All(cv.string, vol.Length(min=2)),
+            vol.Optional(ATTR_ENTRY_ID): cv.string,
+        }),
         supports_response=SupportsResponse.ONLY,
     )
 
@@ -1664,6 +1827,9 @@ async def async_unload_services(hass: HomeAssistant) -> None:
 
     if hass.services.has_service(DOMAIN, SERVICE_GET_CONTACTS):
         hass.services.async_remove(DOMAIN, SERVICE_GET_CONTACTS)
+
+    if hass.services.has_service(DOMAIN, SERVICE_GET_DISCOVERED_CONTACT):
+        hass.services.async_remove(DOMAIN, SERVICE_GET_DISCOVERED_CONTACT)
 
     if hass.services.has_service(DOMAIN, SERVICE_GET_CHANNELS):
         hass.services.async_remove(DOMAIN, SERVICE_GET_CHANNELS)

--- a/custom_components/meshcore/services.yaml
+++ b/custom_components/meshcore/services.yaml
@@ -206,6 +206,31 @@ get_contacts:
       selector:
         text:
 
+get_discovered_contact:
+  name: Get Discovered Contact
+  description: >-
+    Return the full data dict for a single discovered (un-added) contact,
+    matched by public-key prefix. In data-only mode discovered contacts have
+    no per-contact entity, so this is the supported way to inspect one. The
+    returned data is the same already exposed via get_contacts and the
+    discovered-contact dropdown.
+  response: only
+  fields:
+    pubkey_prefix:
+      name: Public Key Prefix
+      description: The public key prefix (e.g. the 12-character prefix shown in the discovered-contact dropdown) of the contact to look up. A full public key also works.
+      required: true
+      example: "f293ac1b2c3d"
+      selector:
+        text:
+    entry_id:
+      name: Config Entry ID
+      description: The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device.
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+
 get_channels:
   name: Get Channels
   description: >-

--- a/custom_components/meshcore/translations/en.json
+++ b/custom_components/meshcore/translations/en.json
@@ -29,10 +29,12 @@
           "usb_path": "USB Device Path",
           "baudrate": "Connection Speed",
           "self_diagnostics_enabled": "Enable Self Diagnostics",
-          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)",
+          "contact_discovery_mode": "Contact Discovery Mode"
         },
         "data_description": {
-          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
+          "contact_discovery_mode": "Entity per contact: every discovered contact gets its own entity (best for small meshes). Data only: discovered contacts are tracked as data only with no per-contact entity -- inspect them via the dropdown or the Get Discovered Contact service. Disabled: contact discovery is turned off entirely and any existing discovered contacts are cleared."
         },
         "description": "Connect to your MeshCore node via USB",
         "title": "Configure USB Connection"
@@ -41,10 +43,12 @@
         "data": {
           "ble_address": "Bluetooth Device",
           "self_diagnostics_enabled": "Enable Self Diagnostics",
-          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)",
+          "contact_discovery_mode": "Contact Discovery Mode"
         },
         "data_description": {
-          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
+          "contact_discovery_mode": "Entity per contact: every discovered contact gets its own entity (best for small meshes). Data only: discovered contacts are tracked as data only with no per-contact entity -- inspect them via the dropdown or the Get Discovered Contact service. Disabled: contact discovery is turned off entirely and any existing discovered contacts are cleared."
         },
         "description": "Connect to your MeshCore node via Bluetooth",
         "title": "Configure Bluetooth Connection"
@@ -54,10 +58,12 @@
           "tcp_host": "Host Address",
           "tcp_port": "Port",
           "self_diagnostics_enabled": "Enable Self Diagnostics",
-          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)"
+          "self_diagnostics_interval": "Self Diagnostics Interval (seconds)",
+          "contact_discovery_mode": "Contact Discovery Mode"
         },
         "data_description": {
-          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds)."
+          "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
+          "contact_discovery_mode": "Entity per contact: every discovered contact gets its own entity (best for small meshes). Data only: discovered contacts are tracked as data only with no per-contact entity -- inspect them via the dropdown or the Get Discovered Contact service. Disabled: contact discovery is turned off entirely and any existing discovered contacts are cleared."
         },
         "description": "Connect to your MeshCore node over the network",
         "title": "Configure Network Connection"
@@ -151,7 +157,7 @@
       },
       "global_settings": {
         "data": {
-          "disable_contact_discovery": "Disable Contact Discovery",
+          "contact_discovery_mode": "Contact Discovery Mode",
           "limit_discovered_contacts": "Limit Discovered Contacts",
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
@@ -168,6 +174,7 @@
         },
         "data_description": {
           "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
+          "contact_discovery_mode": "Entity per contact: every discovered contact gets its own entity (best for small meshes). Data only: discovered contacts are tracked as data only with no per-contact entity -- inspect them via the dropdown or the Get Discovered Contact service. Disabled: contact discovery is turned off entirely and any existing discovered contacts are cleared.",
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
@@ -279,7 +286,7 @@
       },
       "global_settings": {
         "data": {
-          "disable_contact_discovery": "Disable Contact Discovery",
+          "contact_discovery_mode": "Contact Discovery Mode",
           "limit_discovered_contacts": "Limit Discovered Contacts",
           "max_discovered_contacts": "Maximum Discovered Contacts",
           "self_telemetry_enabled": "Enable Self Telemetry",
@@ -296,6 +303,7 @@
         },
         "data_description": {
           "self_diagnostics_enabled": "Creates roughly 15 local diagnostic sensors for the companion node (uptime, TX queue length, noise floor, last RSSI/SNR, TX/RX airtime, and packet counters). Off by default. Adds no mesh traffic — these are local queries to the attached radio, not mesh requests. The interval controls how often the sensors refresh (60–3600 seconds).",
+          "contact_discovery_mode": "Entity per contact: every discovered contact gets its own entity (best for small meshes). Data only: discovered contacts are tracked as data only with no per-contact entity -- inspect them via the dropdown or the Get Discovered Contact service. Disabled: contact discovery is turned off entirely and any existing discovered contacts are cleared.",
           "map_upload_enabled": "When enabled, adverts from repeaters and room servers you receive are uploaded to map.meshcore.io. Those nodes appear on the official MeshCore map for the community. Requires private key export enabled on the firmware (`ENABLE_PRIVATE_KEY_EXPORT=1`); without it, uploads cannot be signed.",
           "auto_cleanup_stale_contacts": "When enabled, discovered contacts whose last update is older than the configured threshold are automatically removed once per day. Contacts saved to the node are always preserved.",
           "auto_cleanup_stale_neighbors": "Automatically remove neighbor entries and their sensor entities when they haven't been heard from in the configured number of days.",
@@ -468,6 +476,20 @@
           "description": "The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device."
         }
       }
+    },
+    "get_discovered_contact": {
+      "name": "Get Discovered Contact",
+      "description": "Return the full data dict for a single discovered (un-added) contact, matched by public-key prefix. In data-only mode discovered contacts have no per-contact entity, so this is the supported way to inspect one.",
+      "fields": {
+        "pubkey_prefix": {
+          "name": "Public Key Prefix",
+          "description": "The public key prefix (e.g. the 12-character prefix shown in the discovered-contact dropdown) of the contact to look up. A full public key also works."
+        },
+        "entry_id": {
+          "name": "Config Entry ID",
+          "description": "The config entry ID if you have multiple MeshCore devices. Leave empty to use the first available device."
+        }
+      }
     }
   },
   "issues": {
@@ -630,6 +652,15 @@
       },
       "recv_errors_rate": {
         "name": "Receive Errors Rate"
+      }
+    }
+  },
+  "selector": {
+    "contact_discovery_mode": {
+      "options": {
+        "full": "Entity per contact",
+        "data_only": "Data only",
+        "off": "Disabled"
       }
     }
   }

--- a/docs/docs/contacts.md
+++ b/docs/docs/contacts.md
@@ -44,30 +44,33 @@ When a device broadcasts on the mesh network, the integration:
 3. Creates a diagnostic binary sensor showing the contact as "discovered"
 4. Makes it available in the "Discovered Contacts" dropdown
 
-#### Disabling Contact Discovery
+#### Contact Discovery Mode
 
-If you have many contacts on your mesh network but only want to track specific repeaters or clients, you can disable automatic contact discovery:
+How much per-discovered-contact machinery the integration creates is controlled by a single **Contact Discovery Mode** setting with three choices:
 
-**To disable:**
+- **Entity per contact** (default) — every discovered contact gets its own diagnostic binary sensor, exactly as before. Choose this if you rely on per-discovered-contact connectivity state, history charting, or per-contact automations.
+- **Data only** — discovered (un-added) contacts are tracked as data only, with no per-contact entity, while contacts you add to your node keep their entities exactly as before. This mirrors the firmware's own two-tier model: a transient "advert heard" tier (discovered → data only) versus a durable "stored contact" tier (added → always an entity). On dense meshes this avoids hundreds of low-utility binary sensors sitting permanently in the `discovered` state, and the entity-registry churn their create/evict/cleanup drives.
+- **Disabled** — no discovered-contact processing at all: no contact binary sensors are created, discovered contacts are not persisted to storage, and the discovered/added selectors do not populate. Choose this if you only ever track specific repeaters or clients and want the lowest possible entity count.
+
+**To set it:**
 1. Go to **Settings → Devices & Services**
 2. Find your MeshCore integration
 3. Click **Configure**
 4. Select **Global Settings**
-5. Enable **Disable Contact Discovery**
+5. Choose a **Contact Discovery Mode**
 6. Click **Submit**
 
-**When disabled:**
-- No contact binary sensors are automatically created
-- Discovered contacts are not persisted to storage
-- Contact selectors (discovered/added) will not populate
-- Reduces overhead if you have 50+ contacts on the network
-- You can still manually track specific devices using repeater/client tracking
+It can also be set at install time — the **Contact Discovery Mode** selector appears in the USB, Bluetooth, and Network setup steps. The same setting is used either way, so it can be changed later in Global Settings.
 
-**When to use:**
-- Large mesh networks with many nodes you don't need to monitor
-- Performance optimization when you only care about tracked repeaters/clients
-- Reducing entity count in Home Assistant
-- You want to use services/automations without contact entities
+**What still works in Data only mode:**
+- The **Discovered Contacts** dropdown still lists every discovered contact (it reads coordinator data, not entities)
+- Adding a discovered contact still works — promotion to your node creates its entity exactly as before
+- Messaging, channels, repeater/neighbor telemetry, the chat panel, and all services are unaffected (none are per-discovered-contact)
+- The aggregate [Discovered Contact Summary sensor](#discovered-contact-summary-sensor) and the [`get_discovered_contact` service](#get-discovered-contact) keep the data-only contacts inspectable
+
+**The one trade-off (Data only):** discovered contacts no longer have an individual `binary_sensor`, so you lose per-discovered-contact connectivity state, history charting, and per-contact automations *for un-added contacts*. Added contacts are unaffected. If you rely on per-discovered-contact entities, use **Entity per contact** (the default).
+
+Switching an existing install to **Data only** or **Disabled** leaves any per-discovered-contact entities created under a previous mode in place until the next discovered-contact cleanup removes them; run the [Clear Discovered Contacts](#clearing-discovered-contacts) service after switching to remove them immediately. The contact-selector entities and all added-contact entities are always preserved.
 
 #### Limiting Discovered Contacts
 
@@ -215,6 +218,35 @@ service: meshcore.remove_discovered_contact
 
 **Note**: This only removes the contact from Home Assistant's discovered list and removes the binary sensor entity. It does **NOT** remove the contact from your node's contact list. Use this to clean up discovered contacts you don't want to track.
 
+### Get Discovered Contact
+
+Return the full data dict for a single discovered (un-added) contact, matched by public-key prefix. This is the supported way to inspect a discovered contact in [Data only mode](#contact-discovery-mode), where discovered contacts have no per-contact entity:
+
+```yaml
+service: meshcore.get_discovered_contact
+data:
+  pubkey_prefix: 1a2b3c4d5e6f
+```
+
+The `pubkey_prefix` accepts the 12-character prefix shown in the discovered-contact dropdown, or a full public key. This service returns a response (`SupportsResponse.ONLY`); call it from a script/automation with `response_variable`, or use **Developer Tools → Actions** and check **Return response**:
+
+```yaml
+action: meshcore.get_discovered_contact
+data:
+  pubkey_prefix: 1a2b3c4d5e6f
+response_variable: result
+```
+
+The response is `{"contact": { ...full contact dict... }}` on a match, or `{"contact": null, "error": "not_found", "pubkey_prefix": "..."}` when no discovered contact starts with that prefix. The returned data is the same already exposed via `get_contacts` and the dropdown — pubkeys are mesh-advertised, not secret.
+
+For multiple devices, specify the entry_id:
+```yaml
+service: meshcore.get_discovered_contact
+data:
+  pubkey_prefix: 1a2b3c4d5e6f
+  entry_id: "abc123def456"
+```
+
 ### Cleanup Unavailable Contacts
 
 After removing contacts, their sensors become unavailable but remain in your entity list. Use this service to remove all unavailable contact sensors at once:
@@ -354,6 +386,20 @@ Sensors show different icons based on node type and state:
 ### Entity Pictures
 
 Contact sensors include custom entity pictures showing the node type and status with visual indicators.
+
+### Discovered Contact Summary Sensor
+
+The integration also creates one aggregate summary sensor per device, `sensor.meshcore_<node>_discovered_summary`, whose state is the total count of discovered contacts. It is useful in every mode — and is the at-a-glance rollup for the data-only contacts in [Data only mode](#contact-discovery-mode).
+
+Attributes are a small, bounded rollup (constant in size regardless of how many contacts are discovered):
+
+- `fresh_count` / `stale_count` — split on the 12-hour advert freshness window
+- `by_type` — counts by node type: `chat`, `repeater`, `room_server`, `sensor`, `unknown`
+- `newest` — the most-recently-heard advert: `adv_name`, `pubkey_short` (12-char prefix), `last_advert`
+- `capacity` — `max_discovered_contacts` when **Limit Discovered Contacts** is enabled, otherwise `unlimited`
+- `capacity_used_pct` — percent of capacity in use (only when the limit is enabled)
+
+This sensor is **disabled by default** and lives under the **diagnostic** category. Its state changes on every advert, so leaving it always-on would write a recorder time-series on every install — exactly the recorder churn the Data only and Disabled modes exist to reduce. Enable it from the entity's settings only if you want to chart the discovered count; the `by_type` / `newest` attributes are then chartable too.
 
 ## Automatic Contact Syncing
 

--- a/docs/docs/sensors.md
+++ b/docs/docs/sensors.md
@@ -222,6 +222,10 @@ Binary sensors showing node freshness:
   - On = Fresh (recent activity within 12 hours)
   - Off = Stale (no recent activity)
 
+:::note
+In [Data only mode](contacts.md#contact-discovery-mode) these per-contact binary sensors are **not** created for discovered (un-added) contacts — they are tracked as data only. Added contacts keep their status sensor. The aggregate [Discovered Contact Summary sensor](contacts.md#discovered-contact-summary-sensor) provides a rollup count in every mode.
+:::
+
 #### Radio Fault Flags (Diagnostic)
 
 Three binary sensors decode the companion radio's `errors` bitmask. They are created only when **Self Diagnostics** is enabled. The firmware latches each flag on first occurrence and clears it only on a radio reboot, so **On** means "this fault has occurred at least once since the radio last booted," not "is occurring now."

--- a/tests/test_contact_discovery_migration.py
+++ b/tests/test_contact_discovery_migration.py
@@ -1,0 +1,232 @@
+"""Tests for the contact-discovery-mode constants, accessor, and the v2->v3
+config-entry migration that collapses the two legacy discovery booleans into
+the single ``contact_discovery_mode`` tri-state.
+
+Unlike the standalone-logic-copy tests in this suite (e.g.
+``test_large_mesh_mode.py``, which mirror gate logic because the modules under
+test subclass mocked HA entity classes), the migration logic lives in a plain
+``async def async_migrate_entry`` in ``custom_components/meshcore/__init__.py``
+with no un-loadable dependencies. We therefore load the *real* ``const.py`` and
+the *real* ``__init__.py`` via importlib (mirroring ``test_flood_scope.py``'s
+real-module load) and exercise the actual migration -- so the v1->v3 chained
+case genuinely guards the standalone-``if`` requirement (an accidental ``elif``
+would strand v1 entries at v2 and this test would fail).
+
+The heavy package dependencies ``__init__.py`` imports (the coordinator, API,
+uploaders, services, the meshcore SDK, and Home Assistant itself) are stubbed;
+only ``const.py`` is loaded for real, so the migration sees real CONF_*/MODE_*
+values.
+"""
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+_PKG = "custom_components.meshcore"
+_BASE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "custom_components", "meshcore"
+)
+
+# --- Stub the heavy deps __init__.py imports at module load -------------------
+_STUBS = (
+    "meshcore",
+    "meshcore.events",
+    "homeassistant",
+    "homeassistant.config_entries",
+    "homeassistant.const",
+    "homeassistant.core",
+    "homeassistant.exceptions",
+    "homeassistant.components",
+    "homeassistant.components.http",
+    "homeassistant.helpers",
+    "homeassistant.helpers.entity_registry",
+    "homeassistant.helpers.issue_registry",
+    "homeassistant.helpers.device_registry",
+    f"{_PKG}.coordinator",
+    f"{_PKG}.meshcore_api",
+    f"{_PKG}.map_uploader",
+    f"{_PKG}.mqtt_uploader",
+    f"{_PKG}.services",
+    f"{_PKG}.utils",
+)
+for _m in _STUBS:
+    sys.modules[_m] = MagicMock()
+
+# Real parent package so the relative imports inside __init__.py resolve.
+_cc = types.ModuleType("custom_components")
+_cc.__path__ = [os.path.dirname(_BASE)]
+sys.modules["custom_components"] = _cc
+
+
+def _load_real(modname: str, filename: str):
+    """Load a real integration module from file, bypassing the conftest stub."""
+    spec = importlib.util.spec_from_file_location(
+        modname, os.path.join(_BASE, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = _PKG
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Real const first, so __init__.py's ``from .const import ...`` binds real values.
+const = _load_real(f"{_PKG}.const", "const.py")
+
+# Real package __init__ (the module under test). Registered as the package
+# itself so its relative imports resolve against the stubs / real const above.
+_init_spec = importlib.util.spec_from_file_location(
+    _PKG, os.path.join(_BASE, "__init__.py"), submodule_search_locations=[_BASE]
+)
+_meshcore_init = importlib.util.module_from_spec(_init_spec)
+_meshcore_init.__package__ = _PKG
+sys.modules[_PKG] = _meshcore_init
+_init_spec.loader.exec_module(_meshcore_init)
+
+async_migrate_entry = _meshcore_init.async_migrate_entry
+
+CONF_MODE = const.CONF_CONTACT_DISCOVERY_MODE
+MODE_FULL = const.MODE_FULL
+MODE_DATA_ONLY = const.MODE_DATA_ONLY
+MODE_OFF = const.MODE_OFF
+
+_LEGACY_DISABLE = "disable_contact_discovery"
+_LEGACY_LARGE_MESH = "large_mesh_mode"
+
+
+class _FakeEntry:
+    """Minimal ConfigEntry stand-in carrying mutable version + data."""
+
+    def __init__(self, version, data):
+        self.version = version
+        self.data = dict(data)
+
+
+class _FakeConfigEntries:
+    """Mirror of hass.config_entries.async_update_entry's mutate-in-place effect."""
+
+    def async_update_entry(self, entry, data=None, version=None, **_kwargs):
+        if data is not None:
+            entry.data = data
+        if version is not None:
+            entry.version = version
+
+
+class _FakeHass:
+    def __init__(self):
+        self.config_entries = _FakeConfigEntries()
+
+
+async def _run(version, data):
+    """Run the real async_migrate_entry against a fake entry; return (ok, entry)."""
+    hass = _FakeHass()
+    entry = _FakeEntry(version, data)
+    ok = await async_migrate_entry(hass, entry)
+    return ok, entry
+
+
+# --- Change 1: constants + accessor ------------------------------------------
+
+def test_mode_constant_values():
+    assert const.CONF_CONTACT_DISCOVERY_MODE == "contact_discovery_mode"
+    assert const.MODE_FULL == "full"
+    assert const.MODE_DATA_ONLY == "data_only"
+    assert const.MODE_OFF == "off"
+    assert const.DEFAULT_CONTACT_DISCOVERY_MODE == const.MODE_FULL
+    assert const.CONTACT_DISCOVERY_MODES == ("full", "data_only", "off")
+
+
+def test_accessor_returns_stored_mode():
+    entry = _FakeEntry(3, {CONF_MODE: MODE_DATA_ONLY})
+    assert const.get_contact_discovery_mode(entry) == MODE_DATA_ONLY
+
+
+def test_accessor_reads_off():
+    entry = _FakeEntry(3, {CONF_MODE: MODE_OFF})
+    assert const.get_contact_discovery_mode(entry) == MODE_OFF
+
+
+def test_accessor_defaults_to_full_when_absent():
+    entry = _FakeEntry(3, {})
+    assert const.get_contact_discovery_mode(entry) == MODE_FULL
+
+
+# --- Change 2: v2->v3 migration mappings -------------------------------------
+
+async def test_migrate_disable_maps_to_off():
+    ok, entry = await _run(2, {_LEGACY_DISABLE: True})
+    assert ok is True
+    assert entry.version == 3
+    assert entry.data[CONF_MODE] == MODE_OFF
+    assert _LEGACY_DISABLE not in entry.data
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_large_mesh_maps_to_data_only():
+    ok, entry = await _run(2, {_LEGACY_LARGE_MESH: True})
+    assert ok is True
+    assert entry.version == 3
+    assert entry.data[CONF_MODE] == MODE_DATA_ONLY
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_neither_maps_to_full():
+    ok, entry = await _run(2, {})
+    assert ok is True
+    assert entry.version == 3
+    assert entry.data[CONF_MODE] == MODE_FULL
+
+
+async def test_migrate_both_true_off_wins_tiebreak():
+    ok, entry = await _run(2, {_LEGACY_DISABLE: True, _LEGACY_LARGE_MESH: True})
+    assert entry.data[CONF_MODE] == MODE_OFF
+    assert _LEGACY_DISABLE not in entry.data
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_drops_explicit_false_legacy_keys():
+    """Even when the legacy flags are explicitly False, they are dropped."""
+    ok, entry = await _run(2, {_LEGACY_DISABLE: False, _LEGACY_LARGE_MESH: False})
+    assert entry.data[CONF_MODE] == MODE_FULL
+    assert _LEGACY_DISABLE not in entry.data
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_preserves_unrelated_keys():
+    ok, entry = await _run(2, {_LEGACY_LARGE_MESH: True, "name": "MattDub", "baudrate": 115200})
+    assert entry.data["name"] == "MattDub"
+    assert entry.data["baudrate"] == 115200
+    assert entry.data[CONF_MODE] == MODE_DATA_ONLY
+
+
+async def test_migrate_v1_chains_to_v3():
+    """A v1 entry must run v1->v2 then fall through to v2->v3 in one pass.
+
+    Guards the standalone-``if`` requirement: an ``elif`` here would leave a v1
+    entry at version 2 with no contact_discovery_mode key.
+    """
+    ok, entry = await _run(1, {})
+    assert ok is True
+    assert entry.version == 3
+    assert entry.data[CONF_MODE] == MODE_FULL
+    assert _LEGACY_DISABLE not in entry.data
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_v1_with_large_mesh_chains_to_data_only():
+    """A v1 entry that already carried large_mesh_mode=True lands on data_only at v3."""
+    ok, entry = await _run(1, {_LEGACY_LARGE_MESH: True})
+    assert ok is True
+    assert entry.version == 3
+    assert entry.data[CONF_MODE] == MODE_DATA_ONLY
+    assert _LEGACY_LARGE_MESH not in entry.data
+
+
+async def test_migrate_rejects_downgrade_from_future_version():
+    ok, entry = await _run(4, {})
+    assert ok is False
+    assert entry.version == 4
+    assert CONF_MODE not in entry.data

--- a/tests/test_contact_discovery_migration.py
+++ b/tests/test_contact_discovery_migration.py
@@ -156,6 +156,7 @@ def test_accessor_defaults_to_full_when_absent():
 
 # --- Change 2: v2->v3 migration mappings -------------------------------------
 
+@pytest.mark.asyncio
 async def test_migrate_disable_maps_to_off():
     ok, entry = await _run(2, {_LEGACY_DISABLE: True})
     assert ok is True
@@ -165,6 +166,7 @@ async def test_migrate_disable_maps_to_off():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_large_mesh_maps_to_data_only():
     ok, entry = await _run(2, {_LEGACY_LARGE_MESH: True})
     assert ok is True
@@ -173,6 +175,7 @@ async def test_migrate_large_mesh_maps_to_data_only():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_neither_maps_to_full():
     ok, entry = await _run(2, {})
     assert ok is True
@@ -180,6 +183,7 @@ async def test_migrate_neither_maps_to_full():
     assert entry.data[CONF_MODE] == MODE_FULL
 
 
+@pytest.mark.asyncio
 async def test_migrate_both_true_off_wins_tiebreak():
     ok, entry = await _run(2, {_LEGACY_DISABLE: True, _LEGACY_LARGE_MESH: True})
     assert entry.data[CONF_MODE] == MODE_OFF
@@ -187,6 +191,7 @@ async def test_migrate_both_true_off_wins_tiebreak():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_drops_explicit_false_legacy_keys():
     """Even when the legacy flags are explicitly False, they are dropped."""
     ok, entry = await _run(2, {_LEGACY_DISABLE: False, _LEGACY_LARGE_MESH: False})
@@ -195,6 +200,7 @@ async def test_migrate_drops_explicit_false_legacy_keys():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_preserves_unrelated_keys():
     ok, entry = await _run(2, {_LEGACY_LARGE_MESH: True, "name": "MattDub", "baudrate": 115200})
     assert entry.data["name"] == "MattDub"
@@ -202,6 +208,7 @@ async def test_migrate_preserves_unrelated_keys():
     assert entry.data[CONF_MODE] == MODE_DATA_ONLY
 
 
+@pytest.mark.asyncio
 async def test_migrate_v1_chains_to_v3():
     """A v1 entry must run v1->v2 then fall through to v2->v3 in one pass.
 
@@ -216,6 +223,7 @@ async def test_migrate_v1_chains_to_v3():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_v1_with_large_mesh_chains_to_data_only():
     """A v1 entry that already carried large_mesh_mode=True lands on data_only at v3."""
     ok, entry = await _run(1, {_LEGACY_LARGE_MESH: True})
@@ -225,6 +233,7 @@ async def test_migrate_v1_with_large_mesh_chains_to_data_only():
     assert _LEGACY_LARGE_MESH not in entry.data
 
 
+@pytest.mark.asyncio
 async def test_migrate_rejects_downgrade_from_future_version():
     ok, entry = await _run(4, {})
     assert ok is False

--- a/tests/test_contact_discovery_mode.py
+++ b/tests/test_contact_discovery_mode.py
@@ -1,0 +1,1551 @@
+"""Tests for the tri-state ``contact_discovery_mode`` (full / data_only / off).
+
+This is the consolidated successor to the boolean-era ``test_large_mesh_mode.py``
+and the interim ``test_contact_discovery_mode_runtime.py``. It covers the whole
+runtime surface driven by the mode enum:
+
+  * the ``create_contact_sensor`` entity-creation gate (full creates / data_only
+    suppresses discovered + keeps added / default == full);
+  * the ``handle_contacts_update`` early-return (off skips discovery entirely);
+  * the discovered-cleanup paths that now run UNCONDITIONALLY (a no-op in
+    data_only, but they clear stale orphans left by a prior mode);
+  * the ``remove_contact`` demote cleanup, gated on data_only (the inverse gate:
+    a demoted added contact must lose its binary_sensor + telemetry/GPS family);
+  * the ``get_discovered_contact`` lookup, incl. the empty/short-prefix guard;
+  * the mode-independent discovered-summary sensor.
+
+As with the modules these mirror (``binary_sensor``/``coordinator``/``services``
+define classes that subclass mocked HA bases and so cannot be imported whole
+under the conftest stubs), the gate/cleanup/demote/lookup bodies are faithful
+logic mirrors of the production code. To keep the *mode decision* honest rather
+than a re-implementation, every mirror calls the **real**
+``const.get_contact_discovery_mode`` accessor and the **real** ``MODE_*``
+constants, loaded from the real ``const.py`` via importlib (the same pattern as
+``test_contact_discovery_migration.py``). A mismatch between the accessor and
+the gate comparisons would fail these tests. The HA-coupled paths
+(coordinator/registry resolution, ``_ensure_contact_compat`` backfill, the
+config-flow form rendering) are exercised live on the HA host.
+"""
+import copy
+import importlib.util
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+# --- Load the real const.py (bypass the conftest MagicMock stub) -------------
+_PKG = "custom_components.meshcore"
+_BASE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "custom_components", "meshcore"
+)
+
+# const.py imports only enum + typing, but stub the parent package so the
+# importlib-loaded module registers under the real dotted name cleanly.
+_cc = types.ModuleType("custom_components")
+_cc.__path__ = [os.path.dirname(_BASE)]
+sys.modules["custom_components"] = _cc
+
+
+def _load_real(modname: str, filename: str):
+    spec = importlib.util.spec_from_file_location(
+        modname, os.path.join(_BASE, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = _PKG
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+const = _load_real(f"{_PKG}.const", "const.py")
+
+MODE_FULL = const.MODE_FULL
+MODE_DATA_ONLY = const.MODE_DATA_ONLY
+MODE_OFF = const.MODE_OFF
+CONF_MODE = const.CONF_CONTACT_DISCOVERY_MODE
+DEFAULT_CONTACT_DISCOVERY_MODE = const.DEFAULT_CONTACT_DISCOVERY_MODE
+CONTACT_DISCOVERY_MODES = const.CONTACT_DISCOVERY_MODES
+DOMAIN = const.DOMAIN
+get_contact_discovery_mode = const.get_contact_discovery_mode
+
+
+# --- Minimal fakes -----------------------------------------------------------
+
+class _FakeEntry:
+    def __init__(self, mode=None, entry_id="01ENTRY"):
+        self.entry_id = entry_id
+        self.data = {} if mode is None else {CONF_MODE: mode}
+
+
+def _entry_with_data(data, entry_id="01ENTRY"):
+    """An entry-like object whose ``.data`` is an arbitrary dict (for the
+    options round-trip, which preserves the whole data cluster)."""
+    return SimpleNamespace(data=data, entry_id=entry_id)
+
+
+class _FakeCoordinator:
+    def __init__(self, mode=None, added=None, entry_id="01ENTRY", tracked=None):
+        self.config_entry = _FakeEntry(mode, entry_id)
+        # _contacts is keyed by 12-hex prefix in production; only the
+        # public_key values matter to the gate.
+        self._contacts = {
+            pk[:12]: {"public_key": pk} for pk in (added or [])
+        }
+        self.tracked_diagnostic_binary_contacts = set(tracked or [])
+
+
+class _FakeEntityRegistry:
+    """Minimal entity-registry stand-in.
+
+    Maps (platform, domain, unique_id) -> entity_id; records async_remove calls
+    and drops the removed entity so a later lookup returns None.
+    """
+
+    def __init__(self, entities=None):
+        self._by_unique = dict(entities or {})
+        self.removed = []
+
+    def async_get_entity_id(self, platform, domain, unique_id):
+        return self._by_unique.get((platform, domain, unique_id))
+
+    def async_remove(self, entity_id):
+        self.removed.append(entity_id)
+        for key, eid in list(self._by_unique.items()):
+            if eid == entity_id:
+                del self._by_unique[key]
+
+
+def _uid(entry_id, pubkey):
+    return f"{entry_id}_contact_{pubkey[:12]}"
+
+
+# 60-hex full keys reused by the demote/sweep sections.
+DISCOVERED_PK = "aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+ADDED_PK = "1122334455667788990011223344556677889900112233445566778899aa"
+
+
+# =============================================================================
+# create_contact_sensor gate: data_only and off suppress discovered contacts
+# =============================================================================
+#
+# Live gate (binary_sensor.create_contact_sensor): in data_only and off, a
+# contact whose public_key is NOT in the added-contact map
+# (coordinator._contacts) returns None and is not tracked. Added contacts create
+# in every mode; only full creates an entity for a discovered (un-added) contact.
+# The off case is load-bearing: the binary_sensor setup path (async_setup_entry)
+# calls this gate directly with no off early-return of its own, so if the gate
+# did not suppress off, a reload in off mode would materialize a per-contact
+# entity for every contact (the orphaned-entity bug this regression set guards).
+
+def create_contact_sensor(coordinator, contact):
+    """Faithful mirror of binary_sensor.create_contact_sensor."""
+    if not isinstance(contact, dict):
+        return None
+    public_key = contact.get("public_key", "")
+    if not public_key:
+        return None
+    if get_contact_discovery_mode(coordinator.config_entry) in (
+        MODE_DATA_ONLY,
+        MODE_OFF,
+    ):
+        added_pubkeys = {
+            c.get("public_key")
+            for c in coordinator._contacts.values()
+            if c.get("public_key")
+        }
+        if public_key not in added_pubkeys:
+            return None  # discovered-only: suppressed in data_only and off
+    if public_key not in coordinator.tracked_diagnostic_binary_contacts:
+        coordinator.tracked_diagnostic_binary_contacts.add(public_key)
+        return f"SENSOR:{public_key[:12]}"
+    return None
+
+
+def test_full_mode_discovered_gets_entity():
+    """full: a discovered (un-added) contact is created and tracked."""
+    coord = _FakeCoordinator(mode=MODE_FULL)
+    pk = "aa" * 16
+    assert create_contact_sensor(coord, {"public_key": pk}) == "SENSOR:" + ("aa" * 6)
+    assert pk in coord.tracked_diagnostic_binary_contacts
+
+
+def test_default_mode_is_full_when_absent():
+    """Unset mode defaults to full -> discovered contact created."""
+    coord = _FakeCoordinator(mode=None)
+    assert create_contact_sensor(coord, {"public_key": "bb" * 16}) is not None
+
+
+def test_off_mode_suppresses_discovered():
+    """off: a discovered (un-added) contact returns None and is not tracked.
+
+    Regression guard for the orphaned-entity bug. The binary_sensor setup path
+    (async_setup_entry) calls this gate directly with no off early-return, so the
+    gate itself must suppress discovered contacts in off -- otherwise a reload in
+    off mode materializes a per-contact entity for every contact (the opposite of
+    disabled).
+    """
+    coord = _FakeCoordinator(mode=MODE_OFF)
+    assert create_contact_sensor(coord, {"public_key": "cc" * 16}) is None
+    assert coord.tracked_diagnostic_binary_contacts == set()
+
+
+def test_off_mode_keeps_added():
+    """off: an added/curated contact still gets its entity."""
+    pk = "cd" * 16
+    coord = _FakeCoordinator(mode=MODE_OFF, added=[pk])
+    assert create_contact_sensor(coord, {"public_key": pk}) == "SENSOR:" + ("cd" * 6)
+    assert pk in coord.tracked_diagnostic_binary_contacts
+
+
+def test_data_only_suppresses_discovered():
+    """data_only: a discovered (un-added) contact returns None and is not tracked."""
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY)
+    assert create_contact_sensor(coord, {"public_key": "dd" * 16}) is None
+    assert coord.tracked_diagnostic_binary_contacts == set()
+
+
+def test_data_only_keeps_added():
+    """data_only: an added/curated contact still gets its entity."""
+    pk = "ee" * 16
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY, added=[pk])
+    assert create_contact_sensor(coord, {"public_key": pk}) == "SENSOR:" + ("ee" * 6)
+    assert pk in coord.tracked_diagnostic_binary_contacts
+
+
+def test_data_only_other_added_does_not_unblock():
+    """data_only: a different added contact does not unblock an un-added one."""
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY, added=["1a" * 16])
+    assert create_contact_sensor(coord, {"public_key": "2b" * 16}) is None
+    assert ("2b" * 16) not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_data_only_added_matches_full_pubkey_not_prefix():
+    """data_only: the gate compares the FULL public_key, not the 12-hex prefix.
+
+    A contact sharing the added contact's 12-hex prefix but a different full key
+    must NOT be treated as added.
+    """
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY, added=[ADDED_PK])
+    impostor = ADDED_PK[:12] + ("f" * (len(ADDED_PK) - 12))
+    assert impostor != ADDED_PK
+    assert create_contact_sensor(coord, {"public_key": impostor}) is None
+
+
+def test_gate_non_dict_contact_returns_none():
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY)
+    assert create_contact_sensor(coord, "not-a-dict") is None
+
+
+def test_gate_missing_public_key_returns_none():
+    coord = _FakeCoordinator(mode=MODE_FULL)
+    assert create_contact_sensor(coord, {"adv_name": "NoKey"}) is None
+
+
+def test_gate_already_tracked_is_idempotent():
+    """A contact already in the tracked set is not re-created (any mode)."""
+    coord = _FakeCoordinator(mode=MODE_FULL)
+    pk = "cc" * 16
+    coord.tracked_diagnostic_binary_contacts.add(pk)
+    assert create_contact_sensor(coord, {"public_key": pk}) is None
+
+
+# =============================================================================
+# handle_contacts_update early-return (Change 4): off skips entirely
+# =============================================================================
+
+def handle_contacts_update_gate(coordinator):
+    """Mirror of the handle_contacts_update early-return: 'skip' iff off."""
+    if get_contact_discovery_mode(coordinator.config_entry) == MODE_OFF:
+        return "skip"
+    return "process"
+
+
+def test_off_mode_early_returns():
+    assert handle_contacts_update_gate(_FakeCoordinator(mode=MODE_OFF)) == "skip"
+
+
+def test_full_and_data_only_do_not_early_return():
+    assert handle_contacts_update_gate(_FakeCoordinator(mode=MODE_FULL)) == "process"
+    assert handle_contacts_update_gate(_FakeCoordinator(mode=MODE_DATA_ONLY)) == "process"
+
+
+def test_default_mode_does_not_early_return():
+    assert handle_contacts_update_gate(_FakeCoordinator(mode=None)) == "process"
+
+
+# =============================================================================
+# Unconditional discovered-cleanup (Changes 5, 6): no mode gate
+# =============================================================================
+#
+# The eviction / stale-cleanup / remove-discovered / clear paths dropped their
+# `if large_mesh` skip gate: registry removal now runs unconditionally. In
+# data_only/off there is no discovered entity so the removal is a no-op, but a
+# stale entity left by a prior mode switch is now correctly removed.
+
+def cleanup_discovered(coordinator, entity_registry, discovered_keys):
+    """Faithful mirror of the post-Change-5/6 cleanup loop (runs every mode)."""
+    entry_id = coordinator.config_entry.entry_id
+    for public_key in list(discovered_keys):
+        coordinator.tracked_diagnostic_binary_contacts.discard(public_key)
+        unique_id = _uid(entry_id, public_key)
+        entity_id = entity_registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, unique_id
+        )
+        if entity_id:
+            entity_registry.async_remove(entity_id)
+    return list(entity_registry.removed)
+
+
+def test_cleanup_full_removes_existing_entity():
+    """full: a discovered contact's entity is removed by cleanup."""
+    pk = "11" * 16
+    reg = _FakeEntityRegistry({("binary_sensor", DOMAIN, _uid("01ENTRY", pk)): "binary_sensor.disco"})
+    coord = _FakeCoordinator(mode=MODE_FULL, tracked=[pk])
+    assert cleanup_discovered(coord, reg, [pk]) == ["binary_sensor.disco"]
+    assert pk not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_cleanup_data_only_is_noop_but_trims_tracking():
+    """data_only: no per-contact entity exists, so removal is a no-op; the
+    tracked-set discard (the in-memory dict-trim analogue) still runs."""
+    pk = "22" * 16
+    reg = _FakeEntityRegistry({})  # no entity registered in data_only
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY, tracked=[pk])
+    assert cleanup_discovered(coord, reg, [pk]) == []
+    assert pk not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_cleanup_data_only_removes_stale_orphan_from_prior_mode():
+    """The point of dropping the gate: a stale entity left by a prior mode
+    switch is now removed even in data_only (the old gate skipped it)."""
+    pk = "33" * 16
+    reg = _FakeEntityRegistry({("binary_sensor", DOMAIN, _uid("01ENTRY", pk)): "binary_sensor.orphan"})
+    coord = _FakeCoordinator(mode=MODE_DATA_ONLY, tracked=[pk])
+    assert cleanup_discovered(coord, reg, [pk]) == ["binary_sensor.orphan"]
+
+
+def test_cleanup_off_removes_stale_orphan():
+    """off: same unconditional removal of a stale orphan."""
+    pk = "44" * 16
+    reg = _FakeEntityRegistry({("binary_sensor", DOMAIN, _uid("01ENTRY", pk)): "binary_sensor.orphan"})
+    coord = _FakeCoordinator(mode=MODE_OFF, tracked=[pk])
+    assert cleanup_discovered(coord, reg, [pk]) == ["binary_sensor.orphan"]
+
+
+# =============================================================================
+# Demote-added binary_sensor cleanup (Change 6): inverse gate, data_only only
+# =============================================================================
+#
+# Live block (demote binary_sensor removal), gated on mode == data_only:
+#   coordinator.tracked_diagnostic_binary_contacts.discard(pubkey)   # FULL key
+#   unique_id = f"{entry_id}_contact_{pubkey[:12]}"
+#   entity_id = registry.async_get_entity_id("binary_sensor", DOMAIN, unique_id)
+#   if entity_id: registry.async_remove(entity_id)
+# In full/off the block is gated off entirely (the entity correctly persists).
+
+def _make_demote_coordinator(mode=None, entry_id="01ENTRY", tracked=None):
+    return SimpleNamespace(
+        config_entry=_FakeEntry(mode, entry_id),
+        tracked_diagnostic_binary_contacts=set(tracked or ()),
+    )
+
+
+def demote_remove_entity(coordinator, entity_registry, pubkey):
+    """Standalone mirror of the live data_only block in the remove_contact
+    handler. Returns the removed entity_id (or None).
+
+    Byte-faithful: the discard uses the FULL public_key; the unique_id uses the
+    12-hex prefix; both the discard and the removal are gated on data_only (the
+    INVERSE of the discovered-cleanup paths, which run in every mode).
+    """
+    prefix = pubkey[:12]
+    if get_contact_discovery_mode(coordinator.config_entry) == MODE_DATA_ONLY:
+        coordinator.tracked_diagnostic_binary_contacts.discard(pubkey)
+        unique_id = f"{coordinator.config_entry.entry_id}_contact_{prefix}"
+        entity_id = entity_registry.async_get_entity_id("binary_sensor", DOMAIN, unique_id)
+        if entity_id:
+            entity_registry.async_remove(entity_id)
+            return entity_id
+    return None
+
+
+def _registry_with_contact(entry_id, pubkey, entity_id):
+    return _FakeEntityRegistry({
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{pubkey[:12]}"): entity_id,
+    })
+
+
+def test_demote_full_keeps_entity_and_tracked():
+    """full: demoting an added contact leaves its entity in place and the pubkey
+    in the tracked set (the inverse gate is closed outside data_only)."""
+    entry_id = "01ENTRY"
+    eid = "binary_sensor.meshcore_added_contact_111122223333"
+    coord = _make_demote_coordinator(mode=MODE_FULL, entry_id=entry_id, tracked={ADDED_PK})
+    reg = _registry_with_contact(entry_id, ADDED_PK, eid)
+    assert demote_remove_entity(coord, reg, ADDED_PK) is None
+    assert reg.removed == []
+    assert ADDED_PK in coord.tracked_diagnostic_binary_contacts
+    assert reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{entry_id}_contact_{ADDED_PK[:12]}"
+    ) == eid
+
+
+def test_demote_off_keeps_entity():
+    """off is not data_only, so the inverse demote gate stays closed."""
+    entry_id = "01ENTRY"
+    eid = "binary_sensor.meshcore_added_contact_111122223333"
+    coord = _make_demote_coordinator(mode=MODE_OFF, entry_id=entry_id, tracked={ADDED_PK})
+    reg = _registry_with_contact(entry_id, ADDED_PK, eid)
+    assert demote_remove_entity(coord, reg, ADDED_PK) is None
+    assert reg.removed == []
+    assert ADDED_PK in coord.tracked_diagnostic_binary_contacts
+
+
+def test_demote_default_mode_keeps_entity():
+    """Unset mode defaults to full -> demote gate closed."""
+    entry_id = "01ENTRY"
+    eid = "binary_sensor.meshcore_added_contact_111122223333"
+    coord = _make_demote_coordinator(mode=None, entry_id=entry_id, tracked={ADDED_PK})
+    reg = _registry_with_contact(entry_id, ADDED_PK, eid)
+    assert demote_remove_entity(coord, reg, ADDED_PK) is None
+    assert reg.removed == []
+    assert ADDED_PK in coord.tracked_diagnostic_binary_contacts
+
+
+def test_demote_data_only_removes_entity_and_discards_full_key():
+    """data_only: async_remove called with the demoted contact's entity_id, and
+    the FULL public_key discarded from the tracked set."""
+    entry_id = "01ENTRY"
+    eid = "binary_sensor.meshcore_added_contact_111122223333"
+    coord = _make_demote_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id, tracked={ADDED_PK})
+    reg = _registry_with_contact(entry_id, ADDED_PK, eid)
+    assert demote_remove_entity(coord, reg, ADDED_PK) == eid
+    assert reg.removed == [eid]
+    # FULL key discarded (a prefix-only discard would leave ADDED_PK present).
+    assert ADDED_PK not in coord.tracked_diagnostic_binary_contacts
+    assert coord.tracked_diagnostic_binary_contacts == set()
+
+
+def test_demote_data_only_unique_id_uses_prefix():
+    """data_only: the registry lookup keys on the 12-hex prefix, not the full key.
+
+    A registry that only knows the full-key unique_id must NOT match -- proving
+    the unique_id is built from pubkey[:12].
+    """
+    entry_id = "01ENTRY"
+    eid = "binary_sensor.meshcore_added_contact_full"
+    reg = _FakeEntityRegistry({
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{ADDED_PK}"): eid,  # FULL-key uid (wrong shape)
+    })
+    coord = _make_demote_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id, tracked={ADDED_PK})
+    assert demote_remove_entity(coord, reg, ADDED_PK) is None
+    assert reg.removed == []
+    # The full key is still discarded from the tracked set.
+    assert ADDED_PK not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_demote_data_only_discards_key_even_without_entity():
+    """data_only: discard happens even if no entity is registered, so a later
+    re-add recreates the entity (tracked set must be clean)."""
+    entry_id = "01ENTRY"
+    coord = _make_demote_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id, tracked={ADDED_PK})
+    reg = _FakeEntityRegistry({})  # nothing registered
+    assert demote_remove_entity(coord, reg, ADDED_PK) is None
+    assert reg.removed == []
+    assert ADDED_PK not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_demote_data_only_spares_selectors_and_sibling():
+    """Survivor safety: demoting one added contact removes ONLY its entity -- the
+    three _contact_select selector entities and a second added contact survive."""
+    entry_id = "01ENTRY"
+    target_pk = ADDED_PK
+    sibling_pk = DISCOVERED_PK  # a distinct second added contact's full key
+    target_eid = "binary_sensor.meshcore_target_111122223333"
+    sibling_eid = "binary_sensor.meshcore_sibling_aabbccddeeff"
+    sel_contact = "select.meshcore_contact"
+    sel_added = "select.meshcore_added_contact"
+    sel_discovered = "select.meshcore_discovered_contact"
+    reg = _FakeEntityRegistry({
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{target_pk[:12]}"): target_eid,
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{sibling_pk[:12]}"): sibling_eid,
+        ("select", DOMAIN, f"{entry_id}_contact_select"): sel_contact,
+        ("select", DOMAIN, f"{entry_id}_added_contact_select"): sel_added,
+        ("select", DOMAIN, f"{entry_id}_discovered_contact_select"): sel_discovered,
+    })
+    coord = _make_demote_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, tracked={target_pk, sibling_pk}
+    )
+
+    assert demote_remove_entity(coord, reg, target_pk) == target_eid
+    assert reg.removed == [target_eid]
+    # Sibling added entity survives (registry + tracked set).
+    assert reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{entry_id}_contact_{sibling_pk[:12]}"
+    ) == sibling_eid
+    assert sibling_pk in coord.tracked_diagnostic_binary_contacts
+    # All three selector entities survive.
+    assert reg.async_get_entity_id("select", DOMAIN, f"{entry_id}_contact_select") == sel_contact
+    assert reg.async_get_entity_id("select", DOMAIN, f"{entry_id}_added_contact_select") == sel_added
+    assert reg.async_get_entity_id(
+        "select", DOMAIN, f"{entry_id}_discovered_contact_select"
+    ) == sel_discovered
+    assert coord.tracked_diagnostic_binary_contacts == {sibling_pk}
+
+
+# =============================================================================
+# Demote telemetry/GPS sweep (Change 6): inside the data_only gate
+# =============================================================================
+#
+# The live sweep sits inside the data_only gate in the remove_contact handler,
+# immediately after the _contact_ binary_sensor removal:
+#   if not _node_has_tracked_subscription(coordinator, prefix):
+#       uid_prefix = f"{entry_id}_{prefix}_"
+#       remove registry entries whose unique_id startswith(uid_prefix) AND
+#           endswith("_telemetry") or endswith("_gps_tracker")
+#       discard keys startswith(prefix) from
+#           coordinator.telemetry_manager.discovered_sensors and
+#           coordinator.device_tracker_manager.discovered_trackers
+# The subscription exclusion uses the bidirectional-startswith convention.
+# Live add -> Req Telemetry -> remove -> re-add is verified on the HA host.
+
+def _node_has_tracked_subscription(coordinator, pubkey_prefix):
+    """Standalone mirror of services._node_has_tracked_subscription."""
+    for cfg in list(coordinator._tracked_repeaters or []) + list(coordinator._tracked_clients or []):
+        cp = cfg.get("pubkey_prefix", "")
+        if cp and (pubkey_prefix.startswith(cp) or cp.startswith(pubkey_prefix)):
+            return True
+    return False
+
+
+class _FakeSweepRegistry(_FakeEntityRegistry):
+    """Fake registry that also serves the er.async_entries_for_config_entry
+    surface the sweep reads: every seeded entity belongs to the one config
+    entry under test, exposed as (unique_id, entity_id) entries."""
+
+    def entries_for_config_entry(self):
+        return [
+            SimpleNamespace(unique_id=uid, entity_id=eid)
+            for (_platform, _domain, uid), eid in self._by_unique.items()
+        ]
+
+
+def demote_sweep_telemetry_gps(coordinator, entity_registry, pubkey):
+    """Standalone mirror of the live telemetry/GPS sweep. Returns removed ids.
+
+    Byte-faithful: gated on data_only; skipped entirely (registry sweep AND
+    dedup-map discards) for nodes with a tracked-device subscription; allowlist
+    by unique_id SHAPE -- startswith(f"{entry_id}_{prefix}_") AND
+    endswith("_telemetry") / endswith("_gps_tracker"); collect-then-remove;
+    getattr(..., None) guards for managers on platforms not yet set up.
+    """
+    prefix = pubkey[:12]
+    if get_contact_discovery_mode(coordinator.config_entry) != MODE_DATA_ONLY:
+        return []
+    if _node_has_tracked_subscription(coordinator, prefix):
+        return []
+    uid_prefix = f"{coordinator.config_entry.entry_id}_{prefix}_"
+    to_remove = [
+        e.entity_id
+        for e in entity_registry.entries_for_config_entry()
+        if (e.unique_id or "").startswith(uid_prefix)
+        and (
+            e.unique_id.endswith("_telemetry")
+            or e.unique_id.endswith("_gps_tracker")
+        )
+    ]
+    for stale_entity_id in to_remove:
+        entity_registry.async_remove(stale_entity_id)
+    tm = getattr(coordinator, "telemetry_manager", None)
+    if tm is not None:
+        for key in [k for k in tm.discovered_sensors if k.startswith(prefix)]:
+            del tm.discovered_sensors[key]
+    dtm = getattr(coordinator, "device_tracker_manager", None)
+    if dtm is not None:
+        for key in [k for k in dtm.discovered_trackers if k.startswith(prefix)]:
+            del dtm.discovered_trackers[key]
+    return to_remove
+
+
+def demote_cleanup_data_only(coordinator, entity_registry, pubkey):
+    """Mirror of the full gated block ordering: binary_sensor removal first
+    (subscription-independent), then the telemetry/GPS sweep."""
+    removed_binary = demote_remove_entity(coordinator, entity_registry, pubkey)
+    swept = demote_sweep_telemetry_gps(coordinator, entity_registry, pubkey)
+    return removed_binary, swept
+
+
+_TARGET_PREFIX = ADDED_PK[:12]
+_SIBLING_PREFIX = DISCOVERED_PK[:12]
+
+
+def _make_sweep_coordinator(mode=None, entry_id="01ENTRY", tracked=None,
+                            tracked_repeaters=None, tracked_clients=None,
+                            telemetry_keys=None, tracker_keys=None,
+                            with_managers=True):
+    coord = SimpleNamespace(
+        config_entry=_FakeEntry(mode, entry_id),
+        tracked_diagnostic_binary_contacts=set(tracked or ()),
+        _tracked_repeaters=list(tracked_repeaters or []),
+        _tracked_clients=list(tracked_clients or []),
+    )
+    if with_managers:
+        coord.telemetry_manager = SimpleNamespace(
+            discovered_sensors={k: object() for k in (telemetry_keys or [])}
+        )
+        coord.device_tracker_manager = SimpleNamespace(
+            discovered_trackers={k: object() for k in (tracker_keys or [])}
+        )
+    return coord
+
+
+def _telemetry_bearing_registry(entry_id):
+    """Registry holding the demoted contact's full entity family plus its
+    _contact_ binary_sensor: two telemetry sensors + one GPS tracker."""
+    return _FakeSweepRegistry({
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{_TARGET_PREFIX}"):
+            "binary_sensor.meshcore_target_contact",
+        ("sensor", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_1_temperature_telemetry"):
+            "sensor.meshcore_target_temperature",
+        ("sensor", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_2_battery_telemetry"):
+            "sensor.meshcore_target_battery",
+        ("device_tracker", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_gps_tracker"):
+            "device_tracker.meshcore_target_gps",
+    })
+
+
+_TARGET_TELEMETRY_KEYS = [
+    f"{_TARGET_PREFIX}_1_temperature",
+    f"{_TARGET_PREFIX}_2_battery",
+]
+_TARGET_TRACKER_KEY = f"{_TARGET_PREFIX}_gps"
+_SIBLING_TELEMETRY_KEY = f"{_SIBLING_PREFIX}_1_temperature"
+_SIBLING_TRACKER_KEY = f"{_SIBLING_PREFIX}_gps"
+
+
+def test_sweep_full_removes_nothing_and_keeps_maps():
+    """full: with the gate closed, no telemetry/GPS registry removal and both
+    dedup maps untouched."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_FULL, entry_id=entry_id,
+        telemetry_keys=_TARGET_TELEMETRY_KEYS, tracker_keys=[_TARGET_TRACKER_KEY],
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+    assert demote_sweep_telemetry_gps(coord, reg, ADDED_PK) == []
+    assert reg.removed == []
+    assert set(coord.telemetry_manager.discovered_sensors) == set(_TARGET_TELEMETRY_KEYS)
+    assert set(coord.device_tracker_manager.discovered_trackers) == {_TARGET_TRACKER_KEY}
+
+
+def test_sweep_off_removes_nothing():
+    """off is not data_only -> the sweep is gated off."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_OFF, entry_id=entry_id,
+        telemetry_keys=_TARGET_TELEMETRY_KEYS, tracker_keys=[_TARGET_TRACKER_KEY],
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+    assert demote_sweep_telemetry_gps(coord, reg, ADDED_PK) == []
+    assert reg.removed == []
+    assert set(coord.telemetry_manager.discovered_sensors) == set(_TARGET_TELEMETRY_KEYS)
+
+
+def test_sweep_data_only_removes_telemetry_gps_and_discards_maps():
+    """data_only: non-subscribed contact with two telemetry sensors + a GPS
+    tracker -> all three removed, both maps' prefix keys discarded, and the
+    _contact_ binary_sensor removal still occurs."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, tracked={ADDED_PK},
+        telemetry_keys=_TARGET_TELEMETRY_KEYS + [_SIBLING_TELEMETRY_KEY],
+        tracker_keys=[_TARGET_TRACKER_KEY, _SIBLING_TRACKER_KEY],
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+
+    removed_binary, swept = demote_cleanup_data_only(coord, reg, ADDED_PK)
+
+    assert removed_binary == "binary_sensor.meshcore_target_contact"
+    assert ADDED_PK not in coord.tracked_diagnostic_binary_contacts
+    assert sorted(swept) == [
+        "device_tracker.meshcore_target_gps",
+        "sensor.meshcore_target_battery",
+        "sensor.meshcore_target_temperature",
+    ]
+    assert sorted(reg.removed) == [
+        "binary_sensor.meshcore_target_contact",
+        "device_tracker.meshcore_target_gps",
+        "sensor.meshcore_target_battery",
+        "sensor.meshcore_target_temperature",
+    ]
+    # Both dedup maps: target-prefix keys discarded, sibling keys retained.
+    assert set(coord.telemetry_manager.discovered_sensors) == {_SIBLING_TELEMETRY_KEY}
+    assert set(coord.device_tracker_manager.discovered_trackers) == {_SIBLING_TRACKER_KEY}
+
+
+def test_sweep_handles_missing_managers():
+    """Guard: platforms not yet set up (no manager attributes) must not crash
+    the sweep -- mirrors the live getattr(..., None) guards."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id,
+                                    with_managers=False)
+    reg = _telemetry_bearing_registry(entry_id)
+    assert sorted(demote_sweep_telemetry_gps(coord, reg, ADDED_PK)) == [
+        "device_tracker.meshcore_target_gps",
+        "sensor.meshcore_target_battery",
+        "sensor.meshcore_target_temperature",
+    ]
+
+
+def test_sweep_collects_before_removing():
+    """Shape guard: the sweep must not mutate the registry while iterating it --
+    removing every matched entity in one pass proves the collect-then-remove
+    ordering (a mutate-while-iterating implementation would skip entries)."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id)
+    reg = _FakeSweepRegistry({
+        ("sensor", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_1_temperature_telemetry"): "sensor.t1",
+        ("sensor", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_2_humidity_telemetry"): "sensor.t2",
+        ("sensor", DOMAIN, f"{entry_id}_{_TARGET_PREFIX}_3_battery_telemetry"): "sensor.t3",
+    })
+    assert sorted(demote_sweep_telemetry_gps(coord, reg, ADDED_PK)) == [
+        "sensor.t1", "sensor.t2", "sensor.t3",
+    ]
+    assert reg.entries_for_config_entry() == []
+
+
+def test_sweep_spares_neighbors_clients_siblings_selectors():
+    """Survivor safety: the uid-shape allowlist structurally excludes every wrong
+    family even when those uids embed the demoted pubkey prefix."""
+    entry_id = "01ENTRY"
+    rptr = "930df029a915"
+    survivors = {
+        # Repeater-neighbor pair embedding the demoted prefix as a NEIGHBOR.
+        ("sensor", DOMAIN,
+         f"{entry_id}_repeater_{rptr}_neighbor_{_TARGET_PREFIX}_snr"): "sensor.nbr_snr",
+        ("sensor", DOMAIN,
+         f"{entry_id}_repeater_{rptr}_neighbor_{_TARGET_PREFIX}_seen"): "sensor.nbr_seen",
+        # Tracked-client entity shape (client_ before the prefix).
+        ("sensor", DOMAIN,
+         f"{entry_id}_client_{_TARGET_PREFIX}_battery"): "sensor.client_battery",
+        # Sibling contact's telemetry sensor.
+        ("sensor", DOMAIN,
+         f"{entry_id}_{_SIBLING_PREFIX}_1_temperature_telemetry"): "sensor.sibling_temp",
+        # Selector entities.
+        ("select", DOMAIN, f"{entry_id}_contact_select"): "select.meshcore_contact",
+        ("select", DOMAIN, f"{entry_id}_added_contact_select"): "select.meshcore_added",
+        ("select", DOMAIN, f"{entry_id}_discovered_contact_select"): "select.meshcore_disc",
+    }
+    target = {
+        ("sensor", DOMAIN,
+         f"{entry_id}_{_TARGET_PREFIX}_1_temperature_telemetry"): "sensor.target_temp",
+        ("device_tracker", DOMAIN,
+         f"{entry_id}_{_TARGET_PREFIX}_gps_tracker"): "device_tracker.target_gps",
+    }
+    reg = _FakeSweepRegistry({**survivors, **target})
+    coord = _make_sweep_coordinator(mode=MODE_DATA_ONLY, entry_id=entry_id)
+
+    assert sorted(demote_sweep_telemetry_gps(coord, reg, ADDED_PK)) == [
+        "device_tracker.target_gps", "sensor.target_temp",
+    ]
+    for (platform, domain, uid), eid in survivors.items():
+        assert reg.async_get_entity_id(platform, domain, uid) == eid
+
+
+def test_sweep_skipped_for_tracked_repeater_subscription():
+    """Subscription exclusion: a demoted node with a repeater subscription
+    (shorter config prefix, bidirectional-startswith) -> sweep skipped entirely:
+    no registry removal AND no dedup-map discards."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id,
+        tracked_repeaters=[{"pubkey_prefix": _TARGET_PREFIX[:6]}],
+        telemetry_keys=_TARGET_TELEMETRY_KEYS, tracker_keys=[_TARGET_TRACKER_KEY],
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+    assert demote_sweep_telemetry_gps(coord, reg, ADDED_PK) == []
+    assert reg.removed == []
+    assert set(coord.telemetry_manager.discovered_sensors) == set(_TARGET_TELEMETRY_KEYS)
+    assert set(coord.device_tracker_manager.discovered_trackers) == {_TARGET_TRACKER_KEY}
+
+
+def test_sweep_skipped_for_tracked_client_longer_prefix():
+    """Subscription exclusion: client subscription whose config prefix is LONGER
+    than the 12-hex demote prefix (the other startswith direction) also skips."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id,
+        tracked_clients=[{"pubkey_prefix": ADDED_PK}],  # full key, longer than 12
+        telemetry_keys=_TARGET_TELEMETRY_KEYS,
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+    assert demote_sweep_telemetry_gps(coord, reg, ADDED_PK) == []
+    assert reg.removed == []
+    assert set(coord.telemetry_manager.discovered_sensors) == set(_TARGET_TELEMETRY_KEYS)
+
+
+def test_sweep_unrelated_subscription_does_not_skip():
+    """Subscription-exclusion complement: a subscription for a DIFFERENT node
+    must not suppress the demoted contact's sweep."""
+    entry_id = "01ENTRY"
+    coord = _make_sweep_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id,
+        tracked_repeaters=[{"pubkey_prefix": _SIBLING_PREFIX}],
+        telemetry_keys=_TARGET_TELEMETRY_KEYS, tracker_keys=[_TARGET_TRACKER_KEY],
+    )
+    reg = _telemetry_bearing_registry(entry_id)
+    assert sorted(demote_sweep_telemetry_gps(coord, reg, ADDED_PK)) == [
+        "device_tracker.meshcore_target_gps",
+        "sensor.meshcore_target_battery",
+        "sensor.meshcore_target_temperature",
+    ]
+    assert coord.telemetry_manager.discovered_sensors == {}
+    assert coord.device_tracker_manager.discovered_trackers == {}
+
+
+# =============================================================================
+# get_discovered_contact service (Change 6 / Fix 4): empty-prefix guard
+# =============================================================================
+#
+# Mirror of services.async_get_discovered_contact_service: the empty/short-prefix
+# guard (Fix 4), first-startswith match, not_found envelope, and the
+# pubkey_prefix backfill for older records. The _ensure_contact_compat backfill
+# and coordinator-resolution branches are HA-coupled and exercised live.
+
+def get_discovered_contact(discovered, pubkey_prefix):
+    """Faithful mirror of the empty-prefix-guarded lookup + envelope shape."""
+    if not pubkey_prefix or len(pubkey_prefix) < 2:
+        return {"contact": None, "error": "invalid_prefix"}
+    match = None
+    for pubkey, contact in discovered.items():
+        if pubkey.startswith(pubkey_prefix):
+            match = contact
+            break
+    if match is None:
+        return {"contact": None, "error": "not_found", "pubkey_prefix": pubkey_prefix}
+    c = dict(match)
+    pk = c.get("public_key") or ""
+    if pk and "pubkey_prefix" not in c:
+        c["pubkey_prefix"] = pk[:12]
+    return {"contact": c}
+
+
+_DISCOVERED = {"abcdef0123456789": {"public_key": "abcdef0123456789", "adv_name": "Disco"}}
+
+
+def test_get_discovered_contact_empty_prefix_invalid():
+    assert get_discovered_contact(_DISCOVERED, "") == {"contact": None, "error": "invalid_prefix"}
+
+
+def test_get_discovered_contact_none_prefix_invalid():
+    assert get_discovered_contact(_DISCOVERED, None) == {"contact": None, "error": "invalid_prefix"}
+
+
+def test_get_discovered_contact_single_char_invalid():
+    assert get_discovered_contact(_DISCOVERED, "a") == {"contact": None, "error": "invalid_prefix"}
+
+
+def test_get_discovered_contact_valid_prefix_matches_and_backfills():
+    pk = "f293ac1b2c3d" + "0" * 52
+    discovered = {pk: {"public_key": pk, "adv_name": "Target"}}
+    out = get_discovered_contact(discovered, "f293ac1b2c3d")
+    assert out["contact"]["adv_name"] == "Target"
+    assert out["contact"]["public_key"] == pk
+    # pubkey_prefix backfilled for older records lacking it.
+    assert out["contact"]["pubkey_prefix"] == pk[:12]
+    assert "error" not in out
+
+
+def test_get_discovered_contact_full_pubkey_also_matches():
+    pk = "abc123" + "d" * 58
+    discovered = {pk: {"public_key": pk, "adv_name": "Full"}}
+    out = get_discovered_contact(discovered, pk)
+    assert out["contact"]["adv_name"] == "Full"
+
+
+def test_get_discovered_contact_valid_prefix_not_found():
+    out = get_discovered_contact(_DISCOVERED, "ffee")
+    assert out["contact"] is None
+    assert out["error"] == "not_found"
+    assert out["pubkey_prefix"] == "ffee"
+
+
+# =============================================================================
+# config_flow coverage (Change 10): install defaults + options round-trip
+# =============================================================================
+#
+# config_flow.py cannot be imported whole (the flow classes subclass mocked HA
+# bases), so these mirror the two mode-bearing expressions exactly and drive
+# them through the real const accessor/consts:
+#
+#   * Install steps async_step_usb/ble/tcp (config_flow.py:390/433/499) all use
+#     the IDENTICAL write: CONF_CONTACT_DISCOVERY_MODE:
+#       user_input.get(CONF_CONTACT_DISCOVERY_MODE, DEFAULT_CONTACT_DISCOVERY_MODE)
+#   * Options async_step_global_settings reads the current value via
+#     get_contact_discovery_mode (config_flow.py:965) for the form default, and
+#     on submit writes new_data[CONF_CONTACT_DISCOVERY_MODE] =
+#       user_input[CONF_CONTACT_DISCOVERY_MODE] onto a deepcopy of entry.data
+#     (config_flow.py:939-940), preserving every other key.
+
+def install_entry_discovery_mode(user_input):
+    """Mirror of the shared install-step write (usb/ble/tcp)."""
+    return user_input.get(CONF_MODE, DEFAULT_CONTACT_DISCOVERY_MODE)
+
+
+def options_read_mode(entry):
+    """Mirror of the global_settings form read (the select default)."""
+    return get_contact_discovery_mode(entry)
+
+
+def options_write(entry_data, user_input):
+    """Mirror of the global_settings submit write (deepcopy + overwrite mode)."""
+    new_data = copy.deepcopy(dict(entry_data))
+    new_data[CONF_MODE] = user_input[CONF_MODE]
+    return new_data
+
+
+@pytest.mark.parametrize("install_step", ["usb", "ble", "tcp"])
+def test_install_defaults_to_full_when_unselected(install_step):
+    """Each install path (USB/BLE/TCP) shares the identical write expression
+    (config_flow.py:390/433/499), so an unselected select stores full."""
+    assert install_entry_discovery_mode({}) == MODE_FULL
+    assert install_entry_discovery_mode({}) == DEFAULT_CONTACT_DISCOVERY_MODE
+
+
+@pytest.mark.parametrize("install_step", ["usb", "ble", "tcp"])
+def test_install_stores_explicit_mode(install_step):
+    """An explicitly-chosen mode is stored verbatim on every install path."""
+    assert install_entry_discovery_mode({CONF_MODE: MODE_DATA_ONLY}) == MODE_DATA_ONLY
+    assert install_entry_discovery_mode({CONF_MODE: MODE_OFF}) == MODE_OFF
+
+
+def test_install_default_is_a_valid_mode():
+    """The install default must be one of the three machine values."""
+    assert install_entry_discovery_mode({}) in CONTACT_DISCOVERY_MODES
+
+
+def test_options_read_returns_current_mode():
+    """The form default reads the stored mode via the real accessor."""
+    assert options_read_mode(_FakeEntry(MODE_DATA_ONLY)) == MODE_DATA_ONLY
+    assert options_read_mode(_FakeEntry(MODE_OFF)) == MODE_OFF
+
+
+def test_options_read_defaults_full_when_absent():
+    """An entry with no mode key reads full (the accessor default)."""
+    assert options_read_mode(_FakeEntry(None)) == MODE_FULL
+
+
+def test_options_write_overwrites_mode_and_preserves_other_keys():
+    """Submitting the form writes the selected mode and leaves the rest of the
+    config-data cluster untouched."""
+    entry_data = {
+        CONF_MODE: MODE_FULL,
+        "self_telemetry_enabled": True,
+        "max_discovered_contacts": 100,
+        "flood_scopes": "*",
+    }
+    new_data = options_write(entry_data, {CONF_MODE: MODE_OFF})
+    assert new_data[CONF_MODE] == MODE_OFF
+    assert new_data["self_telemetry_enabled"] is True
+    assert new_data["max_discovered_contacts"] == 100
+    assert new_data["flood_scopes"] == "*"
+    # The original is not mutated (deepcopy).
+    assert entry_data[CONF_MODE] == MODE_FULL
+
+
+def test_options_round_trip_read_then_write():
+    """End-to-end: an entry on data_only reads back data_only for the form, a
+    submit of off lands off in new_data, and re-reading new_data via the real
+    accessor returns off."""
+    entry = _FakeEntry(MODE_DATA_ONLY)
+    assert options_read_mode(entry) == MODE_DATA_ONLY
+    new_data = options_write(entry.data, {CONF_MODE: MODE_OFF})
+    assert new_data[CONF_MODE] == MODE_OFF
+    assert get_contact_discovery_mode(_entry_with_data(new_data)) == MODE_OFF
+
+
+# =============================================================================
+# Discovered-contact summary sensor (MeshCoreDiscoveredSummarySensor)
+# =============================================================================
+#
+# Mode-independent: the summary sensor reads neither the old booleans nor the
+# new mode; it stays created (diagnostic, disabled-by-default) in every mode.
+# Same standalone-logic-copy pattern -- the real class subclasses a mocked HA
+# entity base and can't be instantiated here, so native_value /
+# extra_state_attributes are mirrored byte-faithfully. The registration flags
+# (entity_registry_enabled_default=False, EntityCategory.DIAGNOSTIC) are class
+# attributes verified live on the HA host; the constants below document the
+# contract the live class must satisfy.
+
+# Mirror of NodeType (custom_components.meshcore.const.NodeType).
+NODE_TYPE_CLIENT = 1
+NODE_TYPE_REPEATER = 2
+NODE_TYPE_ROOM_SERVER = 3
+NODE_TYPE_SENSOR = 4
+
+# Mirror of the freshness window in sensor.py (DISCOVERED_FRESH_WINDOW_SECS).
+FRESH_WINDOW_SECS = 3600 * 12
+
+# Mirror of MeshCoreDiscoveredSummarySensor's load-bearing registration flags.
+SUMMARY_ENTITY_REGISTRY_ENABLED_DEFAULT = False
+SUMMARY_ENTITY_CATEGORY = "diagnostic"
+
+# Default limit (custom_components.meshcore.const.DEFAULT_MAX_DISCOVERED_CONTACTS).
+DEFAULT_MAX_DISCOVERED_CONTACTS = 100
+
+
+def summary_native_value(discovered):
+    """Mirror of MeshCoreDiscoveredSummarySensor.native_value."""
+    return len(discovered)
+
+
+def summary_attributes(discovered, now, limit_enabled=False,
+                       max_contacts=DEFAULT_MAX_DISCOVERED_CONTACTS):
+    """Mirror of MeshCoreDiscoveredSummarySensor.extra_state_attributes."""
+    by_type = {"chat": 0, "repeater": 0, "room_server": 0, "sensor": 0, "unknown": 0}
+    type_key = {
+        NODE_TYPE_CLIENT: "chat",
+        NODE_TYPE_REPEATER: "repeater",
+        NODE_TYPE_ROOM_SERVER: "room_server",
+        NODE_TYPE_SENSOR: "sensor",
+    }
+
+    fresh_count = 0
+    newest_contact = None
+    newest_advert = -1.0
+    for contact in discovered.values():
+        last_advert = contact.get("last_advert", 0) or 0
+        if last_advert and (now - last_advert) < FRESH_WINDOW_SECS:
+            fresh_count += 1
+        by_type[type_key.get(contact.get("type"), "unknown")] += 1
+        if last_advert > newest_advert:
+            newest_advert = last_advert
+            newest_contact = contact
+
+    total = len(discovered)
+
+    if newest_contact is not None:
+        pk = newest_contact.get("public_key", "") or ""
+        newest = {
+            "adv_name": newest_contact.get("adv_name", "Unknown"),
+            "pubkey_short": pk[:12],
+            "last_advert": newest_contact.get("last_advert", 0) or 0,
+        }
+    else:
+        newest = None
+
+    if limit_enabled:
+        capacity = max_contacts
+        capacity_used_pct = round(100.0 * total / max_contacts, 1) if max_contacts else None
+    else:
+        capacity = "unlimited"
+        capacity_used_pct = None
+
+    return {
+        "fresh_count": fresh_count,
+        "stale_count": total - fresh_count,
+        "by_type": by_type,
+        "newest": newest,
+        "capacity": capacity,
+        "capacity_used_pct": capacity_used_pct,
+    }
+
+
+_EXPECTED_ATTR_KEYS = {
+    "fresh_count", "stale_count", "by_type", "newest",
+    "capacity", "capacity_used_pct",
+}
+_EXPECTED_BY_TYPE_KEYS = {"chat", "repeater", "room_server", "sensor", "unknown"}
+
+
+def _disc(pk, name="Disco", type_=NODE_TYPE_CLIENT, last_advert=0):
+    return {pk: {"public_key": pk, "adv_name": name, "type": type_,
+                 "last_advert": last_advert}}
+
+
+def test_summary_state_equals_discovered_count():
+    assert summary_native_value({}) == 0
+    discovered = {}
+    for i in range(5):
+        discovered[f"{i:064x}"] = {"public_key": f"{i:064x}", "type": NODE_TYPE_CLIENT}
+    assert summary_native_value(discovered) == 5
+
+
+def test_summary_attribute_shape_constant_across_counts():
+    """The attribute keys (and by_type keys) never change with contact count."""
+    now = 1_000_000.0
+    for n in (0, 1, 50, 500):
+        discovered = {}
+        for i in range(n):
+            discovered[f"{i:064x}"] = {
+                "public_key": f"{i:064x}", "type": NODE_TYPE_REPEATER,
+                "last_advert": now - 60,
+            }
+        attrs = summary_attributes(discovered, now=now)
+        assert set(attrs.keys()) == _EXPECTED_ATTR_KEYS
+        assert set(attrs["by_type"].keys()) == _EXPECTED_BY_TYPE_KEYS
+
+
+def test_summary_attributes_payload_size_bounded():
+    """A 1000-contact set yields the same small key-set as a 1-contact set."""
+    now = 1_000_000.0
+    big = {f"{i:064x}": {"public_key": f"{i:064x}", "type": NODE_TYPE_SENSOR,
+                         "last_advert": now} for i in range(1000)}
+    attrs = summary_attributes(big, now=now)
+    assert len(attrs["by_type"]) == 5
+    assert attrs["newest"] is not None
+    assert set(attrs["newest"].keys()) == {"adv_name", "pubkey_short", "last_advert"}
+
+
+def test_summary_fresh_stale_split():
+    now = 1_000_000.0
+    discovered = {
+        "a" * 64: {"public_key": "a" * 64, "type": NODE_TYPE_CLIENT,
+                   "last_advert": now - 60},                  # fresh
+        "b" * 64: {"public_key": "b" * 64, "type": NODE_TYPE_CLIENT,
+                   "last_advert": now - (FRESH_WINDOW_SECS + 60)},  # stale
+        "c" * 64: {"public_key": "c" * 64, "type": NODE_TYPE_CLIENT,
+                   "last_advert": 0},                         # stale (never heard)
+    }
+    attrs = summary_attributes(discovered, now=now)
+    assert attrs["fresh_count"] == 1
+    assert attrs["stale_count"] == 2
+    assert attrs["fresh_count"] + attrs["stale_count"] == summary_native_value(discovered)
+
+
+def test_summary_by_type_counts_and_sum_invariant():
+    now = 1_000_000.0
+    discovered = {
+        "1" * 64: {"public_key": "1" * 64, "type": NODE_TYPE_CLIENT, "last_advert": now},
+        "2" * 64: {"public_key": "2" * 64, "type": NODE_TYPE_REPEATER, "last_advert": now},
+        "3" * 64: {"public_key": "3" * 64, "type": NODE_TYPE_REPEATER, "last_advert": now},
+        "4" * 64: {"public_key": "4" * 64, "type": NODE_TYPE_ROOM_SERVER, "last_advert": now},
+        "5" * 64: {"public_key": "5" * 64, "type": NODE_TYPE_SENSOR, "last_advert": now},
+        "6" * 64: {"public_key": "6" * 64, "last_advert": now},  # missing type -> unknown
+    }
+    attrs = summary_attributes(discovered, now=now)
+    assert attrs["by_type"] == {
+        "chat": 1, "repeater": 2, "room_server": 1, "sensor": 1, "unknown": 1,
+    }
+    assert sum(attrs["by_type"].values()) == summary_native_value(discovered)
+
+
+def test_summary_newest_is_most_recent_advert():
+    now = 1_000_000.0
+    discovered = {
+        "a" * 64: {"public_key": "a" * 64, "adv_name": "Old", "type": NODE_TYPE_CLIENT,
+                   "last_advert": now - 5000},
+        "b" * 64: {"public_key": "b" * 64, "adv_name": "Newest", "type": NODE_TYPE_CLIENT,
+                   "last_advert": now - 1},
+    }
+    attrs = summary_attributes(discovered, now=now)
+    assert attrs["newest"]["adv_name"] == "Newest"
+    assert attrs["newest"]["pubkey_short"] == ("b" * 64)[:12]
+    assert attrs["newest"]["last_advert"] == now - 1
+
+
+def test_summary_newest_none_when_empty():
+    attrs = summary_attributes({}, now=1_000_000.0)
+    assert attrs["newest"] is None
+
+
+def test_summary_capacity_unlimited_when_limit_disabled():
+    now = 1_000_000.0
+    discovered = _disc("a" * 64, last_advert=now)
+    attrs = summary_attributes(discovered, now=now, limit_enabled=False)
+    assert attrs["capacity"] == "unlimited"
+    assert attrs["capacity_used_pct"] is None
+
+
+def test_summary_capacity_reports_pct_when_limit_enabled():
+    now = 1_000_000.0
+    discovered = {f"{i:064x}": {"public_key": f"{i:064x}", "type": NODE_TYPE_CLIENT,
+                                "last_advert": now} for i in range(25)}
+    attrs = summary_attributes(discovered, now=now, limit_enabled=True, max_contacts=100)
+    assert attrs["capacity"] == 100
+    assert attrs["capacity_used_pct"] == 25.0
+
+
+def test_summary_registration_flags_contract():
+    """Pin the load-bearing recorder decision (verified live on the host).
+
+    The summary sensor MUST register disabled-by-default and as a diagnostic
+    entity so a count that ticks on every advert imposes no recorder cost on
+    users who never opted in.
+    """
+    assert SUMMARY_ENTITY_REGISTRY_ENABLED_DEFAULT is False
+    assert SUMMARY_ENTITY_CATEGORY == "diagnostic"
+
+
+# =============================================================================
+# Mode reconciliation of EXISTING discovered contacts
+# =============================================================================
+#
+# Live methods (coordinator.async_reconcile_discovered_for_mode +
+# _remove_discovered_contact_entities), run once per setup after platforms are
+# forwarded. Unlike the demote sweep (data_only only), the reconciler removes
+# discovered per-contact entities in BOTH data_only and off, iterates the whole
+# discovered population, and in off additionally clears + persists the
+# discovered set; full ensures an entity exists for each existing discovered
+# contact (idempotent via the tracked set). Added contacts are spared by the
+# added-set membership test, unioned with the SDK's authoritative contact list
+# so a transient-empty _contacts cannot misclassify an added contact as
+# discovered. Subscription-backed and neighbor entities are spared by the same
+# unique_id-SHAPE allowlist as the demote sweep. The post-reload call site (once
+# per setup, correct coordinator) and the added-set union are exercised live on
+# the HA host.
+
+class _FakeStore:
+    """Stand-in for the discovered-contacts Store; records the off persist."""
+
+    def __init__(self):
+        self.saved = None
+        self.save_calls = 0
+
+    def save_sync(self, data):
+        self.save_calls += 1
+        self.saved = dict(data)
+
+
+def _make_reconcile_coordinator(mode=None, entry_id="01ENTRY", added=None,
+                                discovered=None, tracked=None,
+                                tracked_repeaters=None, tracked_clients=None,
+                                telemetry_keys=None, tracker_keys=None,
+                                sdk_contacts=None):
+    return SimpleNamespace(
+        config_entry=_FakeEntry(mode, entry_id),
+        _contacts={pk[:12]: {"public_key": pk} for pk in (added or [])},
+        _discovered_contacts={pk: {"public_key": pk} for pk in (discovered or [])},
+        tracked_diagnostic_binary_contacts=set(tracked or ()),
+        _tracked_repeaters=list(tracked_repeaters or []),
+        _tracked_clients=list(tracked_clients or []),
+        telemetry_manager=SimpleNamespace(
+            discovered_sensors={k: object() for k in (telemetry_keys or [])}
+        ),
+        device_tracker_manager=SimpleNamespace(
+            discovered_trackers={k: object() for k in (tracker_keys or [])}
+        ),
+        _store=_FakeStore(),
+        # Stand-in for self.api.mesh_core.contacts (the added set union safety net).
+        _sdk_contacts={pk[:12]: {"public_key": pk} for pk in (sdk_contacts or [])},
+    )
+
+
+def _reconcile_added_pubkeys(coordinator):
+    """Mirror of the reconciler's added-set union (self._contacts | SDK list)."""
+    sdk = getattr(coordinator, "_sdk_contacts", {}) or {}
+    return {
+        c.get("public_key")
+        for c in list(coordinator._contacts.values()) + list(sdk.values())
+        if isinstance(c, dict) and c.get("public_key")
+    }
+
+
+def _reconcile_remove_entities(coordinator, entity_registry, public_key):
+    """Mirror of coordinator._remove_discovered_contact_entities.
+
+    binary_sensor removal is unconditional; the telemetry/GPS sweep + dedup-map
+    discards are gated on NOT having a tracked subscription. Allowlist by
+    unique_id SHAPE so a neighbor sensor (embedding another node's pubkey) is
+    never matched. Returns True if a contact binary_sensor was removed.
+    """
+    prefix = public_key[:12]
+    coordinator.tracked_diagnostic_binary_contacts.discard(public_key)
+    removed = False
+    unique_id = f"{coordinator.config_entry.entry_id}_contact_{prefix}"
+    entity_id = entity_registry.async_get_entity_id("binary_sensor", DOMAIN, unique_id)
+    if entity_id:
+        entity_registry.async_remove(entity_id)
+        removed = True
+    if not _node_has_tracked_subscription(coordinator, prefix):
+        uid_prefix = f"{coordinator.config_entry.entry_id}_{prefix}_"
+        to_remove = [
+            e.entity_id
+            for e in entity_registry.entries_for_config_entry()
+            if (e.unique_id or "").startswith(uid_prefix)
+            and (
+                e.unique_id.endswith("_telemetry")
+                or e.unique_id.endswith("_gps_tracker")
+            )
+        ]
+        for stale_entity_id in to_remove:
+            entity_registry.async_remove(stale_entity_id)
+        tm = getattr(coordinator, "telemetry_manager", None)
+        if tm is not None:
+            for key in [k for k in tm.discovered_sensors if k.startswith(prefix)]:
+                del tm.discovered_sensors[key]
+        dtm = getattr(coordinator, "device_tracker_manager", None)
+        if dtm is not None:
+            for key in [k for k in dtm.discovered_trackers if k.startswith(prefix)]:
+                del dtm.discovered_trackers[key]
+    return removed
+
+
+def reconcile_for_mode(coordinator, entity_registry):
+    """Faithful mirror of coordinator.async_reconcile_discovered_for_mode.
+
+    Returns (created, removed): the list of created sensors (full) and the list
+    of removed entity_ids (data_only/off).
+    """
+    mode = get_contact_discovery_mode(coordinator.config_entry)
+    added_pubkeys = _reconcile_added_pubkeys(coordinator)
+
+    if mode == MODE_FULL:
+        created = []
+        for contact in list(coordinator._discovered_contacts.values()):
+            if not isinstance(contact, dict):
+                continue
+            pubkey = contact.get("public_key")
+            if pubkey and pubkey in added_pubkeys:
+                continue  # added contacts use the normal create path
+            sensor = create_contact_sensor(coordinator, contact)
+            if sensor:
+                created.append(sensor)
+        return created, []
+
+    # data_only / off
+    for public_key in list(coordinator._discovered_contacts.keys()):
+        if public_key in added_pubkeys:
+            continue  # never touch added contacts
+        _reconcile_remove_entities(coordinator, entity_registry, public_key)
+    if mode == MODE_OFF:
+        coordinator._discovered_contacts.clear()
+        coordinator._store.save_sync(coordinator._discovered_contacts)
+    return [], list(entity_registry.removed)
+
+
+def _reconcile_registry(entry_id, contact_pks):
+    """Registry seeded with a _contact_ binary_sensor for each given pubkey."""
+    return _FakeSweepRegistry({
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{pk[:12]}"):
+            f"binary_sensor.meshcore_{pk[:12]}"
+        for pk in contact_pks
+    })
+
+
+_DISC_A = "a1" * 32
+_DISC_B = "b2" * 32
+_DISC_C = "c3" * 32
+
+
+def test_reconcile_data_only_removes_discovered_keeps_added():
+    """data_only: discovered per-contact entities removed; the added one kept."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A, _DISC_B, ADDED_PK])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, added=[ADDED_PK],
+        discovered=[_DISC_A, _DISC_B], tracked=[_DISC_A, _DISC_B, ADDED_PK],
+    )
+    _created, removed = reconcile_for_mode(coord, reg)
+    assert set(removed) == {
+        f"binary_sensor.meshcore_{_DISC_A[:12]}",
+        f"binary_sensor.meshcore_{_DISC_B[:12]}",
+    }
+    # Added contact's entity survives in the registry and the tracked set.
+    assert reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{entry_id}_contact_{ADDED_PK[:12]}"
+    ) == f"binary_sensor.meshcore_{ADDED_PK[:12]}"
+    assert coord.tracked_diagnostic_binary_contacts == {ADDED_PK}
+
+
+def test_reconcile_data_only_keeps_discovered_data():
+    """data_only: the discovered DATA (the dict) is preserved -- only entities go."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, discovered=[_DISC_A], tracked=[_DISC_A],
+    )
+    reconcile_for_mode(coord, reg)
+    assert _DISC_A in coord._discovered_contacts  # data kept
+    assert coord._store.save_calls == 0  # data_only does not persist-clear
+
+
+def test_reconcile_off_removes_discovered_and_clears_set():
+    """off: entities removed AND the discovered set cleared + persisted."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A, _DISC_B])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_OFF, entry_id=entry_id, discovered=[_DISC_A, _DISC_B],
+        tracked=[_DISC_A, _DISC_B],
+    )
+    _created, removed = reconcile_for_mode(coord, reg)
+    assert set(removed) == {
+        f"binary_sensor.meshcore_{_DISC_A[:12]}",
+        f"binary_sensor.meshcore_{_DISC_B[:12]}",
+    }
+    assert coord._discovered_contacts == {}  # cleared
+    assert coord._store.save_calls == 1  # persisted
+    assert coord._store.saved == {}  # the empty set was saved
+
+
+def test_reconcile_off_keeps_added_entity_and_data():
+    """off: an added contact is never removed even though the set is cleared."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A, ADDED_PK])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_OFF, entry_id=entry_id, added=[ADDED_PK],
+        discovered=[_DISC_A], tracked=[_DISC_A, ADDED_PK],
+    )
+    reconcile_for_mode(coord, reg)
+    assert reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{entry_id}_contact_{ADDED_PK[:12]}"
+    ) == f"binary_sensor.meshcore_{ADDED_PK[:12]}"
+    assert ADDED_PK in coord.tracked_diagnostic_binary_contacts
+    # _discovered_contacts held only discovered keys, so clearing it is correct
+    # and does not touch the added contact (which lives in _contacts).
+    assert coord._discovered_contacts == {}
+
+
+def test_reconcile_full_creates_existing_discovered():
+    """full: every existing discovered contact gets an entity (gate #6)."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [])  # none exist yet
+    coord = _make_reconcile_coordinator(
+        mode=MODE_FULL, entry_id=entry_id, discovered=[_DISC_A, _DISC_B, _DISC_C],
+    )
+    created, _removed = reconcile_for_mode(coord, reg)
+    assert set(created) == {
+        f"SENSOR:{_DISC_A[:12]}",
+        f"SENSOR:{_DISC_B[:12]}",
+        f"SENSOR:{_DISC_C[:12]}",
+    }
+    assert coord.tracked_diagnostic_binary_contacts == {_DISC_A, _DISC_B, _DISC_C}
+
+
+def test_reconcile_full_idempotent_second_run_creates_nothing():
+    """full: a second reconcile in the same mode creates nothing (gates #6/#8)."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_FULL, entry_id=entry_id, discovered=[_DISC_A, _DISC_B],
+    )
+    reconcile_for_mode(coord, reg)
+    created2, _ = reconcile_for_mode(coord, reg)  # already tracked -> no double
+    assert created2 == []
+
+
+def test_reconcile_data_only_idempotent_second_run_removes_nothing():
+    """data_only: a second reconcile finds no discovered entity to remove (gate #8)."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, discovered=[_DISC_A], tracked=[_DISC_A],
+    )
+    reconcile_for_mode(coord, reg)
+    reg.removed.clear()
+    _created, removed2 = reconcile_for_mode(coord, reg)
+    assert removed2 == []
+
+
+def test_reconcile_off_idempotent_second_run_is_noop():
+    """off: a second reconcile on the already-empty set removes/saves nothing
+    (the persisted empty set is not repopulated by store-load) (gate #8)."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_OFF, entry_id=entry_id, discovered=[_DISC_A], tracked=[_DISC_A],
+    )
+    reconcile_for_mode(coord, reg)
+    reg.removed.clear()
+    saves_after_first = coord._store.save_calls
+    _created, removed2 = reconcile_for_mode(coord, reg)
+    assert removed2 == []
+    # The empty set is saved again (harmless) but nothing is removed.
+    assert coord._discovered_contacts == {}
+    assert coord._store.save_calls == saves_after_first + 1
+
+
+def test_reconcile_bulk_spares_added_among_many():
+    """data_only bulk pass over many discovered + a few added: only the
+    discovered ones are removed; every added contact survives (gate #5 bulk)."""
+    entry_id = "01ENTRY"
+    discovered = [f"{i:02x}" + "dd" * 31 for i in range(20)]
+    added = [ADDED_PK, _DISC_C]  # two added contacts mixed in the registry
+    reg = _reconcile_registry(entry_id, discovered + added)
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, added=added,
+        discovered=discovered, tracked=set(discovered) | set(added),
+    )
+    _created, removed = reconcile_for_mode(coord, reg)
+    assert len(removed) == 20
+    for pk in added:
+        assert reg.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"{entry_id}_contact_{pk[:12]}"
+        ) == f"binary_sensor.meshcore_{pk[:12]}"
+    assert coord.tracked_diagnostic_binary_contacts == set(added)
+
+
+def test_reconcile_added_via_sdk_union_is_spared():
+    """A contact present in the SDK list but absent from _contacts is still
+    treated as added (the union safety net) and not removed."""
+    entry_id = "01ENTRY"
+    reg = _reconcile_registry(entry_id, [_DISC_A, ADDED_PK])
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id, added=[],  # _contacts empty
+        sdk_contacts=[ADDED_PK],                            # but SDK knows it
+        discovered=[_DISC_A, ADDED_PK], tracked=[_DISC_A, ADDED_PK],
+    )
+    _created, removed = reconcile_for_mode(coord, reg)
+    assert removed == [f"binary_sensor.meshcore_{_DISC_A[:12]}"]
+    assert reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{entry_id}_contact_{ADDED_PK[:12]}"
+    ) == f"binary_sensor.meshcore_{ADDED_PK[:12]}"
+
+
+def test_reconcile_data_only_spares_subscription_telemetry_and_neighbor():
+    """data_only bulk: a discovered contact's telemetry/GPS are swept, BUT a
+    subscription-backed contact's are spared, and a neighbor sensor (owned by
+    another node, embedding this contact's prefix as the neighbor) is never
+    matched -- the unique_id-SHAPE allowlist (gate #5)."""
+    entry_id = "01ENTRY"
+    target_prefix = _DISC_A[:12]
+    sub_prefix = _DISC_B[:12]
+    other_prefix = _DISC_C[:12]
+    reg = _FakeSweepRegistry({
+        # Target discovered contact: contact bs + telemetry + gps (all swept).
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{target_prefix}"):
+            "binary_sensor.target_contact",
+        ("sensor", DOMAIN, f"{entry_id}_{target_prefix}_1_temperature_telemetry"):
+            "sensor.target_temp",
+        ("device_tracker", DOMAIN, f"{entry_id}_{target_prefix}_gps_tracker"):
+            "device_tracker.target_gps",
+        # Subscription-backed discovered contact: telemetry must SURVIVE.
+        ("binary_sensor", DOMAIN, f"{entry_id}_contact_{sub_prefix}"):
+            "binary_sensor.sub_contact",
+        ("sensor", DOMAIN, f"{entry_id}_{sub_prefix}_1_temperature_telemetry"):
+            "sensor.sub_temp",
+        # Neighbor sensor owned by OTHER node, embedding target_prefix as the
+        # neighbor pubkey -- must NOT be swept (startswith other_prefix, and not
+        # a _telemetry/_gps_tracker suffix).
+        ("sensor", DOMAIN, f"{entry_id}_{other_prefix}_neighbor_{target_prefix}"):
+            "sensor.other_neighbor_of_target",
+    })
+    coord = _make_reconcile_coordinator(
+        mode=MODE_DATA_ONLY, entry_id=entry_id,
+        discovered=[_DISC_A, _DISC_B],  # target + subscription-backed
+        tracked=[_DISC_A, _DISC_B],
+        tracked_clients=[{"pubkey_prefix": sub_prefix}],  # _DISC_B is subscribed
+        telemetry_keys=[f"{target_prefix}_1_temperature", f"{sub_prefix}_1_temperature"],
+        tracker_keys=[f"{target_prefix}_gps"],
+    )
+    _created, removed = reconcile_for_mode(coord, reg)
+    # Target's contact bs + telemetry + gps removed.
+    assert "binary_sensor.target_contact" in removed
+    assert "sensor.target_temp" in removed
+    assert "device_tracker.target_gps" in removed
+    # Subscription-backed contact: bs removed (it is a discovered contact) but
+    # its subscription-backed telemetry SURVIVES (recreates from the sub).
+    assert "binary_sensor.sub_contact" in removed
+    assert reg.async_get_entity_id(
+        "sensor", DOMAIN, f"{entry_id}_{sub_prefix}_1_temperature_telemetry"
+    ) == "sensor.sub_temp"
+    # Neighbor sensor owned by another node survives untouched.
+    assert reg.async_get_entity_id(
+        "sensor", DOMAIN, f"{entry_id}_{other_prefix}_neighbor_{target_prefix}"
+    ) == "sensor.other_neighbor_of_target"
+    # Subscription-backed contact's telemetry key NOT discarded from the map.
+    assert f"{sub_prefix}_1_temperature" in coord.telemetry_manager.discovered_sensors
+    assert f"{target_prefix}_1_temperature" not in coord.telemetry_manager.discovered_sensors

--- a/tests/test_create_contact_sensor_real.py
+++ b/tests/test_create_contact_sensor_real.py
@@ -1,0 +1,183 @@
+"""Regression tests that exercise the REAL ``binary_sensor.create_contact_sensor``.
+
+Companion to ``test_contact_discovery_mode.py``, which tests a hand-written
+*mirror* of the gate. The mirror exists because ``binary_sensor`` cannot be
+imported whole under the conftest stubs: its entity classes subclass mocked HA
+bases, and conftest replaces the module itself with a ``MagicMock``. But a mirror
+passes whether or not production matches it, so a production-only regression in
+``create_contact_sensor`` would not be caught -- which is exactly how the
+2026-06-15 off-mode orphaned-entity bug shipped past the green unit suite (the
+mirror had replicated the buggy gate).
+
+This module closes that gap WITHOUT importing ``binary_sensor``: it parses
+``binary_sensor.py``, extracts only the ``create_contact_sensor`` ``FunctionDef``,
+and ``exec``s it with its free names bound (the real ``const`` accessor + the
+``MODE_*`` constants, plus a sentinel for the entity class). The assertions
+therefore run the real production source -- a regression in the gate (e.g.
+dropping the ``off`` branch) flips them red. The suppression paths return before
+the entity class is ever instantiated, so the sentinel only matters on the
+create paths.
+"""
+import ast
+import importlib.util
+import os
+import sys
+import types
+
+_PKG = "custom_components.meshcore"
+_BASE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "custom_components", "meshcore"
+)
+
+
+# --- Load the real const.py (bypass the conftest MagicMock stub) -------------
+_cc = types.ModuleType("custom_components")
+_cc.__path__ = [os.path.dirname(_BASE)]
+sys.modules["custom_components"] = _cc
+_ccm = types.ModuleType(_PKG)
+_ccm.__path__ = [_BASE]
+sys.modules[_PKG] = _ccm
+
+
+def _load_real(modname: str, filename: str):
+    spec = importlib.util.spec_from_file_location(
+        modname, os.path.join(_BASE, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = _PKG
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+const = _load_real(f"{_PKG}.const", "const.py")
+MODE_FULL = const.MODE_FULL
+MODE_DATA_ONLY = const.MODE_DATA_ONLY
+MODE_OFF = const.MODE_OFF
+CONF_MODE = const.CONF_CONTACT_DISCOVERY_MODE
+
+
+# --- Extract the real create_contact_sensor without importing the module -----
+
+class _SentinelSensor:
+    """Stand-in for MeshCoreContactDiagnosticBinarySensor on the create path."""
+
+    def __init__(self, coordinator, name, public_key, unique_id):
+        self.name = name
+        self.public_key = public_key
+        self.unique_id = unique_id
+
+
+def _extract_create_contact_sensor():
+    with open(os.path.join(_BASE, "binary_sensor.py"), encoding="utf-8") as fh:
+        src = fh.read()
+    fn = next(
+        (n for n in ast.parse(src).body
+         if isinstance(n, ast.FunctionDef) and n.name == "create_contact_sensor"),
+        None,
+    )
+    assert fn is not None, "create_contact_sensor not found in binary_sensor.py"
+    code = compile(ast.Module(body=[fn], type_ignores=[]), "binary_sensor.py", "exec")
+    namespace = {
+        "get_contact_discovery_mode": const.get_contact_discovery_mode,
+        "MODE_DATA_ONLY": MODE_DATA_ONLY,
+        "MODE_OFF": MODE_OFF,
+        "MeshCoreContactDiagnosticBinarySensor": _SentinelSensor,
+    }
+    exec(code, namespace)  # noqa: S102 -- executing our own production source
+    return namespace["create_contact_sensor"]
+
+
+create_contact_sensor = _extract_create_contact_sensor()
+
+
+# --- Fakes (match test_contact_discovery_mode.py shapes) ---------------------
+
+class _FakeEntry:
+    def __init__(self, mode=None, entry_id="01ENTRY"):
+        self.entry_id = entry_id
+        self.data = {} if mode is None else {CONF_MODE: mode}
+
+
+class _FakeCoordinator:
+    def __init__(self, mode=None, added=None, entry_id="01ENTRY"):
+        self.config_entry = _FakeEntry(mode, entry_id)
+        # _contacts is keyed by 12-hex prefix in production; only the
+        # public_key values matter to the gate.
+        self._contacts = {pk[:12]: {"public_key": pk} for pk in (added or [])}
+        self.tracked_diagnostic_binary_contacts = set()
+
+
+# --- Suppression / create matrix against the REAL function -------------------
+
+def test_full_discovered_creates_and_tracks():
+    """full: a discovered (un-added) contact is created and tracked."""
+    coord = _FakeCoordinator(MODE_FULL)
+    pk = "aa" * 16
+    sensor = create_contact_sensor(coord, {"public_key": pk})
+    assert isinstance(sensor, _SentinelSensor)
+    assert pk in coord.tracked_diagnostic_binary_contacts
+
+
+def test_default_mode_creates():
+    """Unset mode defaults to full -> discovered contact created."""
+    sensor = create_contact_sensor(_FakeCoordinator(None), {"public_key": "bb" * 16})
+    assert isinstance(sensor, _SentinelSensor)
+
+
+def test_off_suppresses_discovered():
+    """off: a discovered (un-added) contact returns None and is not tracked.
+
+    Regression guard for the orphaned-entity bug -- the setup path calls this
+    gate directly with no off early-return of its own, so the gate itself must
+    suppress, or a reload in off mode materializes an entity per contact.
+    """
+    coord = _FakeCoordinator(MODE_OFF)
+    assert create_contact_sensor(coord, {"public_key": "cc" * 16}) is None
+    assert coord.tracked_diagnostic_binary_contacts == set()
+
+
+def test_off_keeps_added():
+    """off: an added/curated contact still gets its entity."""
+    pk = "cd" * 16
+    coord = _FakeCoordinator(MODE_OFF, added=[pk])
+    assert isinstance(create_contact_sensor(coord, {"public_key": pk}), _SentinelSensor)
+
+
+def test_data_only_suppresses_discovered():
+    """data_only: a discovered (un-added) contact returns None and is not tracked."""
+    coord = _FakeCoordinator(MODE_DATA_ONLY)
+    assert create_contact_sensor(coord, {"public_key": "dd" * 16}) is None
+    assert coord.tracked_diagnostic_binary_contacts == set()
+
+
+def test_data_only_keeps_added_with_entry_scoped_uid():
+    """data_only: an added contact gets its entity, with the entry-scoped uid."""
+    pk = "ee" * 16
+    coord = _FakeCoordinator(MODE_DATA_ONLY, added=[pk])
+    sensor = create_contact_sensor(coord, {"public_key": pk})
+    assert isinstance(sensor, _SentinelSensor)
+    assert sensor.unique_id == f"01ENTRY_contact_{pk[:12]}"
+
+
+def test_data_only_other_added_does_not_unblock():
+    """data_only: a different added contact does not unblock an un-added one."""
+    coord = _FakeCoordinator(MODE_DATA_ONLY, added=["1a" * 16])
+    assert create_contact_sensor(coord, {"public_key": "2b" * 16}) is None
+    assert ("2b" * 16) not in coord.tracked_diagnostic_binary_contacts
+
+
+def test_non_dict_returns_none():
+    assert create_contact_sensor(_FakeCoordinator(MODE_FULL), "not-a-dict") is None
+
+
+def test_missing_public_key_returns_none():
+    assert create_contact_sensor(_FakeCoordinator(MODE_FULL), {"adv_name": "NoKey"}) is None
+
+
+def test_already_tracked_is_idempotent():
+    """A contact already in the tracked set is not re-created (any mode)."""
+    coord = _FakeCoordinator(MODE_FULL)
+    pk = "cc" * 16
+    coord.tracked_diagnostic_binary_contacts.add(pk)
+    assert create_contact_sensor(coord, {"public_key": pk}) is None


### PR DESCRIPTION
### Summary

This reshapes the PR per your review. It replaces the two overlapping contact-discovery flags — the existing `disable_contact_discovery` and the `large_mesh_mode` boolean this PR originally proposed — with a single **`contact_discovery_mode`** select offering three values:

- **Entity per contact** (`full`) — today's default: one `binary_sensor` per discovered contact.
- **Data only** (`data_only`) — discovered contacts are tracked as data (visible in the discovered-contact dropdown, the aggregate summary sensor, and the `get_discovered_contact` lookup service) but get no per-contact entity. This is the behaviour the `large_mesh_mode` boolean added.
- **Disabled** (`off`) — discovered-contact processing is suppressed and the existing discovered set is cleared. This is what `disable_contact_discovery=true` did, now also reconciling already-stored discovered contacts.

Added/curated contacts keep their entities in every mode. Existing installs migrate automatically via a config-entry migration (no reload, no entity-registry churn). With the mode left at its migrated default, behaviour is unchanged from today.

This answers your 2026-06-13 note that the two booleans ask the same question — "how much discovered-contact machinery do I want" — with different mechanics, and that a second overlapping flag is a confusing config surface.

### Problem

The integration creates one `binary_sensor` per discovered contact. On dense meshes this means hundreds of entities for transient peers heard in passing. On my instance, 100 of ~105 discovered-contact entities sat permanently in `discovered` — never promoted, never charted, never used in an automation — and the surfaces users actually work through (the discovered-contact dropdown, the add/remove/clear services, the chat panel) all read coordinator data rather than these entities. That is the situation Home Assistant's [entity-disabled-by-default rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-disabled-by-default/) warns about: noisy, low-utility entities shouldn't make every user pay their tracking cost by default.

The larger cost is churn. Measured on my instance, the registry's `deleted_entities` array held **766 deleted meshcore contact entities — 94.6% of all 810 deleted entities in the entire registry** (every other integration combined: 44). That debris re-accumulated within two days of being manually cleared, and 453 of the 766 carried numeric collision suffixes (`_contact_2`, `_3`, …) — direct evidence of contacts cycling through create/delete repeatedly. The entity registry is a single multi-megabyte JSON store HA rewrites in full on a short debounce whenever entities are added or removed, so this cycle drives repeated whole-file rewrites (flash wear on the SD/eMMC typical of HA hardware) plus recorder state history for entities that live a few days.

Separately, the integration already had `disable_contact_discovery` to suppress discovered-contact processing entirely. So before this PR there were two flags addressing the same axis with different mechanics. This reshape unifies them.

### Approach

A single `contact_discovery_mode` setting (stored values `full` / `data_only` / `off`, default `full`), read through one accessor `get_contact_discovery_mode(config_entry)` that every consumer calls. The fundamental gate is unchanged from the original: `create_contact_sensor` suppresses a per-contact `binary_sensor` for contacts not in the coordinator's added set — now when the mode is `data_only` or `off` (added contacts always get an entity; only `full` creates one for a discovered contact).

Existing entries migrate in `async_migrate_entry` (config-entry `VERSION` 2 → 3), which runs before setup, rewrites `config_entry.data` only, and never touches the entity registry or schedules a reload:

- `disable_contact_discovery=true` → `off` (wins the tie-break even if `large_mesh_mode` was also set — no discovery means nothing to be data-only)
- else `large_mesh_mode=true` → `data_only`
- else → `full`

### Reconciliation of existing contacts on mode switch

Changing the mode reloads the entry, and a single reconciliation pass runs on every setup, in the coordinator's post-reload path, to enforce the chosen mode on the *existing* discovered population — so a switch takes effect immediately rather than only applying to newly-heard contacts. This restores the immediate cleanup you removed as racy, but race-free: it runs after the reload against the final coordinator/registry state, not from the options flow.

- **Disabled** (`off`) — clears the existing discovered set (persisted, so it stays empty across reloads) and gates incoming adverts so they don't repopulate it; the dropdown and summary sensor go empty. The radio keeps hearing adverts — HA just stops tracking them. It is entirely HA-side: the companion is already in manual mode, so discovered contacts only ever lived in HA, and there is no radio mutation.
- **Data only** (`data_only`) — removes the per-contact entities of existing discovered contacts but keeps their data (the dropdown, summary sensor, and `get_discovered_contact` still work).
- **Entity per contact** (`full`) — recreates per-contact entities for the existing discovered set on the next setup, and for new contacts as they are heard.

The pass is idempotent (a no-op in a steady mode) and reuses the demote sweep's unique-id allowlist, so it never touches added contacts, tracked-client/subscription entities, or repeater-neighbor sensors. This removes the earlier need to run `clear_discovered_contacts` by hand after switching.

### What's included

- **`const`** — `contact_discovery_mode` key, the three mode values, default, and the `get_contact_discovery_mode` accessor. The two old `CONF_*` flags are removed once all consumers are re-keyed; the migration reads the literal old keys so it doesn't depend on the retired constants.
- **`__init__` migration** — the `v2→v3` branch above; v1 entries chain through to v3 in one pass.
- **`binary_sensor`** — `create_contact_sensor` suppresses discovered contacts in `data_only` and `off`; both call paths (the contacts-update event path and the platform-setup path) route through the one gate, so a reload in any mode is consistent.
- **`coordinator` / `services`** — the eviction, stale-cleanup, remove-discovered, and clear-discovered paths run unconditionally; in `data_only`/`off` the registry lookup simply returns nothing, and the same pass cleans up any entities stranded by a prior mode. The demote path (removing an added contact) still removes that contact's acquired entities in `data_only`/`off`, with subscription-managed telemetry/GPS entities excluded.
- **`config_flow`** — `VERSION = 3`; one `contact_discovery_mode` SelectSelector replaces both booleans on every install path (USB/BLE/TCP) and in the options step. The racy toggle-on migration is deleted (the entry migration replaces it).
- **`sensor`** — the aggregate "Discovered Contacts" summary sensor (diagnostic, disabled-by-default) is unchanged and created in all modes, so users can gauge the discovered count before switching.
- **`services`** — `get_discovered_contact` gains a min-length guard on `pubkey_prefix` (enforced both at the `vol.Schema` and inline) so an empty prefix returns `not_found` instead of matching an arbitrary contact.
- **`README` + docs site + `en.json`** — retitled to the unified tier model (Entity per contact / Data only / Disabled), the inspection surfaces, and the one trade-off.

### What it does NOT change

- **Default behaviour** (mode `full`): byte-for-byte today's — entity per discovered contact, all cleanup paths active.
- **Added/curated contacts**: get entities in every mode; promotion creates the entity.
- **Channels, repeater/neighbor telemetry, companion sensors, message store, RX_LOG correlation, logbook, MQTT uploader**: none are per-discovered-contact; all unchanged.
- **The discovered-contact dropdown**: already data-driven from coordinator data, so it lists discovered contacts in `full` and `data_only`.
- **`meshcore_py`**: no SDK change and no `manifest.json` requirement bump — the mode gates are HA-side only.

### Review fixes (from your 2026-06-11 notes)

1. **Toggle-on migration raced the options reload** → removed entirely; replaced by the `async_migrate_entry` config-data migration, which runs before setup and never schedules a reload or touches the registry. (The entity cleanup it used to do is now handled race-free by the setup-time reconciliation pass above.)
2. **`if large_mesh` gates blocked entity removal exactly when leftovers existed** → the cleanup gates are gone; removal runs unconditionally and is a harmless no-op when there's nothing to remove.
3. **"Run `clear_discovered_contacts` after enabling" guidance** → no longer needed; mode switches reconcile existing contacts automatically (see above).
4. **Empty `pubkey_prefix` matched an arbitrary contact** (`startswith("")` is always true) → min-length guard at the schema and inline.

### Trade-off (the one visible loss)

In `data_only` and `off` there is no per-discovered-contact connectivity sensor, so no per-contact charting or automation for un-added contacts. The aggregate summary sensor and the `get_discovered_contact` service cover inspection; promoting a contact to "added" restores a full entity.

### Testing

Unit coverage drives the real code paths: the `create_contact_sensor` gate across all three modes (including a test that AST-extracts and runs the *real* function against production source, with a negative control), the `async_migrate_entry` mappings (disable→off, both→off, large→data_only, neither→full, old keys dropped, v1→v3 chained), the unconditional cleanup paths, the demote-removal decision and its telemetry/GPS sweep with subscription exclusion, the summary sensor, and the lookup service including the empty-prefix guard. Config-flow tests confirm each install path defaults to `full` and the options step round-trips the select. Full suite green on Python 3.13; `py_compile` and `en.json` / `services.yaml` parse clean. All 197 tests pass.

The change has also run on my own instance for a day of normal operation: the migrated entry stayed on `data_only` with the old keys gone, the discovered/added census stayed stable across several restarts, and there was no migration re-fire, reload-race, or new error attributable to the change.

### Notes / open questions for review

- **Labels.** Used **Entity per contact** / **Data only** / **Disabled** per your suggestion that "full" is too vague as a user-facing label; stored values stay `full` / `data_only` / `off`.
- **Storage location.** `contact_discovery_mode` is in `config_entry.data` alongside the existing contact-settings cluster, per your call; the broader `data` → `options` migration remains a separate refactor.
- **Accessor.** Added `get_contact_discovery_mode(config_entry)` as the single read point, replacing the scattered `.data.get(...)` reads.
- **Migration.** Proper `async_migrate_entry` (VERSION 2→3), before setup, no reload, no registry access — per your "migration approach is right" note; the off-wins tie-break is as you confirmed.