### PR TITLE
fix: outgoing direct message lost when send_message is called with entry_id

### DIFF
--- a/custom_components/meshcore/binary_sensor.py
+++ b/custom_components/meshcore/binary_sensor.py
@@ -347,6 +347,11 @@ async def async_setup_entry(
         so the filter has authoritative source data.
         """
         if event.data.get("device") != entry.entry_id:
+            _LOGGER.debug(
+                "Ignoring message_sent for device %s (not %s)",
+                event.data.get("device"),
+                entry.entry_id,
+            )
             return
         if event.data.get("message_type") == "direct":
             # Handle outgoing direct message

--- a/custom_components/meshcore/services.py
+++ b/custom_components/meshcore/services.py
@@ -248,7 +248,22 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         # service call returns immediately after sending.
                         send_id = uuid.uuid4().hex[:8]
 
-                        async def _wait_for_ack_and_notify():
+                        # Bind every loop-scoped value this background task reads
+                        # by value at task-creation time. Without this, the deferred
+                        # task reads the loop variables when it *executes* (~0.5-1s
+                        # later, after the ACK), by which point the
+                        # ``for config_entry_id, ...`` loop may have advanced past
+                        # the sending coordinator to a trailing non-coordinator key,
+                        # corrupting ``device``.
+                        async def _wait_for_ack_and_notify(
+                            sender_entry_id=config_entry_id,
+                            api=api,
+                            result=result,
+                            contact=contact,
+                            pubkey=pubkey,
+                            display_name=display_name,
+                            send_id=send_id,
+                        ):
                             """Background: wait for ACK then fire delivery event."""
                             ack_received = False
                             try:
@@ -276,7 +291,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
                             outgoing_msg = {
                                 "message": message,
-                                "device": config_entry_id,
+                                "device": sender_entry_id,
                                 "message_type": "direct",
                                 "receiver": contact.get("adv_name") or contact.get("name"),
                                 "timestamp": int(time.time()),
@@ -286,7 +301,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                             }
                             hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
 
-                        asyncio.create_task(_wait_for_ack_and_notify())
+                        # Retain the task reference (HA-native; ties it to the event
+                        # loop so it cannot be GC'd before the ACK resolves).
+                        hass.async_create_background_task(
+                            _wait_for_ack_and_notify(),
+                            name=f"{DOMAIN}_ack_{send_id}",
+                        )
                 except Exception as ex:
                     _LOGGER.error(
                         "Error sending message to %s: %s", target_identifier, ex

--- a/tests/test_send_message_service.py
+++ b/tests/test_send_message_service.py
@@ -1,0 +1,119 @@
+"""Regression test for the outgoing-DM stale ``device`` fix in services.py.
+
+A direct message sent via ``meshcore.send_message`` *with* an ``entry_id``
+argument used to fire the ``meshcore_message_sent`` event with a stale
+``device`` field. The deferred ACK-wait task read the loop variable
+``config_entry_id`` at execution time, by which point the send-loop had
+advanced past the sending coordinator to a trailing non-coordinator key, so
+``device`` no longer identified the sender and the downstream handler dropped
+the event. The fix binds the loop-scoped values by value at task-creation
+time (default arguments on the nested coroutine).
+
+This test drives the real ``async_send_message_service`` against a multi-key
+``hass.data[DOMAIN]`` (a coordinator followed by a trailing bookkeeping key)
+and runs the deferred coroutine only after the send-loop has fully advanced,
+asserting the fired event carries the *sending* coordinator's entry id.
+"""
+import importlib.util
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+# Load services.py directly (same pattern as test_services_parsing.py) so the
+# relative imports resolve against the mocked sys.modules entries in conftest.
+_SERVICES_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "custom_components", "meshcore", "services.py",
+)
+_spec = importlib.util.spec_from_file_location(
+    "custom_components.meshcore.services", _SERVICES_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+_module.__package__ = "custom_components.meshcore"
+_spec.loader.exec_module(_module)
+
+
+async def _extract_send_message_handler(hass):
+    """Run async_setup_services and return the registered send_message handler."""
+    await _module.async_setup_services(hass)
+    for call in hass.services.async_register.call_args_list:
+        # async_register(DOMAIN, SERVICE_NAME, handler, schema=...)
+        handler = call.args[2]
+        if getattr(handler, "__name__", "") == "async_send_message_service":
+            return handler
+    raise AssertionError("async_send_message_service was not registered")
+
+
+def _make_coordinator(contact):
+    """A coordinator that sends successfully and reports no expected_ack."""
+    coordinator = MagicMock()
+    result = MagicMock()
+    result.type = "SUCCESS"            # != EventType.ERROR (a distinct mock)
+    result.payload = {}                # no expected_ack -> ACK wait is skipped
+    coordinator.api.connected = True
+    coordinator.api.mesh_core.get_contact_by_key_prefix.return_value = contact
+    coordinator.api.mesh_core.commands.send_msg = AsyncMock(return_value=result)
+    return coordinator
+
+
+async def test_outgoing_dm_fires_event_with_sending_entry_id():
+    """device == the sending coordinator's entry id, not a trailing key."""
+    contact = {
+        "public_key": "abcdef1234567890",
+        "adv_name": "PeerNode",
+        "name": "PeerNode",
+    }
+    coordinator = _make_coordinator(contact)
+    sender_entry_id = "coordinator_entry_aaaa"
+    # A trailing, non-coordinator key that sorts AFTER the coordinator in
+    # insertion order and lacks an ``api`` attribute (the listener-unsubscribe
+    # bookkeeping handle that triggered issue #20). The buggy code left
+    # config_entry_id pointing here once the loop finished.
+    trailing_key = "zzzz_message_sent_listener"
+
+    def _unsub():  # a callable bookkeeping value with no .api attribute
+        return None
+
+    hass = MagicMock()
+    # Configure hass.data AFTER setup so any setup-time bookkeeping cannot
+    # clobber it; the handler reads hass.data only when it is called.
+    handler = await _extract_send_message_handler(hass)
+    hass.data = {
+        _module.DOMAIN: {
+            sender_entry_id: coordinator,
+            trailing_key: _unsub,
+        }
+    }
+    # Capture the deferred coroutine instead of letting a real loop run it.
+    hass.async_create_background_task = MagicMock()
+    hass.bus.async_fire = MagicMock()
+
+    call = MagicMock()
+    call.data = {
+        _module.ATTR_MESSAGE: "hello there",
+        _module.ATTR_PUBKEY_PREFIX: "abcdef123456",
+        _module.ATTR_ENTRY_ID: sender_entry_id,
+    }
+
+    await handler(call)
+
+    # The fix schedules the ACK-wait via async_create_background_task with a
+    # retained (named) reference, not the old untracked asyncio.create_task.
+    assert hass.async_create_background_task.called, (
+        "deferred ACK-wait task was not scheduled"
+    )
+    bg_call = hass.async_create_background_task.call_args
+    assert bg_call.kwargs.get("name"), "background task was not given a retained name"
+
+    # Run the deferred coroutine AFTER the send-loop has fully advanced past the
+    # coordinator to the trailing key -- the timing that exposed the bug.
+    coro = bg_call.args[0]
+    await coro
+
+    hass.bus.async_fire.assert_called_once()
+    event_payload = hass.bus.async_fire.call_args.args[1]
+    assert event_payload["device"] == sender_entry_id, (
+        f"device should be the sending entry id {sender_entry_id!r}, "
+        f"got {event_payload['device']!r}"
+    )
+    assert event_payload["device"] != trailing_key
+    assert event_payload["message_type"] == "direct"


### PR DESCRIPTION
## Summary

A direct message sent through the `meshcore.send_message` service **with an `entry_id` argument** is delivered to the peer but never recorded by the integration: it does not appear in the conversation's message entity or the logbook, and no `meshcore_message_sent` delivery event is observed by listeners. Sending **without** `entry_id`, and **all channel sends**, are unaffected.

This is an integration-side defect in `async_send_message_service`; it affects meshcore-ha's own message entity and logbook regardless of any frontend. It was first reported downstream against a companion panel that always passes `entry_id` (so it routes to the user-selected coordinator on multi-entry setups) — mwolter805/meshcore-ha-chat#20, "sent DM not retained" — but the companion is only the messenger: a plain Developer Tools `meshcore.send_message` call with `entry_id` loses the message the same way.

## Root cause

`async_send_message_service` iterates every registered entry:

```python
for config_entry_id, coordinator in hass.data[DOMAIN].items():
    ...
    # send, then schedule a deferred task that waits for the ACK
    async def _wait_for_ack_and_notify():
        ...
        outgoing_msg = {..., "device": config_entry_id, ...}
        hass.bus.async_fire(f"{DOMAIN}_message_sent", outgoing_msg)
    asyncio.create_task(_wait_for_ack_and_notify())
    if not entry_id:
        return            # only the no-entry_id path returns early
```

The deferred task closes over the loop variable `config_entry_id` and reads it **when it executes** (≈0.5–1 s later, after the ACK wait), not when it is created. When the caller passes `entry_id`, the loop's early `return` is skipped, so the loop runs to completion and `config_entry_id` is left pointing at the **last** key in `hass.data[DOMAIN]` — typically a trailing non-coordinator bookkeeping entry (e.g. a `..._message_sent_listener_...` unsubscribe handle), not the coordinator that actually sent. The event therefore fires with a wrong `device`, and the per-entry listener in `binary_sensor.py` (`message_sent_handler`) drops any event whose `device` does not match its own `entry.entry_id` — so the message is never persisted.

Channel sends (`async_send_channel_message_service`) are immune because they fire the event **synchronously inside the loop iteration**, while `config_entry_id` still holds the sending coordinator's key.

## Fix

1. Bind every loop-scoped value the deferred task reads **by value at task-creation time**, using default arguments on the nested coroutine (the canonical idiom for capturing a loop variable). `device` now uses the bound sender id, so a later loop iteration can no longer corrupt it.
2. Schedule the task with `hass.async_create_background_task(...)` (named, reference retained) instead of a bare `asyncio.create_task(...)`, so it cannot be garbage-collected before the ACK resolves.
3. Add one debug line before the `device`-mismatch early-return in `message_sent_handler`, so a future mis-addressed event is visible in logs instead of being dropped silently (this silent drop is what made the bug hard to attribute).

The `meshcore_message_sent` event schema is unchanged; only the **value** of `device` is corrected. No change to the no-`entry_id` path, channel sends, or multi-entry routing semantics.

## Behaviour before / after

| `meshcore.send_message` | `meshcore_message_sent` | `device` on event | handler runs | recorded |
|---|---|---|---|---|
| with `entry_id` — **before** | fired (deferred) | stale trailing key | no | **no** |
| with `entry_id` — **after** | fired (deferred) | sending entry id | yes | **yes** |
| without `entry_id` | fired (deferred) | sending entry id | yes | yes (unchanged) |
| channel send | fired (synchronous) | sending entry id | yes | yes (unchanged) |

## Reproduction (v2.8.0)

1. On any install, call the service with an explicit entry:

   ```yaml
   service: meshcore.send_message
   data:
     entry_id: <your meshcore config entry id>
     pubkey_prefix: <a contact key prefix>
     message: "hello"
   ```

2. The peer receives the message, but it never appears in the contact's message entity or the logbook, and no delivery event is recorded.
3. Repeat without `entry_id`: the message is recorded normally.

After the fix, step 1 records the message and emits the delivery event with the correct `device`.

## Tests

Adds a regression test that calls `async_send_message_service` with an explicit `entry_id` against a multi-key `hass.data[DOMAIN]` (a coordinator followed by a trailing bookkeeping key), runs the deferred coroutine only after the send-loop has advanced, and asserts the fired `meshcore_message_sent` carries `device == <sending entry id>`. Reverting the value-binding makes the test fail with `device` equal to the trailing key (the reported corruption), confirming the test guards the fix. Full unit suite passes.

## Compatibility / scope

- The two files touched (`services.py`, `binary_sensor.py`) are byte-identical between the released v2.8.0 tag and current `main`, so the bug is present on the latest code and the fix applies cleanly.
- No dependency or version bump required; the event schema is unchanged.
- The nested coroutine has a single call site (no positional callers), so the added keyword-defaulted parameters are safe.

## Files

- `custom_components/meshcore/services.py` — bind loop-scoped values by value; retain the background task.
- `custom_components/meshcore/binary_sensor.py` — debug line before the `device`-mismatch return.
- `tests/test_send_message_service.py` — regression test (new).
