### PR TITLE
fix(coordinator): re-arm the self-telemetry interval on failure

### DIFF
--- a/custom_components/meshcore/coordinator.py
+++ b/custom_components/meshcore/coordinator.py
@@ -92,6 +92,44 @@ def _log_get_msg_error(action: str, payload: Any) -> None:
         _LOGGER.error("Error %s messages: %s", action, payload)
 
 
+# Companion-protocol error codes that mean the node can never satisfy the
+# request, however many times it is repeated -- as opposed to a transient
+# fault that a later attempt may clear.
+_TELEMETRY_UNSUPPORTED_CODES = frozenset(
+    {"ERR_CODE_ILLEGAL_ARG", "ERR_CODE_UNSUPPORTED_CMD"}
+)
+
+
+def _log_self_telemetry_error(payload: Any, already_reported: bool) -> None:
+    """Log a failed self-telemetry result at the appropriate level.
+
+    ``get_self_telemetry()`` sends the four-byte "self" form of
+    ``CMD_SEND_TELEMETRY_REQ`` (opcode plus three reserved bytes, no pub key).
+    Firmware answers it, but a non-firmware companion need not: an openHop
+    virtual companion up to and including 1.1.1 requires the 36-byte contact
+    form and rejects the short frame with ``ERR_CODE_ILLEGAL_ARG``.
+
+    That is a fixed property of the peer, not a fault, so it is reported once
+    at WARNING naming the cause and the remedy, then demoted to DEBUG. Every
+    other failure keeps ERROR on every occurrence. The caller clears its flag
+    on success, so a genuine later regression is reported afresh.
+    """
+    code = payload.get("code_string") if isinstance(payload, dict) else None
+    if code in _TELEMETRY_UNSUPPORTED_CODES:
+        if already_reported:
+            _LOGGER.debug("Self telemetry still unsupported by this node: %s", payload)
+        else:
+            _LOGGER.warning(
+                "This node rejected the self-telemetry request (%s): it does not "
+                "implement the 'self' form of CMD_SEND_TELEMETRY_REQ. Turn off "
+                "self telemetry for this entry, or update the node's firmware or "
+                "companion software. Further occurrences are logged at DEBUG.",
+                code,
+            )
+    else:
+        _LOGGER.error("Failed to get self telemetry: %s", payload)
+
+
 class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the MeshCore node and trigger event-generating commands."""
 
@@ -190,6 +228,10 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         
         # Self telemetry tracking
         self._last_self_telemetry_update = 0
+        # Set once a self-telemetry failure has been reported, so a node that
+        # cannot answer the request is named once rather than on every cycle.
+        # Cleared on the next success.
+        self._self_telemetry_error_reported = False
         self._self_telemetry_enabled = config_entry.data.get(CONF_SELF_TELEMETRY_ENABLED, False)
         self._self_telemetry_interval = config_entry.data.get(CONF_SELF_TELEMETRY_INTERVAL, DEFAULT_SELF_TELEMETRY_INTERVAL)
 
@@ -1619,13 +1661,24 @@ class MeshCoreDataUpdateCoordinator(DataUpdateCoordinator):
         if self._self_telemetry_enabled:
             if current_time - self._last_self_telemetry_update >= self._self_telemetry_interval:
                 self.logger.debug(f"Getting self telemetry (interval: {self._self_telemetry_interval}s)")
+                # The interval gates *attempts*, not successes. Recording the
+                # attempt before it runs keeps a failing node on the configured
+                # cadence; advancing this only in the success branch left the
+                # gate permanently open against a node that cannot answer, so a
+                # 300 s setting collapsed to the coordinator tick and re-sent a
+                # request that could never succeed (~17k ERROR lines a day at a
+                # 5 s tick).
+                self._last_self_telemetry_update = current_time
                 try:
                     telemetry_result = await self.api.mesh_core.commands.get_self_telemetry()
                     if telemetry_result.type == EventType.TELEMETRY_RESPONSE:
                         self.logger.debug(f"Self telemetry received: {telemetry_result.payload}")
-                        self._last_self_telemetry_update = current_time
+                        self._self_telemetry_error_reported = False
                     else:
-                        self.logger.error(f"Failed to get self telemetry: {telemetry_result.payload}")
+                        _log_self_telemetry_error(
+                            telemetry_result.payload, self._self_telemetry_error_reported
+                        )
+                        self._self_telemetry_error_reported = True
                 except Exception as ex:
                     self.logger.error(f"Exception getting self telemetry: {ex}")
             else:

--- a/tests/test_self_telemetry_retry.py
+++ b/tests/test_self_telemetry_retry.py
@@ -1,0 +1,166 @@
+"""Regression tests for the self-telemetry retry storm and its log level.
+
+``get_self_telemetry()`` sends the four-byte "self" form of
+``CMD_SEND_TELEMETRY_REQ``. Firmware answers it; a non-firmware companion need
+not. An openHop virtual companion up to and including 1.1.1 requires the
+36-byte contact form and rejects the short frame with ``ERR_CODE_ILLEGAL_ARG``
+(``openhop_core/companion/frame_server.py``: ``if len(data) < 35``).
+
+Two bugs compounded that on a live instance:
+
+1. ``_last_self_telemetry_update`` advanced only in the success branch, so a
+   node that always fails never re-armed the interval gate. The configured
+   300 s interval collapsed to the coordinator tick -- a measured ~357 requests
+   per 30 minutes (~5 s apart), half of every companion frame the integration
+   sent, none of which could succeed.
+2. Every failure logged at ERROR, so that storm surfaced as roughly 17k
+   ERROR-tier lines a day.
+
+``coordinator.py`` cannot be imported whole under the conftest stubs, so these
+tests AST-extract the real module-level helper and run it with its free names
+bound, exercising production source. A second test guards the ordering fix
+structurally: the attempt must be recorded before the request is issued, not
+inside the ``try`` that only records it on success.
+"""
+import ast
+import logging
+import os
+
+from typing import Any
+
+_BASE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "custom_components", "meshcore"
+)
+_COORDINATOR_PY = os.path.join(_BASE, "coordinator.py")
+
+_LOGGER_NAME = "custom_components.meshcore.coordinator"
+_LOGGER = logging.getLogger(_LOGGER_NAME)
+
+
+def _read_source():
+    with open(_COORDINATOR_PY, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _extract_log_self_telemetry_error():
+    """Compile the production helper plus the constant it closes over."""
+    tree = ast.parse(_read_source())
+    wanted = ("_TELEMETRY_UNSUPPORTED_CODES", "_log_self_telemetry_error")
+    body = [
+        node
+        for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name in wanted)
+        or (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id in wanted for t in node.targets
+            )
+        )
+    ]
+    assert len(body) == 2, f"expected both {wanted} at module level, got {len(body)}"
+    module = ast.Module(body=body, type_ignores=[])
+    ast.fix_missing_locations(module)
+    code = compile(module, _COORDINATOR_PY, "exec")
+    namespace = {"_LOGGER": _LOGGER, "Any": Any, "frozenset": frozenset}
+    exec(code, namespace)  # noqa: S102 -- executing our own production source
+    return namespace["_log_self_telemetry_error"]
+
+
+_log_self_telemetry_error = _extract_log_self_telemetry_error()
+
+
+def _records(caplog):
+    return [(r.levelno, r.getMessage()) for r in caplog.records]
+
+
+def test_unsupported_code_warns_once_then_debugs(caplog):
+    """A node that cannot answer is named once, then demoted."""
+    payload = {"error_code": 6, "code_string": "ERR_CODE_ILLEGAL_ARG"}
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_self_telemetry_error(payload, already_reported=False)
+    levels = [level for level, _ in _records(caplog)]
+    assert levels == [logging.WARNING]
+    assert "ERR_CODE_ILLEGAL_ARG" in caplog.records[0].getMessage()
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_self_telemetry_error(payload, already_reported=True)
+    assert [level for level, _ in _records(caplog)] == [logging.DEBUG]
+
+
+def test_unsupported_cmd_code_is_also_demoted(caplog):
+    """openHop >= 1.1.2 answers the self form and returns UNSUPPORTED_CMD for
+    other malformed lengths; treat it the same way."""
+    payload = {"error_code": 2, "code_string": "ERR_CODE_UNSUPPORTED_CMD"}
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _log_self_telemetry_error(payload, already_reported=True)
+    assert [level for level, _ in _records(caplog)] == [logging.DEBUG]
+
+
+def test_other_failures_keep_error(caplog):
+    """Transient or unknown failures stay at ERROR on every occurrence."""
+    for payload in (
+        {"error_code": 4, "code_string": "ERR_CODE_TABLE_FULL"},
+        {"reason": "no_event_received"},
+        None,
+    ):
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            _log_self_telemetry_error(payload, already_reported=True)
+        assert [level for level, _ in _records(caplog)] == [logging.ERROR], payload
+
+
+def _self_telemetry_gate():
+    """Return the ``if`` node holding the self-telemetry attempt."""
+    for node in ast.walk(ast.parse(_read_source())):
+        if not isinstance(node, ast.Try):
+            continue
+        calls = [
+            n
+            for n in ast.walk(node)
+            if isinstance(n, ast.Attribute) and n.attr == "get_self_telemetry"
+        ]
+        if calls:
+            return node
+    raise AssertionError("no try block issuing get_self_telemetry() found")
+
+
+def _assignments_to(node, name):
+    return [
+        n
+        for n in ast.walk(node)
+        if isinstance(n, ast.Assign)
+        and any(
+            isinstance(t, ast.Attribute) and t.attr == name for t in n.targets
+        )
+    ]
+
+
+def test_attempt_recorded_before_request_not_only_on_success():
+    """The interval gate must re-arm on failure, not just on success.
+
+    Structural guard against the original bug returning: no assignment to
+    ``_last_self_telemetry_update`` may live inside the ``try`` that issues the
+    request, because every path in there other than success would skip it.
+    """
+    try_node = _self_telemetry_gate()
+    inside = _assignments_to(try_node, "_last_self_telemetry_update")
+    assert not inside, (
+        "_last_self_telemetry_update is assigned inside the get_self_telemetry() "
+        "try block; a failing node would never re-arm the interval and would be "
+        "retried on every coordinator tick"
+    )
+
+
+def test_error_reported_flag_is_cleared_on_success():
+    """A success must reset the flag so a later regression is reported again."""
+    try_node = _self_telemetry_gate()
+    assigns = _assignments_to(try_node, "_self_telemetry_error_reported")
+    values = {
+        n.value.value for n in assigns if isinstance(n.value, ast.Constant)
+    }
+    assert values == {True, False}, (
+        "expected _self_telemetry_error_reported to be set True on failure and "
+        f"cleared False on success, found {values}"
+    )


### PR DESCRIPTION
## Problem

`get_self_telemetry()` sends the four-byte "self" form of `CMD_SEND_TELEMETRY_REQ` — opcode plus three reserved bytes, no pub key ([`meshcore_py/commands/device.py`](https://github.com/meshcore-dev/meshcore_py/blob/main/src/meshcore/commands/device.py)). Firmware answers it; `MyMesh.cpp` splits the command by frame length and has an explicit `len == 4` self branch.

A non-firmware companion need not. An openHop virtual companion up to and including 1.1.1 requires the 36-byte contact form and rejects the short frame:

```python
# openhop_core/companion/frame_server.py
if len(data) < 35:
    self._write_err(ERR_CODE_ILLEGAL_ARG)
    return
```

`_last_self_telemetry_update` advanced only in the success branch, so against such a node the interval gate never re-armed. The configured interval collapsed to the coordinator tick and the request was re-sent on every cycle, forever, each one logged at ERROR.

Measured on a live instance against an openHop companion, from the repeater's own frame log over 30 minutes:

| Opcode | Command | Count | Cadence | Result |
|---|---|---|---|---|
| `0x27` len=4 | SEND_TELEMETRY_REQ (self) | 357 | ~5.0 s | refused, every time |
| `0x14` len=1 | GET_BATT_AND_STORAGE | 357 | ~5.0 s | ok |
| `0x0a` len=1 | SYNC_NEXT_MESSAGE | 37 | ~48 s | ok |
| `0x38` len=2 | GET_STATS | 15 | ~2 min | ok |

The configured interval was 300 s. Half of every companion frame the integration sent was a request that could not succeed, and it produced roughly 17k ERROR-tier log lines a day.

## Change

**Re-arm the interval on failure.** The interval gates *attempts*, not successes, so the attempt is recorded before it is issued. A failure now waits the configured interval exactly as a success does. Behaviour against a node that answers normally is unchanged.

**Level the log by whether a retry could ever help.** Failures route through a new `_log_self_telemetry_error`, following the existing `_log_get_msg_error` pattern. An error code meaning the node can never satisfy the request (`ERR_CODE_ILLEGAL_ARG`, `ERR_CODE_UNSUPPORTED_CMD`) is reported once at WARNING, naming the cause and the remedy, then demoted to DEBUG. Every other failure keeps ERROR on every occurrence. A success clears the flag, so a genuine later regression is reported afresh.

Together: a node that cannot answer produces one actionable WARNING instead of ~17k ERRORs a day, and stops consuming a request slot every tick.

## Note on the other side of this

openHop already fixed its half — [`3513bab`](https://github.com/openhop-dev/openhop_core/commit/3513bab), *"answer the self form of telemetry requests"*, 16 Jul 2026 — but it is on `dev` only, not in any tag, and `dev` is ~340 commits ahead of `main`. Until that ships, released openHop builds still reject the frame. This change is also worth having independently: it makes any peer that refuses any optional command degrade quietly instead of hammering it.

## Tests

`tests/test_self_telemetry_retry.py`, following `test_get_msg_error_log_level.py`: the helper is AST-extracted from production source and exercised directly, since `coordinator.py` cannot be imported whole under the conftest stubs.

- unsupported code warns once, then demotes to DEBUG
- `ERR_CODE_UNSUPPORTED_CMD` treated the same way
- other payloads (including `None`) keep ERROR
- **structural guard**: no assignment to `_last_self_telemetry_update` may sit inside the `try` that issues the request — this fails on the pre-change source and passes after, so it pins the actual bug rather than the symptom
- a success must clear the reported flag

Verified locally: the 5 new tests pass, and the collectible suite is unchanged versus clean `HEAD` (104 passed vs 99, same 32 failures and 10 collection errors, all pre-existing `TypeError: unsupported operand type(s) for |` from PEP 604 syntax on the local Python 3.9 — CI runs a newer interpreter).
