### PR TITLE
fix(mqtt_uploader): emit UTC Z-suffixed timestamps in /status and /packets

### DIFF
--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -12,7 +12,7 @@ import ssl
 import subprocess
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from typing import Any
 
@@ -819,7 +819,7 @@ class MeshCoreMqttUploader:
         """Build status payload compatible with other uploaders."""
         payload: dict[str, Any] = {
             "status": state,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",
@@ -1016,7 +1016,7 @@ class MeshCoreMqttUploader:
     def _build_raw_event_payload(self, event_type: str, payload: Any) -> dict[str, Any]:
         """Build raw event payload for non-normalized broker mode."""
         return {
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "source": "meshcore-ha",
@@ -1145,7 +1145,7 @@ class MeshCoreMqttUploader:
         if "RX_LOG" not in et and "RF_LOG" not in et and "PACKET" not in et:
             return None
 
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         payload_hex = str(payload.get("payload") or "").strip()
         raw_hex_fallback = str(payload.get("raw_hex") or "").strip()
         # Match packet-capture behavior: prefer payload, fallback to raw_hex without first 2 bytes.
@@ -1209,7 +1209,7 @@ class MeshCoreMqttUploader:
             route = str(payload.get("route") or "").strip().upper() or "F"
 
         packet = {
-            "timestamp": now.isoformat(),
+            "timestamp": now.isoformat().replace("+00:00", "Z"),
             "origin": self.node_name,
             "origin_id": self.public_key or "DEVICE",
             "type": "PACKET",


### PR DESCRIPTION
## Problem

Four sites in `custom_components/meshcore/mqtt_uploader.py` emit naive (timezone-less) ISO 8601 timestamps in `/status` and `/packets` payloads:

| Line | Context | Current |
|---|---|---|
| 15 | import | `from datetime import datetime` |
| 822 | `_build_status_payload` | `datetime.now().isoformat()` |
| 1019 | `_build_raw_event_payload` | `datetime.now().isoformat()` |
| 1148 | `_normalize_packet_event` shared `now` | `now = datetime.now()` |
| 1212 | `_normalize_packet_event` packet `timestamp` | `now.isoformat()` |

Output shape: `"timestamp": "2026-06-09T20:14:27.030713"` — no Z suffix, no offset.

## Symptom

Observers like [CoreScope](https://github.com/Kpa-clawbot/CoreScope) detect these as zone-less local-time, then clamp per-packet `rxTime` to ingest time, breaking propagation-delay analytics.

CoreScope banner I'm seeing on the SWOH instance (mqtt.w8oof.net broker) — 10478 clamp events in 24 hours, ~every packet my XIAO observes:

> ⚠ **Naive observer clock — timing is being clamped**
> This observer is emitting **zone-less local-time** timestamps and its clock is currently **4.0h behind UTC**. We have recorded **10478 clamp events in the last 24 hours**.
> **Fix:** set the observer host clock to UTC, OR have the observer script emit Z-suffixed (`datetime.now(timezone.utc).isoformat()`) or offset-aware timestamps.

Anecdotally, scanning the same broker, every other meshcore-ha v2.6.0/v2.7.0 contributor's `/status` payload also lacks a Z suffix, so this is bridge-wide rather than my install.

## Fix

5-line diff: import `timezone`, switch all 4 timestamp call sites to `datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")`. Output shape becomes `"timestamp": "2026-06-09T20:14:27.030713Z"`.

The `replace("+00:00", "Z")` keeps the wire format compact + matches the RFC 3339 "Z" convention that downstream JS consumers tend to prefer. Could drop the `.replace(...)` and emit `+00:00` instead — CoreScope's banner says either form works — happy to take the maintainer's preference.

## Notes

- `_normalize_packet_event` shares `now` across `timestamp`, `time` (HH:MM:SS), and `date` (D/M/Y) fields. With `now` switched to UTC, the `time` and `date` fields also go UTC. That's the right semantics for observer-broker payloads (downstream dashboards aggregate across timezones).
- No new dependencies. `timezone` is in the stdlib `datetime` module.

## Verification

Patched a v2.6.0 install locally, restarted HA, captured the next `/status` via `mosquitto_sub` against the SWOH broker:

```
"timestamp": "2026-06-10T00:20:31.700048Z"
```

Within 10 seconds of restart, Z-suffixed. CoreScope clamp counter stopped incrementing immediately; banner self-clears after 24h with no new clamp events (per the banner text).
