### PR TITLE
Allow removing entity-less devices; evict telemetry dedup map on entity removal

### DIFF
--- a/custom_components/meshcore/__init__.py
+++ b/custom_components/meshcore/__init__.py
@@ -823,6 +823,20 @@ async def async_remove_config_entry_device(
     (devices whose pubkey_prefix is no longer in the configured lists).
     """
     entry_id = config_entry.entry_id
+
+    # Allow removing a device that has no entities left. An empty device
+    # shell is no longer being populated, so deletion is safe -- this covers
+    # a device whose entities the user has already removed (e.g. a discovered
+    # contact's telemetry sensor). The hub device (identifier == entry_id) is
+    # excluded: it is never user-removable even when empty.
+    meshcore_identifiers = {i for d, i in device_entry.identifiers if d == DOMAIN}
+    if entry_id not in meshcore_identifiers:
+        entity_registry = er.async_get(hass)
+        if not er.async_entries_for_device(
+            entity_registry, device_entry.id, include_disabled_entities=True
+        ):
+            return True
+
     repeater_prefixes = {
         r.get("pubkey_prefix")
         for r in config_entry.data.get(CONF_REPEATER_SUBSCRIPTIONS, [])

--- a/custom_components/meshcore/device_tracker.py
+++ b/custom_components/meshcore/device_tracker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
+from functools import partial
 from typing import Any, Dict
 from meshcore import EventType
 from meshcore.events import Event
@@ -92,6 +93,9 @@ class DeviceTrackerManager:
                 self.coordinator, pubkey_prefix, node_info
             )
             self.discovered_trackers[tracker_key] = tracker
+            tracker.async_on_remove(
+                partial(self.discovered_trackers.pop, tracker_key, None)
+            )
             self.async_add_entities([tracker])
             _LOGGER.info(f"Discovered new GPS tracker: {tracker.name} ({tracker_key})")
         else:

--- a/custom_components/meshcore/telemetry_sensor.py
+++ b/custom_components/meshcore/telemetry_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
+from functools import partial
 from typing import Any, Dict
 
 from custom_components.meshcore import MeshCoreDataUpdateCoordinator
@@ -248,6 +249,9 @@ class TelemetrySensorManager:
                 )
                 if sensor_key not in self.discovered_sensors:
                     self.discovered_sensors[sensor_key] = sensor
+                    sensor.async_on_remove(
+                        partial(self.discovered_sensors.pop, sensor_key, None)
+                    )
                     new_sensors.append(sensor)
                     _LOGGER.info(
                         f"Discovered new telemetry sensor: {sensor.name} ({sensor_key})"

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -85,6 +85,20 @@ def _id(node_type, pubkey):
     return f"{ENTRY_ID}_{node_type}_{pubkey}"
 
 
+@pytest.fixture(autouse=True)
+def _default_device_has_entities():
+    """Default every test to the populated-device path.
+
+    Change A allows removing a device that has no entities, keyed off
+    er.async_entries_for_device. The existing refusal/orphan tests must run with
+    a device that still HAS entities so they exercise PR #247's populated-device
+    guards (the empty-device allowance is only reached when that list is empty).
+    Individual empty-device tests override the return value to [].
+    """
+    MOD.er.async_entries_for_device.return_value = [MagicMock()]
+    yield
+
+
 @pytest.mark.asyncio
 async def test_hub_device_refused():
     hass = _make_hass()
@@ -180,3 +194,36 @@ async def test_missing_coordinator_orphan_contact_allowed():
     entry = _make_config_entry()
     device = _make_device(_id("contact", CONTACT_PREFIX))
     assert await remove(hass, entry, device) is True
+
+
+@pytest.mark.asyncio
+async def test_empty_contact_device_allowed():
+    """An emptied discovered-contact device is removable even while the contact
+    is live in the mesh (the reported 'Node fe3af5' case): no entities -> allow."""
+    MOD.er.async_entries_for_device.return_value = []
+    hass = _make_hass(contacts=[{"pubkey_prefix": CONTACT_PREFIX}])
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is True
+
+
+@pytest.mark.asyncio
+async def test_empty_device_hub_still_refused():
+    """The hub device is excluded from the empty-device allowance: it stays
+    non-removable even with no entities."""
+    MOD.er.async_entries_for_device.return_value = []
+    hass = _make_hass()
+    entry = _make_config_entry()
+    device = _make_device(ENTRY_ID)  # identifier == entry_id
+    assert await remove(hass, entry, device) is False
+
+
+@pytest.mark.asyncio
+async def test_populated_live_contact_refused():
+    """A live contact whose device still has entities stays refused -- awolden's
+    PR #247 guard is preserved for populated devices."""
+    MOD.er.async_entries_for_device.return_value = [MagicMock()]
+    hass = _make_hass(contacts=[{"pubkey_prefix": CONTACT_PREFIX}])
+    entry = _make_config_entry()
+    device = _make_device(_id("contact", CONTACT_PREFIX))
+    assert await remove(hass, entry, device) is False

--- a/tests_integration/test_dedup_eviction.py
+++ b/tests_integration/test_dedup_eviction.py
@@ -1,0 +1,128 @@
+"""Integration-tier regression for telemetry/GPS dedup-map eviction.
+
+When Home Assistant removes a telemetry sensor or GPS tracker entity, the
+managing ``TelemetrySensorManager`` / ``DeviceTrackerManager`` must drop the
+entity's key from its in-memory dedup map (``discovered_sensors`` /
+``discovered_trackers``). Without the eviction the manager keeps the
+deregistered entity object and a later telemetry event updates the dead entity
+instead of recreating it -- the desync flagged during PR #247 review and already
+patched in the untracked-contact-discard and data-only-demote flows.
+
+These tests drive the *real* manager handlers under *real* Home Assistant: the
+entity is created and added through the production ``AddEntitiesCallback``
+(``EntityPlatform._async_schedule_add_entities``, eager-start, so ``entity.hass``
+is set synchronously the way it is in production), then removed via the entity
+registry. That exercises the real ``async_on_remove`` ->
+``_call_on_remove_callbacks`` lifecycle. Teeth-check: without the eviction
+registration the key persists after removal and these tests fail.
+"""
+
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockEntityPlatform,
+)
+
+from custom_components.meshcore.const import DOMAIN
+from custom_components.meshcore.device_tracker import DeviceTrackerManager
+from custom_components.meshcore.telemetry_sensor import TelemetrySensorManager
+
+# A pubkey prefix that matches no configured repeater/client, no root pubkey, and
+# no live contact, so _get_node_info resolves the node as "unknown" -- the
+# discovered-node case the eviction protects.
+PUBKEY_PREFIX = "a1b2c3d4e5f6"
+
+
+def _coordinator(config_entry):
+    """A coordinator stub exposing only the attributes the handlers read.
+
+    get_device_update_interval returns a real number because the entities'
+    ``available`` property does arithmetic with it during the initial state
+    write.
+    """
+    coordinator = MagicMock()
+    coordinator.config_entry = config_entry
+    coordinator.pubkey = ""
+    coordinator.name = "Test Root"
+    coordinator.data = {"contacts": []}
+    coordinator.get_device_update_interval.return_value = 60
+    return coordinator
+
+
+def _platform(hass, config_entry, domain):
+    """A real EntityPlatform bound to a real config entry so added entities are
+    registered in the entity registry (and so the registry-remove cascade can
+    reach them)."""
+    platform = MockEntityPlatform(hass, domain=domain, platform_name=DOMAIN)
+    platform.config_entry = config_entry
+    return platform
+
+
+async def test_telemetry_sensor_evicted_on_entity_removal(hass: HomeAssistant):
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    platform = _platform(hass, config_entry, "sensor")
+    manager = TelemetrySensorManager(
+        _coordinator(config_entry), platform._async_schedule_add_entities
+    )
+
+    event = MagicMock()
+    event.payload = {
+        "pubkey_prefix": PUBKEY_PREFIX,
+        "lpp": [{"channel": 1, "type": 103, "value": 21.5}],  # 103 = temperature
+    }
+    await manager._handle_telemetry_event(event)
+    await hass.async_block_till_done()
+
+    # Exactly one sensor discovered and added to HA.
+    assert len(manager.discovered_sensors) == 1
+    sensor_key, sensor = next(iter(manager.discovered_sensors.items()))
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get(sensor.entity_id) is not None
+
+    # Remove the entity via the entity registry -> real async_on_remove cascade.
+    ent_reg.async_remove(sensor.entity_id)
+    await hass.async_block_till_done()
+
+    # The removal cascade actually ran (state machine no longer has the entity),
+    assert hass.states.get(sensor.entity_id) is None
+    # and eviction popped the key, so a later telemetry event recreates the
+    # sensor instead of updating a deregistered entity.
+    assert sensor_key not in manager.discovered_sensors
+
+
+async def test_gps_tracker_evicted_on_entity_removal(hass: HomeAssistant):
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    platform = _platform(hass, config_entry, "device_tracker")
+    manager = DeviceTrackerManager(
+        _coordinator(config_entry), platform._async_schedule_add_entities
+    )
+
+    event = MagicMock()
+    event.payload = {
+        "pubkey_prefix": PUBKEY_PREFIX,
+        "lpp": [
+            {
+                "channel": 5,
+                "type": "gps",
+                "value": {"latitude": 1.0, "longitude": 2.0},
+            }
+        ],
+    }
+    await manager._handle_gps_telemetry_event(event)
+    await hass.async_block_till_done()
+
+    assert len(manager.discovered_trackers) == 1
+    tracker_key, tracker = next(iter(manager.discovered_trackers.items()))
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get(tracker.entity_id) is not None
+
+    ent_reg.async_remove(tracker.entity_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(tracker.entity_id) is None
+    assert tracker_key not in manager.discovered_trackers


### PR DESCRIPTION
## Summary

Follow-up to #247 / #229. #247 made orphaned repeater/client devices removable from the HA UI and, per review, deliberately refused `contact`/`unknown` devices while the contact is still live — to avoid deleting a device while it is producing live data and leaving stale entity references behind. Two gaps remain:

1. **An entity-less device is still refused while the contact is live.** Once the user has already removed a device's only entity (e.g. a discovered contact's telemetry sensor), the device page shows "This device has no entities" — but **Delete** is still refused because the pubkey prefix is a live contact, so HA renders the rejection as an unhelpful `[object Object]` dialog and the empty shell can't be removed. This is the entity-less half of #229.
2. **The telemetry/GPS dedup maps are never evicted on entity removal.** `TelemetrySensorManager.discovered_sensors` and `DeviceTrackerManager.discovered_trackers` cache the live entity objects by key. Nothing pops those caches when HA removes an entity (UI delete, device-delete cascade, or platform unload), so the manager keeps updating a deregistered entity and won't recreate it until an HA restart — the same desync already patched in the untracked-contact-discard (`coordinator.py`) and data-only-demote (`services.py`) flows; the UI-removal path just never reached either eviction.

## Changes

- **`__init__.py` (`async_remove_config_entry_device`):** insert an early "device has no entities → allow removal" branch, excluding the hub (identifier == entry_id). The existing #247 guards (hub, subscribed repeater/client, live contact/unknown) are unchanged and still govern *populated* devices — the new branch is only reached when `er.async_entries_for_device(..., include_disabled_entities=True)` returns empty.
- **`telemetry_sensor.py` / `device_tracker.py`:** register `async_on_remove(partial(self.discovered_*.pop, key, None))` on each telemetry sensor and GPS tracker at the manager's creation site, so removal pops the dedup key and a later telemetry/GPS event recreates the entity instead of updating a deregistered one.

## Tests

- **Unit (`tests/test_device_removal.py`):** 3 added — an emptied contact device is removable even while the contact is live; the hub stays refused even when empty; a populated live contact stays refused (the #247 guard, preserved). Existing refusal/orphan tests run under an autouse non-empty entity-count default, so #247's behavior is unchanged.
- **Integration (`tests_integration/test_dedup_eviction.py`):** new regression — drives the real telemetry/GPS manager handlers under real Home Assistant, removes the entity via the entity registry, and asserts the dedup key is evicted (riding the real `async_on_remove` lifecycle). Fails without the eviction.
- Also verified on a live HA install: deleting an emptied contact device now succeeds with no error dialog, and no "rejected by integration" line is logged.

## Compatibility / scope

- Additive — reverts nothing from #247. `entity_registry` is already imported; `async_on_remove` is standard HA. No dependency or version bump; the populated-device guards are preserved.
- A removed entity-less device can reappear if the node telemeters again (clean recreate, by design); permanent "ignore this contact" suppression is out of scope.

## Files

- `custom_components/meshcore/__init__.py` — entity-less-device removal allowance (hub-excluded).
- `custom_components/meshcore/telemetry_sensor.py` — `async_on_remove` eviction of `discovered_sensors`.
- `custom_components/meshcore/device_tracker.py` — `async_on_remove` eviction of `discovered_trackers`.
- `tests/test_device_removal.py` — empty-device unit coverage.
- `tests_integration/test_dedup_eviction.py` — eviction regression (new).