### PR TITLE
Suppress duplicate received message frames

### DIFF
--- a/custom_components/meshcore/meshcore_api.py
+++ b/custom_components/meshcore/meshcore_api.py
@@ -2,6 +2,7 @@
 import logging
 import asyncio
 import time
+from collections import OrderedDict
 from typing import Any, Optional
 from asyncio import Lock
 
@@ -20,6 +21,35 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Duplicate-message suppression. Some firmware delivers the same frame more than
+# once when a second companion client is connected: once as a live push, and
+# again from the device's sync history because the per-client watermark was not
+# advanced. See https://github.com/meshcore-dev/meshcore-ha/issues/320
+DEDUP_MAX_ENTRIES = 256
+DEDUP_WINDOW_SECONDS = 30
+DEDUP_EVENT_TYPES = (EventType.CONTACT_MSG_RECV, EventType.CHANNEL_MSG_RECV)
+
+
+def _message_signature(event) -> Optional[tuple]:
+    """Return a stable identity for a received message, or None if not dedupable.
+
+    Only message-receive events are deduped. Everything else passes through
+    untouched so that adverts, telemetry and status frames are unaffected.
+    """
+    if event.type not in DEDUP_EVENT_TYPES:
+        return None
+    payload = event.payload or {}
+    if not isinstance(payload, dict):
+        return None
+    return (
+        event.type,
+        payload.get("pubkey_prefix"),
+        payload.get("channel_idx"),
+        payload.get("sender_timestamp") or payload.get("timestamp"),
+        payload.get("text"),
+    )
+
 
 class MeshCoreAPI:
     """API for interacting with MeshCore devices using the event-driven meshcore-py library."""
@@ -171,6 +201,9 @@ class MeshCoreAPI:
             # Set up disconnect event handler for backup reconnect
             self._setup_disconnect_handler()
 
+            # Suppress duplicate message frames (see issue #320)
+            self._install_message_dedup()
+
             # Sync time on connection
             try:
                 _LOGGER.info("Syncing time with MeshCore device...")
@@ -246,6 +279,46 @@ class MeshCoreAPI:
             _LOGGER.info("Disconnection complete")
         return
     
+    def _install_message_dedup(self) -> None:
+        """Suppress duplicate message frames before they reach subscribers.
+
+        Entities, the logbook and any automation listening for meshcore_message
+        each subscribe to the dispatcher independently, so a duplicate frame
+        would otherwise produce a duplicate of every downstream effect --
+        including automations that transmit, which costs shared airtime.
+        Filtering at dispatch is the single point that covers all subscribers.
+        """
+        if not self._mesh_core:
+            return
+
+        dispatcher = self._mesh_core.dispatcher
+        if getattr(dispatcher, "_ha_dedup_installed", False):
+            return
+
+        seen: "OrderedDict[tuple, float]" = OrderedDict()
+        original_dispatch = dispatcher.dispatch
+
+        async def dispatch_with_dedup(event):
+            signature = _message_signature(event)
+            if signature is not None:
+                now = time.monotonic()
+                previous = seen.get(signature)
+                if previous is not None and (now - previous) < DEDUP_WINDOW_SECONDS:
+                    _LOGGER.debug(
+                        "Suppressed duplicate %s frame within %ss window",
+                        event.type,
+                        DEDUP_WINDOW_SECONDS,
+                    )
+                    return
+                seen[signature] = now
+                while len(seen) > DEDUP_MAX_ENTRIES:
+                    seen.popitem(last=False)
+            await original_dispatch(event)
+
+        dispatcher.dispatch = dispatch_with_dedup
+        dispatcher._ha_dedup_installed = True
+        _LOGGER.debug("Message deduplication filter installed")
+
     def _setup_disconnect_handler(self) -> None:
         """Set up disconnect event handler."""
         if not self._mesh_core:


### PR DESCRIPTION
Draft — opening for direction rather than as a merge candidate. Fixes #320.

## Problem

Some firmware delivers the same message frame more than once when a second companion client is connected: once as a live push, and again from the device's sync history because the per-client watermark was not advanced.

Root cause on the firmware side is traced here: https://github.com/ALLFATHER-BV/meshcomod/issues/42 — the watermark advance is gated on the broadcast succeeding to *every* connected client, so one transient write failure means no client's watermark advances.

That fix belongs upstream, but I think the integration is worth hardening regardless: it currently processes whatever arrives, so any firmware that delivers a frame twice produces duplicates here.

## Impact today

- Duplicate `meshcore_message` events and duplicate logbook entries
- **Automations triggering on `meshcore_message` fire twice per message.** In my case that includes a bot that replies over LoRa, so a duplicate has a real cost in airtime on a shared channel
- MeshCore Chat's message store fills at twice the expected rate

## Approach

Entities, the logbook and user automations each subscribe to the SDK dispatcher independently, so there's no existing single point to filter at. This wraps `dispatcher.dispatch()` after connect, which is the one place that covers every subscriber.

- Only `CONTACT_MSG_RECV` and `CHANNEL_MSG_RECV` are deduped. Adverts, telemetry and status frames pass through untouched.
- Signature is (event type, pubkey prefix, channel index, sender timestamp, text).
- Bounded LRU, 256 entries, 30 second window — so a genuine repeat of identical text from the same sender after 30s still comes through.
- Guarded with `_ha_dedup_installed` so a reconnect doesn't stack wrappers.

## Please review carefully

I can't run this against real hardware, so two things need checking by someone who can:

1. **Payload key names** — I inferred `pubkey_prefix` / `channel_idx` / `sender_timestamp` / `text` from the parser. If those differ on some frame types the signature silently degrades to a weaker match.
2. **Wrapping `dispatch` is a monkeypatch.** It works, but you may prefer this as a first-class filter hook in the dispatcher, or pushed upstream into meshcore-py so every consumer benefits. Happy to rework it either way.

Observed on meshcore-ha v2.9.0 / HA 2026.7.4, Heltec V3 running meshcomod, duplicates arriving 80–200 ms apart.