### PR TITLE
fix: quiet benign no_event_received errors from get_msg loops

### DIFF
--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -69,6 +69,23 @@ _LOGGER = logging.getLogger(__name__)
 MSG_SAFETY_NET_INTERVAL: int = 60
 
 
+def _log_get_msg_error(action: str, payload: Any) -> None:
+    """Log a ``get_msg()`` ERROR result at the appropriate level.
+
+    The ``no_event_received`` reason is a benign startup race: a flush or poll
+    fired before the radio link produced its first event, and the next cycle
+    recovers. It is logged at DEBUG to avoid ERROR-tier noise (e.g. on a
+    config-entry re-add). Every other failure is logged at ERROR. ``action``
+    is the gerund used in the message ("flushing" / "retrieving").
+    """
+    if isinstance(payload, dict) and payload.get("reason") == "no_event_received":
+        _LOGGER.debug(
+            "Skipped %s messages, radio link still coming up: %s", action, payload
+        )
+    else:
+        _LOGGER.error("Error %s messages: %s", action, payload)
+
+
 class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the MeshCore node and trigger event-generating commands."""
 
@@ -1238,9 +1255,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                     if result.type == EventType.NO_MORE_MSGS:
                         break
                     elif result.type == EventType.ERROR:
-                        _LOGGER.error(
-                            "Error flushing messages: %s", result.payload
-                        )
+                        _log_get_msg_error("flushing", result.payload)
                         break
                     else:
                         _LOGGER.debug(
@@ -1424,7 +1439,7 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
                             _LOGGER.debug("No messages in device queue")
                             break
                         elif result.type == EventType.ERROR:
-                            _LOGGER.error("Error retrieving messages: %s", result.payload)
+                            _log_get_msg_error("retrieving", result.payload)
                             break
                         else:
                             _LOGGER.debug("Drained queued message: %s", result.type)

--- a/tests/test_get_msg_error_log_level.py
+++ b/tests/test_get_msg_error_log_level.py
@@ -1,0 +1,129 @@
+"""Regression test for the benign ``no_event_received`` get_msg log level.
+
+Two ``get_msg()`` loops in ``coordinator.py`` can return an ``EventType.ERROR``
+result whose payload is ``{'reason': 'no_event_received'}`` -- a startup race
+where the flush or poll fired before the radio link produced its first event.
+It has no functional impact (the next cycle recovers), but both loops logged
+every ``EventType.ERROR`` result at ERROR, so the benign race surfaced as
+ERROR-tier noise: ``async_flush_messages`` -> "Error flushing messages" and the
+``_async_update_data`` safety-net poll -> "Error retrieving messages" (the one
+actually observed on the live host). Both now route through the shared
+``_log_get_msg_error`` helper, which reason-gates that one payload to DEBUG and
+keeps ERROR for every other failure.
+
+``coordinator.py`` cannot be imported whole under the conftest stubs, so this
+test AST-extracts the real module-level ``_log_get_msg_error`` and runs it with
+its free names bound (the module logger, ``Any``). The assertions therefore
+exercise production source. A second test guards against drift by asserting
+both call sites route through the helper and no raw per-action ERROR log
+survives.
+"""
+import ast
+import logging
+import os
+
+from typing import Any
+
+_BASE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "custom_components", "meshcore"
+)
+_COORDINATOR_PY = os.path.join(_BASE, "coordinator.py")
+
+_LOGGER_NAME = "custom_components.meshcore.coordinator"
+_LOGGER = logging.getLogger(_LOGGER_NAME)
+
+
+def _read_source():
+    with open(_COORDINATOR_PY, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _extract_log_get_msg_error():
+    tree = ast.parse(_read_source())
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_log_get_msg_error"
+    )
+    module = ast.Module(body=[fn], type_ignores=[])
+    ast.fix_missing_locations(module)
+    code = compile(module, _COORDINATOR_PY, "exec")
+    namespace = {"_LOGGER": _LOGGER, "Any": Any}
+    exec(code, namespace)  # noqa: S102 -- executing our own production source
+    return namespace["_log_get_msg_error"]
+
+
+_log_get_msg_error = _extract_log_get_msg_error()
+
+
+def _records(caplog):
+    return [
+        (r.levelno, r.getMessage())
+        for r in caplog.records
+        if r.name == _LOGGER_NAME
+    ]
+
+
+# --- benign startup race -> DEBUG -------------------------------------------
+
+def test_no_event_received_flushing_is_debug_not_error(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_get_msg_error("flushing", {"reason": "no_event_received"})
+    recs = _records(caplog)
+    assert not [m for lvl, m in recs if lvl >= logging.ERROR], recs
+    assert any(
+        lvl == logging.DEBUG and "radio link still coming up" in m
+        for lvl, m in recs
+    ), recs
+
+
+def test_no_event_received_retrieving_is_debug_not_error(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_get_msg_error("retrieving", {"reason": "no_event_received"})
+    recs = _records(caplog)
+    assert not [m for lvl, m in recs if lvl >= logging.ERROR], recs
+    assert any(
+        lvl == logging.DEBUG and "radio link still coming up" in m
+        for lvl, m in recs
+    ), recs
+
+
+# --- real failures keep the original ERROR text -----------------------------
+
+def test_other_reason_flushing_stays_error(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_get_msg_error("flushing", {"reason": "device_error"})
+    errors = [m for lvl, m in _records(caplog) if lvl >= logging.ERROR]
+    assert any("Error flushing messages" in m for m in errors), errors
+
+
+def test_other_reason_retrieving_stays_error(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_get_msg_error("retrieving", {"reason": "device_error"})
+    errors = [m for lvl, m in _records(caplog) if lvl >= logging.ERROR]
+    assert any("Error retrieving messages" in m for m in errors), errors
+
+
+def test_non_dict_payload_stays_error(caplog):
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_get_msg_error("retrieving", "boom")
+    errors = [m for lvl, m in _records(caplog) if lvl >= logging.ERROR]
+    assert any("Error retrieving messages" in m for m in errors), errors
+
+
+# --- drift guard: both call sites route through the helper ------------------
+
+def test_both_call_sites_route_through_helper():
+    src = _read_source()
+    assert '_log_get_msg_error("flushing", result.payload)' in src, (
+        "flush path no longer routes through _log_get_msg_error"
+    )
+    assert '_log_get_msg_error("retrieving", result.payload)' in src, (
+        "poll path no longer routes through _log_get_msg_error"
+    )
+    # No raw per-action ERROR log should survive outside the helper.
+    assert '"Error flushing messages: %s"' not in src, (
+        "a raw 'Error flushing messages' log bypasses the helper"
+    )
+    assert '"Error retrieving messages: %s"' not in src, (
+        "a raw 'Error retrieving messages' log bypasses the helper"
+    )


### PR DESCRIPTION
## Problem

During a config-entry re-add or a radio-link reconnect, two `get_msg()` loops in `coordinator.py` can receive an `EventType.ERROR` result whose payload is `{'reason': 'no_event_received'}` — a startup/reconnect race where the flush or poll fired before the radio link produced its first event. It has no functional impact (the next cycle recovers), but both loops logged every `EventType.ERROR` result at ERROR, so the benign race surfaced as ERROR-tier log noise:

- `async_flush_messages` → `Error flushing messages: {'reason': 'no_event_received'}`
- the `_async_update_data` safety-net poll → `Error retrieving messages: {'reason': 'no_event_received'}`

## Fix

Route both sites through a shared `_log_get_msg_error(action, payload)` helper that logs the `no_event_received` reason at DEBUG and keeps ERROR — with the original message text — for every other failure, including non-dict payloads.

## Tests

`tests/test_get_msg_error_log_level.py` AST-extracts the real `_log_get_msg_error` helper and asserts `no_event_received` → DEBUG for both actions, that other reasons and non-dict payloads stay ERROR with the original text, plus a guard that both call sites route through the helper.

Verified live on Home Assistant 2026.6.2: with the radio link interrupted, the safety-net poll's `no_event_received` now logs at DEBUG (`Skipped retrieving messages, radio link still coming up`) with zero ERROR lines.