### PR TITLE
fix: make WebSocket path configurable for EMQX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Auth-token mode is easy install by default:
 - Signing key is pulled from the connected node via `export_private_key()`.
 - If private key export is disabled/blocked on firmware, auth-token upload cannot start.
 
+Support for MQTT brokers that serve MQTT over a different path than / 
+
+- Example: EMQX requires the path to be /mqtt
+
 ## Map Auto Uploader (map.meshcore.io)
 
 When enabled (off by default), the integration automatically uploads repeater and room server adverts to [map.meshcore.io](https://map.meshcore.io) when your Companion hears them. A standalone alternative is [map.meshcore.io-uploader](https://github.com/recrof/map.meshcore.io-uploader). Enable in Global Settings if you want Map Auto Uploader.

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -1099,7 +1099,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "owner_email": user_input.get("owner_email", ""),
                 "topic_status": user_input.get("topic_status", DEFAULT_MQTT_TOPIC_STATUS),
                 "topic_events": user_input.get("topic_events", DEFAULT_MQTT_TOPIC_EVENTS),
-                 "ws_path": user_input.get("ws_path", "/mqtt"),
+                "ws_path": user_input.get("ws_path", "/mqtt"),
                 "iata": user_input.get("iata", legacy_global_iata),
                 "token_ttl_seconds": user_input.get("token_ttl_seconds", legacy_global_ttl),
                 "payload_mode": user_input.get("payload_mode", "packet"),

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -1099,7 +1099,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "owner_email": user_input.get("owner_email", ""),
                 "topic_status": user_input.get("topic_status", DEFAULT_MQTT_TOPIC_STATUS),
                 "topic_events": user_input.get("topic_events", DEFAULT_MQTT_TOPIC_EVENTS),
-                "ws_path": user_input.get("ws_path", "/mqtt"),
+                "ws_path": user_input.get("ws_path", "/"),
                 "iata": user_input.get("iata", legacy_global_iata),
                 "token_ttl_seconds": user_input.get("token_ttl_seconds", legacy_global_ttl),
                 "payload_mode": user_input.get("payload_mode", "packet"),
@@ -1135,7 +1135,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ): vol.All(cv.positive_int, vol.Range(min=60, max=86400)),
             vol.Optional("topic_status", default=broker.get("topic_status", DEFAULT_MQTT_TOPIC_STATUS)): str,
             vol.Optional("topic_events", default=broker.get("topic_events", DEFAULT_MQTT_TOPIC_EVENTS)): str,
-            vol.Optional("ws_path", default=broker.get("ws_path", "/mqtt")): str,
+            vol.Optional("ws_path", default=broker.get("ws_path", "/")): str,
             vol.Optional("iata", default=broker.get("iata", legacy_global_iata)): str,
         })
 

--- a/custom_components/meshcore/config_flow.py
+++ b/custom_components/meshcore/config_flow.py
@@ -1099,6 +1099,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "owner_email": user_input.get("owner_email", ""),
                 "topic_status": user_input.get("topic_status", DEFAULT_MQTT_TOPIC_STATUS),
                 "topic_events": user_input.get("topic_events", DEFAULT_MQTT_TOPIC_EVENTS),
+                 "ws_path": user_input.get("ws_path", "/mqtt"),
                 "iata": user_input.get("iata", legacy_global_iata),
                 "token_ttl_seconds": user_input.get("token_ttl_seconds", legacy_global_ttl),
                 "payload_mode": user_input.get("payload_mode", "packet"),
@@ -1134,6 +1135,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ): vol.All(cv.positive_int, vol.Range(min=60, max=86400)),
             vol.Optional("topic_status", default=broker.get("topic_status", DEFAULT_MQTT_TOPIC_STATUS)): str,
             vol.Optional("topic_events", default=broker.get("topic_events", DEFAULT_MQTT_TOPIC_EVENTS)): str,
+            vol.Optional("ws_path", default=broker.get("ws_path", "/mqtt")): str,
             vol.Optional("iata", default=broker.get("iata", legacy_global_iata)): str,
         })
 

--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -74,6 +74,7 @@ class BrokerConfig:
     client_id_prefix: str
     topic_status: str
     topic_packets: str
+    ws_path: str = "/mqtt"
 
     @property
     def name(self) -> str:
@@ -304,6 +305,9 @@ class MeshCoreMqttUploader:
                     ),
                     iata,
                 ),
+                ws_path=str(
+                    broker_settings.get("ws_path", "/mqtt") or "/mqtt"
+                  ).strip(),
             )
 
             if broker.is_letsmesh and iata in placeholder_iata_values:
@@ -426,7 +430,7 @@ class MeshCoreMqttUploader:
         )
 
         if broker.transport == "websockets":
-            client.ws_set_options(path="/", headers=None)
+            client.ws_set_options(path=broker.ws_path, headers=None)
 
         self.logger.info(
             "[%s] Ready (status_topic=%s packets_topic=%s auth_token=%s)",

--- a/custom_components/meshcore/mqtt_uploader.py
+++ b/custom_components/meshcore/mqtt_uploader.py
@@ -74,7 +74,7 @@ class BrokerConfig:
     client_id_prefix: str
     topic_status: str
     topic_packets: str
-    ws_path: str = "/mqtt"
+    ws_path: str = "/"
 
     @property
     def name(self) -> str:
@@ -306,7 +306,7 @@ class MeshCoreMqttUploader:
                     iata,
                 ),
                 ws_path=str(
-                    broker_settings.get("ws_path", "/mqtt") or "/mqtt"
+                    broker_settings.get("ws_path", "/") or "/"
                   ).strip(),
             )
 


### PR DESCRIPTION
## Summary
  - Fixes WebSocket connection failures with EMQX broker, which serves MQTT over WebSocket at `/mqtt` instead of `/`
  - Adds a new `ws_path` broker config option (default: `/` for backwards compatibility)
  - Existing configs default to `/` on next save, maintaining compatibility with most broker deployments.
  - Allows users of different brokers to customize the MQTT path if needed

  ## Context
  The hardcoded `ws_set_options(path="/", ...)` caused the Home Assistant integration to fail when connecting to EMQX, which expects WebSocket connections at the `/mqtt` path. This is the default WebSocket
  endpoint for EMQX deployments.

  ## Changes
  - `mqtt_uploader.py`: Added `ws_path` field to `BrokerConfig` with default `/`
  - `mqtt_uploader.py`: Pass `ws_path` from broker settings when creating `BrokerConfig`
  - `mqtt_uploader.py`: Use `broker.ws_path` instead of hardcoded `/` in `ws_set_options`
  - `config_flow.py`: Added `ws_path` field to broker config UI form
  - `config_flow.py`: Persist `ws_path` value when saving broker configuration

  ## Testing
  - Verified against EMQX 6.2.0 with WebSocket at `/mqtt`
  - Backward compatible — existing configs without `ws_path` default to `/`
  - Users can override to any path via the HA integration config UI
  - **Note:** Not yet tested with non-EMQX brokers — please test with your broker and report any issues
  
  ## Admission of Guilt
  - I used Claude to develop this fix, but I do understand the relatively minor changes made to the code.
  - I have not tested it against other popular brokers. 