### PR TITLE
test: add phcc integration test tier with config-flow coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  pytest:
+  unit:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -25,10 +25,24 @@ jobs:
       - run: pip install -r requirements-test.txt
       # --strict-markers turns an unregistered/typo'd marker into an error
       # rather than a silently-skipped test.
-      - run: pytest --strict-markers --cov=custom_components/meshcore --cov-report=xml --cov-report=term
+      - run: pytest tests --strict-markers --cov=custom_components/meshcore --cov-report=xml --cov-report=term
       - uses: actions/upload-artifact@v4
         if: matrix.python-version == '3.13'
         with:
           name: coverage-xml
           path: coverage.xml
           if-no-files-found: ignore
+
+  integration:
+    # Real Home Assistant via pytest-homeassistant-custom-component. Separate
+    # job (and process) from the unit tier, which stubs Home Assistant.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-test-integration.txt
+      - run: pip install -r requirements-test-integration.txt
+      - run: pytest tests_integration --strict-markers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,12 @@
 # without needing a per-test marker. This prevents the silent-skip failure
 # mode where an async test missing @pytest.mark.asyncio is collected but
 # never actually run.
+# The unit tier (tests/) and integration tier (tests_integration/) run as
+# separate pytest invocations because tests/conftest.py MagicMock-stubs
+# Home Assistant in sys.modules, which is incompatible with the real Home
+# Assistant the integration tier loads. testpaths is therefore not set; CI
+# passes the target directory explicitly.
 asyncio_mode = "auto"
-testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py313"

--- a/requirements-test-integration.txt
+++ b/requirements-test-integration.txt
@@ -1,0 +1,13 @@
+# Integration-tier test deps: real Home Assistant (via pytest-homeassistant-
+# custom-component) plus the integration's runtime deps, so the real
+# custom_components.meshcore package imports and sets up. This tier runs as a
+# SEPARATE pytest invocation from the unit tier (tests/), which MagicMock-stubs
+# Home Assistant in sys.modules and therefore cannot share a process with this.
+pytest-homeassistant-custom-component==0.13.316
+# Pulled in because the integration depends on logbook -> frontend.
+home-assistant-frontend
+meshcore>=2.3.7
+pycryptodome>=3.20.0
+cachetools>=5.3.0
+paho-mqtt>=1.6.0
+pynacl>=1.5.0

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for the integration test tier, which runs against a real Home
+Assistant instance via pytest-homeassistant-custom-component.
+
+This tier is deliberately separate from tests/ (the unit tier). tests/conftest.py
+injects MagicMock stubs for homeassistant.* into sys.modules at import time, which
+is incompatible with the real Home Assistant these tests need. The two tiers must
+run as separate pytest invocations (see .github/workflows/tests.yml).
+
+Tests request `enable_custom_integrations` explicitly (not autouse) so that, where
+the recorder is needed, `recorder_mock` can be ordered before the `hass` fixture
+(phcc requires recorder fixtures to resolve before Home Assistant starts).
+"""
+import logging
+import os
+import sys
+
+# Ensure the repo root (which contains custom_components/) is importable.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# The recorder (pulled in via the logbook dependency) emits very chatty
+# SQL/engine logging during setup; keep test output readable.
+logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)

--- a/tests_integration/test_config_flow.py
+++ b/tests_integration/test_config_flow.py
@@ -1,0 +1,85 @@
+"""Config-flow tests exercising the real flow code under Home Assistant.
+
+The unit tier cannot test this (it stubs Home Assistant), so the ~20 flow steps
+in config_flow.py had no coverage before this tier. These drive the real flow
+handler end to end and assert on the resulting entry.
+"""
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.meshcore.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_TCP_HOST,
+    CONF_TCP_PORT,
+    CONNECTION_TYPE_TCP,
+    DOMAIN,
+)
+
+
+async def test_user_flow_tcp_creates_entry(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant
+) -> None:
+    """User picks TCP, supplies host/port, and an entry is created.
+
+    recorder_mock is required because the integration depends on logbook, which
+    in turn depends on recorder; it must be ordered before hass.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "tcp"
+
+    # validate_tcp_input does real device I/O; stub it. async_setup_entry is
+    # stubbed so creating the entry doesn't try to connect to a real node.
+    with patch(
+        "custom_components.meshcore.config_flow.validate_tcp_input",
+        return_value={"title": "MeshCore TCP", "name": "MeshCore TCP", "pubkey": "deadbeef0123"},
+    ), patch(
+        "custom_components.meshcore.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TCP_HOST: "10.0.0.5", CONF_TCP_PORT: 5000},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_CONNECTION_TYPE] == CONNECTION_TYPE_TCP
+    assert result["data"][CONF_TCP_HOST] == "10.0.0.5"
+    assert result["data"][CONF_TCP_PORT] == 5000
+
+
+async def test_user_flow_cannot_connect(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant
+) -> None:
+    """A failed TCP validation surfaces a cannot_connect error, not an entry."""
+    from custom_components.meshcore.config_flow import CannotConnect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CONNECTION_TYPE: CONNECTION_TYPE_TCP}
+    )
+
+    with patch(
+        "custom_components.meshcore.config_flow.validate_tcp_input",
+        side_effect=CannotConnect,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TCP_HOST: "10.0.0.5", CONF_TCP_PORT: 5000},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
Phase 1 of test hardening: stand up a real-Home-Assistant test tier so we can test the integration the way it actually runs, not just mocked.

## What this adds

- **`tests_integration/`** — a second test tier running against a real HA instance via `pytest-homeassistant-custom-component`. It's separate from `tests/` (the unit tier) because `tests/conftest.py` MagicMock-stubs `homeassistant.*` in `sys.modules`, which is incompatible with the real HA this tier loads. The two run as **separate pytest invocations / CI jobs**.
- **First real tests** (`test_config_flow.py`) cover the config flow, which had **0% coverage** before (the unit tier can't import it): the TCP user-flow happy path (asserts the created entry data) and the `cannot_connect` error path. These drive the real flow handler end to end.
- **`requirements-test-integration.txt`** — phcc + the integration's runtime deps (so the real package imports) + `home-assistant-frontend` (pulled in via the logbook→frontend dependency).
- **CI** — `tests.yml` split into `unit` (3.12/3.13, `pytest tests`, coverage) and `integration` (3.13, `pytest tests_integration`) jobs.

## Notes

- No production code changed.
- `recorder_mock` is required in tests that create an entry, because the integration depends on logbook → recorder.
- This is the foundation for **Phase 2**: a `FakeMeshCore` node simulator to drive `async_setup_entry` and coordinator behavior (login, telemetry, RX_LOG correlation) end to end. That's the deeper piece and is intentionally not in this PR.

## Verified locally

- `pytest tests` → 215 passed (unit tier still green with real HA now installed — the stubbing correctly overrides it).
- `pytest tests_integration` → 2 passed.